### PR TITLE
[codex] refresh msrv and docs tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,20 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  msrv:
+    name: Rust MSRV
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Rust 1.88
+        uses: dtolnay/rust-toolchain@1.88.0
+
+      - name: Check workspace with MSRV
+        run: cargo +1.88.0 check --workspace --all-targets --all-features --locked
+
   test:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Examples:
   - `cargo fmt --all --check`
   - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 - If you add or change dependencies, make sure `Cargo.lock` is updated and the locked checks still pass before push.
+- Keep the declared MSRV in `Cargo.toml` covered by CI. The policy is to support a Rust stable release roughly 9-12 months behind current stable when practical, rather than only the newest stable toolchain.
 
 ## Public API Changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ edition = "2024"
 homepage = "https://github.com/sebastian-software/ferrocat"
 license = "MIT"
 repository = "https://github.com/sebastian-software/ferrocat"
-rust-version = "1.85"
-version = "0.2.0"
+rust-version = "1.88"
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "deny"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ For the common “merge fresh extracted messages into an existing catalog” wor
 
 ## Compatibility Snapshot
 
-- **MSRV:** Rust `1.85`
+- **MSRV:** Rust `1.88`
+- **MSRV policy:** keep support roughly 9-12 months behind current stable when practical, rather than tracking only the newest stable toolchain
 - **Semver:** the public API is treated seriously, but the project is still pre-`1.0`
 - **Documentation surface:** README examples, rustdoc examples, and the docs site aim to stay aligned
 

--- a/conformance/harness.rs
+++ b/conformance/harness.rs
@@ -364,21 +364,21 @@ fn compare_po_parse(
     expected: &PoParseExpected,
     item_start_index: usize,
 ) -> Result<String, String> {
-    if let Some(item_count) = expected.item_count {
-        if parsed.items.len() != item_count {
-            return Err(format!(
-                "item count mismatch: expected {item_count}, got {}",
-                parsed.items.len()
-            ));
-        }
+    if let Some(item_count) = expected.item_count
+        && parsed.items.len() != item_count
+    {
+        return Err(format!(
+            "item count mismatch: expected {item_count}, got {}",
+            parsed.items.len()
+        ));
     }
-    if let Some(header_count) = expected.header_count {
-        if parsed.headers.len() != header_count {
-            return Err(format!(
-                "header count mismatch: expected {header_count}, got {}",
-                parsed.headers.len()
-            ));
-        }
+    if let Some(header_count) = expected.header_count
+        && parsed.headers.len() != header_count
+    {
+        return Err(format!(
+            "header count mismatch: expected {header_count}, got {}",
+            parsed.headers.len()
+        ));
     }
     for (key, value) in &expected.headers {
         let actual = parsed
@@ -466,13 +466,13 @@ fn compare_po_item(actual: &PoItem, expected: &PoItemExpected) -> Result<(), Str
     reason = "Conformance expectations are intentionally checked in one linear routine for auditability."
 )]
 fn compare_icu_parse(nodes: &[IcuNode], expected: &IcuParseExpected) -> Result<String, String> {
-    if let Some(count) = expected.top_level_count {
-        if nodes.len() != count {
-            return Err(format!(
-                "top-level node count mismatch: expected {count}, got {}",
-                nodes.len()
-            ));
-        }
+    if let Some(count) = expected.top_level_count
+        && nodes.len() != count
+    {
+        return Err(format!(
+            "top-level node count mismatch: expected {count}, got {}",
+            nodes.len()
+        ));
     }
     if !expected.node_kinds.is_empty() {
         let actual = nodes.iter().map(node_kind).collect::<Vec<_>>();
@@ -527,13 +527,13 @@ fn compare_icu_parse(nodes: &[IcuNode], expected: &IcuParseExpected) -> Result<S
                         ));
                     }
                 }
-                if let Some(expected_count) = expected.first_plural_option_count {
-                    if options.len() != expected_count {
-                        return Err(format!(
-                            "first plural option count mismatch: expected {expected_count}, got {}",
-                            options.len()
-                        ));
-                    }
+                if let Some(expected_count) = expected.first_plural_option_count
+                    && options.len() != expected_count
+                {
+                    return Err(format!(
+                        "first plural option count mismatch: expected {expected_count}, got {}",
+                        options.len()
+                    ));
                 }
             }
             other => return Err(format!("expected first node to be plural, got {other:?}")),
@@ -556,12 +556,12 @@ fn compare_icu_parse(nodes: &[IcuNode], expected: &IcuParseExpected) -> Result<S
                         plural_kind_name(kind)
                     ));
                 }
-                if let Some(expected_count) = expected.second_plural_option_count {
-                    if *option_count != expected_count {
-                        return Err(format!(
-                            "second plural option count mismatch: expected {expected_count}, got {option_count}"
-                        ));
-                    }
+                if let Some(expected_count) = expected.second_plural_option_count
+                    && *option_count != expected_count
+                {
+                    return Err(format!(
+                        "second plural option count mismatch: expected {expected_count}, got {option_count}"
+                    ));
                 }
             }
             None => return Err("expected second plural node but none was found".to_owned()),
@@ -582,19 +582,19 @@ fn compare_icu_reject(
             expected.message_contains, message
         ));
     }
-    if let Some(expected_line) = expected.line {
-        if line != expected_line {
-            return Err(format!(
-                "error line mismatch: expected {expected_line}, got {line}"
-            ));
-        }
+    if let Some(expected_line) = expected.line
+        && line != expected_line
+    {
+        return Err(format!(
+            "error line mismatch: expected {expected_line}, got {line}"
+        ));
     }
-    if let Some(min_column) = expected.min_column {
-        if column < min_column {
-            return Err(format!(
-                "error column mismatch: expected at least {min_column}, got {column}"
-            ));
-        }
+    if let Some(min_column) = expected.min_column
+        && column < min_column
+    {
+        return Err(format!(
+            "error column mismatch: expected at least {min_column}, got {column}"
+        ));
     }
     Ok(String::new())
 }

--- a/conformance/icu_harness.rs
+++ b/conformance/icu_harness.rs
@@ -127,13 +127,13 @@ fn evaluate_icu_reject(case: &ConformanceCase) -> Result<String, String> {
     reason = "Conformance expectations are intentionally checked in one linear routine for auditability."
 )]
 fn compare_icu_parse(nodes: &[IcuNode], expected: &IcuParseExpected) -> Result<String, String> {
-    if let Some(count) = expected.top_level_count {
-        if nodes.len() != count {
-            return Err(format!(
-                "top-level node count mismatch: expected {count}, got {}",
-                nodes.len()
-            ));
-        }
+    if let Some(count) = expected.top_level_count
+        && nodes.len() != count
+    {
+        return Err(format!(
+            "top-level node count mismatch: expected {count}, got {}",
+            nodes.len()
+        ));
     }
     if !expected.node_kinds.is_empty() {
         let actual = nodes.iter().map(node_kind).collect::<Vec<_>>();
@@ -188,13 +188,13 @@ fn compare_icu_parse(nodes: &[IcuNode], expected: &IcuParseExpected) -> Result<S
                         ));
                     }
                 }
-                if let Some(expected_count) = expected.first_plural_option_count {
-                    if options.len() != expected_count {
-                        return Err(format!(
-                            "first plural option count mismatch: expected {expected_count}, got {}",
-                            options.len()
-                        ));
-                    }
+                if let Some(expected_count) = expected.first_plural_option_count
+                    && options.len() != expected_count
+                {
+                    return Err(format!(
+                        "first plural option count mismatch: expected {expected_count}, got {}",
+                        options.len()
+                    ));
                 }
             }
             other => return Err(format!("expected first node to be plural, got {other:?}")),
@@ -217,12 +217,12 @@ fn compare_icu_parse(nodes: &[IcuNode], expected: &IcuParseExpected) -> Result<S
                         plural_kind_name(kind)
                     ));
                 }
-                if let Some(expected_count) = expected.second_plural_option_count {
-                    if *option_count != expected_count {
-                        return Err(format!(
-                            "second plural option count mismatch: expected {expected_count}, got {option_count}"
-                        ));
-                    }
+                if let Some(expected_count) = expected.second_plural_option_count
+                    && *option_count != expected_count
+                {
+                    return Err(format!(
+                        "second plural option count mismatch: expected {expected_count}, got {option_count}"
+                    ));
                 }
             }
             None => return Err("expected second plural node but none was found".to_owned()),
@@ -243,19 +243,19 @@ fn compare_icu_reject(
             expected.message_contains, message
         ));
     }
-    if let Some(expected_line) = expected.line {
-        if line != expected_line {
-            return Err(format!(
-                "error line mismatch: expected {expected_line}, got {line}"
-            ));
-        }
+    if let Some(expected_line) = expected.line
+        && line != expected_line
+    {
+        return Err(format!(
+            "error line mismatch: expected {expected_line}, got {line}"
+        ));
     }
-    if let Some(min_column) = expected.min_column {
-        if column < min_column {
-            return Err(format!(
-                "error column mismatch: expected at least {min_column}, got {column}"
-            ));
-        }
+    if let Some(min_column) = expected.min_column
+        && column < min_column
+    {
+        return Err(format!(
+            "error column mismatch: expected at least {min_column}, got {column}"
+        ));
     }
     Ok(String::new())
 }

--- a/crates/ferrocat-bench/src/compare.rs
+++ b/crates/ferrocat-bench/src/compare.rs
@@ -244,7 +244,7 @@ fn run_profile(
             samples_by_plan[index].push(sample);
         }
 
-        for (plan, samples) in plans.into_iter().zip(samples_by_plan.into_iter()) {
+        for (plan, samples) in plans.into_iter().zip(samples_by_plan) {
             let statistics = ScenarioStatistics::from_samples(&samples);
             reports.push(ScenarioReport {
                 id: plan.scenario.id.clone(),

--- a/crates/ferrocat-bench/src/compare.rs
+++ b/crates/ferrocat-bench/src/compare.rs
@@ -1937,7 +1937,19 @@ fn digest_summary<T: Serialize>(value: &T) -> Result<String, String> {
     let canonical = canonical_json_string(value)?;
     let mut hasher = Sha256::new();
     hasher.update(canonical.as_bytes());
-    Ok(format!("{:x}", hasher.finalize()))
+    let digest = hasher.finalize();
+    Ok(bytes_to_lower_hex(digest.as_ref()))
+}
+
+fn bytes_to_lower_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[usize::from(byte >> 4)] as char);
+        out.push(HEX[usize::from(byte & 0x0f)] as char);
+    }
+    out
 }
 
 fn canonical_json_string<T: Serialize>(value: &T) -> Result<String, String> {
@@ -2515,28 +2527,26 @@ fn detect_cpu_model(path_override: Option<&OsStr>) -> String {
 
 fn detect_memory_bytes(path_override: Option<&OsStr>) -> u64 {
     let workspace = workspace_root().unwrap_or_else(|_| PathBuf::from("."));
-    if env::consts::OS == "macos" {
-        if let Some(bytes) = read_macos_sysctl_u64("hw.memsize") {
-            return bytes;
-        }
+    if env::consts::OS == "macos"
+        && let Some(bytes) = read_macos_sysctl_u64("hw.memsize")
+    {
+        return bytes;
     }
-    if env::consts::OS == "linux" {
-        if let Ok(meminfo) = fs::read_to_string("/proc/meminfo") {
-            for line in meminfo.lines() {
-                if let Some(value) = line.strip_prefix("MemTotal:") {
-                    let kb = value
-                        .split_whitespace()
-                        .next()
-                        .and_then(|raw| raw.parse::<u64>().ok());
-                    if let Some(kb) = kb {
-                        return kb.saturating_mul(1024);
-                    }
-                }
+    if env::consts::OS == "linux"
+        && let Ok(meminfo) = fs::read_to_string("/proc/meminfo")
+    {
+        for line in meminfo.lines() {
+            if let Some(kb) = line
+                .strip_prefix("MemTotal:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|raw| raw.parse::<u64>().ok())
+            {
+                return kb.saturating_mul(1024);
             }
         }
     }
-    if env::consts::OS == "windows" {
-        if let Ok(output) = run_command_capture_with_path(
+    if env::consts::OS == "windows"
+        && let Ok(output) = run_command_capture_with_path(
             "powershell",
             &[
                 "-NoProfile",
@@ -2545,11 +2555,10 @@ fn detect_memory_bytes(path_override: Option<&OsStr>) -> u64 {
             ],
             &workspace,
             path_override,
-        ) {
-            if let Ok(bytes) = output.stdout.trim().parse::<u64>() {
-                return bytes;
-            }
-        }
+        )
+        && let Ok(bytes) = output.stdout.trim().parse::<u64>()
+    {
+        return bytes;
     }
     0
 }

--- a/crates/ferrocat-bench/src/fixtures.rs
+++ b/crates/ferrocat-bench/src/fixtures.rs
@@ -11,6 +11,14 @@ const TINY_FIXTURE: &str = include_str!("../fixtures/tiny.po");
 const REALISTIC_FIXTURE: &str = include_str!("../fixtures/realistic.po");
 const STRESS_FIXTURE: &str = include_str!("../fixtures/stress.po");
 
+#[expect(
+    clippy::manual_is_multiple_of,
+    reason = "`usize::is_multiple_of` would raise the MSRV beyond Rust 1.88."
+)]
+const fn is_multiple_of(value: usize, divisor: usize) -> bool {
+    value % divisor == 0
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct FixtureStats {
     pub entries: usize,
@@ -327,7 +335,7 @@ fn merge_fixture_from_existing(
             continue;
         }
         active_index += 1;
-        if active_index % 5 == 0 {
+        if is_multiple_of(active_index, 5) {
             continue;
         }
 
@@ -336,7 +344,7 @@ fn merge_fixture_from_existing(
             active_index,
             (active_index % 200) + 1
         );
-        let extracted_comment = (active_index % 7 == 0)
+        let extracted_comment = is_multiple_of(active_index, 7)
             .then(|| format!("Merged extractor comment {}", active_index % 13));
         let msgctxt = item.msgctxt.clone();
         let msgid = item.msgid.clone();
@@ -352,7 +360,7 @@ fn merge_fixture_from_existing(
                 .into_iter()
                 .map(Cow::Owned)
                 .collect(),
-            flags: if active_index % 11 == 0 {
+            flags: if is_multiple_of(active_index, 11) {
                 vec![Cow::Borrowed("c-format")]
             } else {
                 Vec::new()
@@ -384,17 +392,18 @@ fn merge_fixture_from_existing(
 
     for index in 0..(parsed.items.len() / 10).max(1) {
         let message_index = parsed.items.len() + index;
-        let msgctxt =
-            (message_index % 9 == 0).then(|| format!("merge-context-{}", message_index % 5));
+        let msgctxt = is_multiple_of(message_index, 9)
+            .then(|| format!("merge-context-{}", message_index % 5));
         let msgid = format!("Merged message {message_index}");
         let msgid_plural =
-            (message_index % 8 == 0).then(|| format!("Merged messages {message_index}"));
+            is_multiple_of(message_index, 8).then(|| format!("Merged messages {message_index}"));
         let reference = format!(
             "src/new_merge_{:04}.rs:{}",
             message_index,
             (message_index % 200) + 1
         );
-        let extracted_comment = (message_index % 6 == 0).then(|| "newly extracted".to_owned());
+        let extracted_comment =
+            is_multiple_of(message_index, 6).then(|| "newly extracted".to_owned());
 
         extracted_messages.push(MergeExtractedMessage {
             msgctxt: msgctxt.as_ref().map(|context| Cow::Owned(context.clone())),
@@ -406,7 +415,7 @@ fn merge_fixture_from_existing(
                 .into_iter()
                 .map(Cow::Owned)
                 .collect(),
-            flags: if message_index % 10 == 0 {
+            flags: if is_multiple_of(message_index, 10) {
                 vec![Cow::Borrowed("fuzzy")]
             } else {
                 Vec::new()
@@ -460,9 +469,9 @@ fn generated_catalog_icu_fixture(kind: CatalogIcuFixtureKind, entries: usize) ->
     let mut api_extracted_messages = Vec::with_capacity(entries);
 
     for index in 0..entries {
-        let msgctxt = (index % 9 == 0).then(|| format!("icu-context-{}", index % 5));
+        let msgctxt = is_multiple_of(index, 9).then(|| format!("icu-context-{}", index % 5));
         let reference = format!("src/icu_{:04}.tsx:{}", index, (index % 200) + 1);
-        let comments = if index % 7 == 0 {
+        let comments = if is_multiple_of(index, 7) {
             vec![format!("ICU benchmark extractor note {}", index % 11)]
         } else {
             Vec::new()
@@ -520,9 +529,9 @@ fn generated_catalog_modern_fixture(locale: GettextLocaleProfile, entries: usize
     let mut api_extracted_messages = Vec::with_capacity(entries);
 
     for index in 0..entries {
-        let msgctxt = (index % 11 == 0).then(|| format!("modern-context-{}", index % 5));
+        let msgctxt = is_multiple_of(index, 11).then(|| format!("modern-context-{}", index % 5));
         let reference = format!("src/catalog_{:04}.tsx:{}", index, (index % 200) + 1);
-        let comments = (index % 8 == 0)
+        let comments = is_multiple_of(index, 8)
             .then(|| format!("Modern catalog extractor note {}", index % 13))
             .into_iter()
             .collect::<Vec<_>>();
@@ -545,7 +554,7 @@ fn generated_catalog_modern_fixture(locale: GettextLocaleProfile, entries: usize
         existing_po.push_str("#: ");
         existing_po.push_str(&reference);
         existing_po.push('\n');
-        if index % 17 == 0 {
+        if is_multiple_of(index, 17) {
             existing_po.push_str("#, fuzzy\n");
         }
         if let Some(ref msgctxt) = msgctxt {
@@ -826,14 +835,14 @@ const fn gettext_feature_shape(family: GettextFixtureFamily, index: usize) -> Ge
     };
 
     GettextFeatureShape {
-        is_plural: index % plural_mod == 0,
-        is_multiline: index % multiline_mod == 0,
-        has_escape: index % 17 == 0,
-        has_context: index % context_mod == 0,
-        has_references: index % 2 == 0,
-        has_translator_comment: index % 9 == 0,
-        has_extracted_comment: index % 11 == 0,
-        has_fuzzy: index % 19 == 0,
+        is_plural: is_multiple_of(index, plural_mod),
+        is_multiline: is_multiple_of(index, multiline_mod),
+        has_escape: is_multiple_of(index, 17),
+        has_context: is_multiple_of(index, context_mod),
+        has_references: is_multiple_of(index, 2),
+        has_translator_comment: is_multiple_of(index, 9),
+        has_extracted_comment: is_multiple_of(index, 11),
+        has_fuzzy: is_multiple_of(index, 19),
         has_c_format: true,
     }
 }
@@ -1181,9 +1190,9 @@ fn icu_top_level_plural(variable: &str, one: &str, other: &str) -> String {
 const fn catalog_icu_flavor(kind: CatalogIcuFixtureKind, index: usize) -> CatalogIcuFlavor {
     match kind {
         CatalogIcuFixtureKind::Light => {
-            if index % 12 == 0 {
+            if is_multiple_of(index, 12) {
                 CatalogIcuFlavor::ProjectablePlural
-            } else if index % 5 == 0 {
+            } else if is_multiple_of(index, 5) {
                 CatalogIcuFlavor::Formatters
             } else {
                 CatalogIcuFlavor::Args
@@ -1548,15 +1557,15 @@ fn build_mixed_fixture(entries: usize) -> String {
     out.push_str("\"Plural-Forms: nplurals=2; plural=(n != 1);\\n\"\n\n");
 
     for index in 0..entries {
-        let is_plural = index % 10 == 0;
-        let has_comment = index % 20 == 0;
-        let has_extracted = index % 25 == 0;
-        let has_references = index % 3 == 0;
-        let has_context = index % 12 == 0;
-        let has_metadata = index % 50 == 0;
-        let is_obsolete = index > 0 && index % 100 == 0;
-        let is_multiline = index % 33 == 0;
-        let has_escape = index % 40 == 0;
+        let is_plural = is_multiple_of(index, 10);
+        let has_comment = is_multiple_of(index, 20);
+        let has_extracted = is_multiple_of(index, 25);
+        let has_references = is_multiple_of(index, 3);
+        let has_context = is_multiple_of(index, 12);
+        let has_metadata = is_multiple_of(index, 50);
+        let is_obsolete = index > 0 && is_multiple_of(index, 100);
+        let is_multiline = is_multiple_of(index, 33);
+        let has_escape = is_multiple_of(index, 40);
         let prefix = if is_obsolete { "#~ " } else { "" };
 
         if has_comment {
@@ -1575,7 +1584,7 @@ fn build_mixed_fixture(entries: usize) -> String {
                 &format!("#: src/feature_{:04}.rs:{}", index, (index % 200) + 1),
             );
         }
-        if index % 18 == 0 {
+        if is_multiple_of(index, 18) {
             push_line(&mut out, prefix, "#, fuzzy");
         }
         if has_context {

--- a/crates/ferrocat-po/src/scan.rs
+++ b/crates/ferrocat-po/src/scan.rs
@@ -89,7 +89,11 @@ mod backend {
                 matched = vorrq_u8(matched, vceqq_u8(chunk, vdupq_n_u8(b'\x08')));
                 vorrq_u8(matched, vceqq_u8(chunk, vdupq_n_u8(b'\x0c')))
             };
-            if vmaxvq_u8(matched) != 0 {
+            // SAFETY: Rust 1.88 requires the NEON reduction call to be inside
+            // an unsafe block; newer toolchains treat it as safe.
+            #[allow(unused_unsafe)]
+            let has_match = unsafe { vmaxvq_u8(matched) } != 0;
+            if has_match {
                 return haystack[offset..offset + 16]
                     .iter()
                     .position(|byte| {

--- a/crates/ferrocat-po/src/text.rs
+++ b/crates/ferrocat-po/src/text.rs
@@ -217,7 +217,7 @@ pub fn validate_quoted_content(raw: &[u8]) -> Result<(), ParseError> {
     for &byte in raw {
         match byte {
             b'\\' => trailing_backslashes += 1,
-            b'"' if trailing_backslashes % 2 == 0 => {
+            b'"' if has_even_trailing_backslashes(trailing_backslashes) => {
                 return Err(ParseError::new("unescaped quote in string literal"));
             }
             _ => trailing_backslashes = 0,
@@ -225,6 +225,14 @@ pub fn validate_quoted_content(raw: &[u8]) -> Result<(), ParseError> {
     }
 
     Ok(())
+}
+
+#[expect(
+    clippy::manual_is_multiple_of,
+    reason = "`usize::is_multiple_of` would raise the MSRV beyond Rust 1.88."
+)]
+fn has_even_trailing_backslashes(count: usize) -> bool {
+    count % 2 == 0
 }
 
 fn escape_string_from(out: &mut String, input: &str, bytes: &[u8], first_escape: usize) {

--- a/docs/app/root.tsx
+++ b/docs/app/root.tsx
@@ -1,15 +1,13 @@
-import { RootLayout, ArdoRoot } from "ardo/ui"
+import { ArdoRoot } from "ardo/ui"
 import config from "virtual:ardo/config"
 import sidebar from "virtual:ardo/sidebar"
 import type { MetaFunction } from "react-router"
 import "ardo/ui/styles.css"
 import "./styles/site.css"
 
-export const meta: MetaFunction = () => [{ title: config.title }]
+export { ArdoRootLayout as Layout } from "ardo/ui"
 
-export function Layout({ children }: { children: React.ReactNode }) {
-  return <RootLayout>{children}</RootLayout>
-}
+export const meta: MetaFunction = () => [{ title: config.title }]
 
 export default function Root() {
   return (

--- a/docs/app/routes/guide/getting-started.mdx
+++ b/docs/app/routes/guide/getting-started.mdx
@@ -46,7 +46,8 @@ assert!(rendered.contains(r#"msgstr "Welt""#));
 
 ## Compatibility policy
 
-- **MSRV:** Rust `1.85`
+- **MSRV:** Rust `1.88`
+- **MSRV policy:** support a Rust stable release roughly 9-12 months behind current stable when practical, rather than only the newest stable toolchain
 - **Semver:** the public API is treated seriously, but the project is still pre-`1.0`
 - **Docs surface:** README examples, rustdoc, and the site should stay aligned
 

--- a/docs/app/routes/guide/project-status.mdx
+++ b/docs/app/routes/guide/project-status.mdx
@@ -16,7 +16,8 @@ description: Current strengths, roadmap themes, compatibility policy, and long-t
 
 ## Compatibility policy
 
-- **MSRV:** `1.85`
+- **MSRV:** `1.88`
+- **MSRV policy:** support a Rust stable release roughly 9-12 months behind current stable when practical, rather than only the newest stable toolchain
 - **Semver:** the public API is treated seriously, but carefully documented breaking changes may still happen before `1.0`
 - **Documentation:** README examples, rustdoc, and repository docs aim to stay aligned
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,18 +10,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "ardo": "^3.1.0",
-    "isbot": "*",
-    "lucide-react": "*",
-    "react": "*",
-    "react-dom": "*",
-    "react-router": "*"
+    "ardo": "^3.2.1",
+    "isbot": "^5.1.36",
+    "lucide-react": "^0.577.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "react-router": "^7.15.0"
   },
   "devDependencies": {
-    "@react-router/dev": "*",
+    "@react-router/dev": "^7.15.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "typescript": "^5.9.3",
-    "vite": "^8.0.0-beta.0"
+    "vite": "^8.0.11"
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -9,27 +9,27 @@ importers:
   .:
     dependencies:
       ardo:
-        specifier: ^3.1.0
-        version: 3.1.0(@types/node@25.5.0)(esbuild@0.27.4)(lightningcss@1.32.0)(lucide-react@0.577.0(react@19.2.4))(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2))(yaml@2.8.2)
+        specifier: ^3.2.1
+        version: 3.2.1(@types/node@25.5.0)(esbuild@0.27.4)(lightningcss@1.32.0)(lucide-react@0.577.0(react@19.2.6))(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4))(yaml@2.8.4)
       isbot:
-        specifier: '*'
+        specifier: ^5.1.36
         version: 5.1.36
       lucide-react:
-        specifier: '*'
-        version: 0.577.0(react@19.2.4)
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.6)
       react:
-        specifier: '*'
-        version: 19.2.4
+        specifier: ^19.2.6
+        version: 19.2.6
       react-dom:
-        specifier: '*'
-        version: 19.2.4(react@19.2.4)
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
       react-router:
-        specifier: '*'
-        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^7.15.0
+        version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@react-router/dev':
-        specifier: '*'
-        version: 7.13.1(@types/node@25.5.0)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2))(yaml@2.8.2)
+        specifier: ^7.15.0
+        version: 7.15.0(@types/node@25.5.0)(lightningcss@1.32.0)(react-router@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4))(yaml@2.8.4)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -40,8 +40,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.0.0-beta.0
-        version: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2)
+        specifier: ^8.0.11
+        version: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4)
 
 packages:
 
@@ -150,18 +150,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-typescript@7.28.6':
     resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
     engines: {node: '>=6.9.0'}
@@ -190,14 +178,14 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@emnapi/core@1.9.0':
-    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.9.0':
-    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
@@ -388,23 +376,26 @@ packages:
   '@mjackson/node-fetch-server@0.2.0':
     resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
-  '@oxc-project/types@0.120.0':
-    resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
+  '@oxc-project/types@0.128.0':
+    resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
 
-  '@react-router/dev@7.13.1':
-    resolution: {integrity: sha512-H+kEvbbOaWGaitOyL6CgqPsHqRUh66HuVRvIEaZEqdoAY/1xChdhmmq6ZumMHzcFHgHlfOcoXgNHlz6ZO4NWcg==}
+  '@react-router/dev@7.15.0':
+    resolution: {integrity: sha512-ZwUQu4KNZrViFqdeFWqh00Bk/QbLNvoWRDfjsqOp3oyuG3jSRLYnqRD3VAMK/FYMpL+s37ByT7XqqLXaF7Nw1g==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
-      '@react-router/serve': ^7.13.1
-      '@vitejs/plugin-rsc': ~0.5.7
-      react-router: ^7.13.1
+      '@react-router/serve': ^7.15.0
+      '@vitejs/plugin-rsc': ~0.5.21
+      react-router: ^7.15.0
       react-server-dom-webpack: ^19.2.3
-      typescript: ^5.1.0
-      vite: ^5.1.0 || ^6.0.0 || ^7.0.0
+      typescript: ^5.1.0 || ^6.0.0
+      vite: ^5.1.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       wrangler: ^3.28.2 || ^4.0.0
     peerDependenciesMeta:
       '@react-router/serve':
@@ -418,12 +409,12 @@ packages:
       wrangler:
         optional: true
 
-  '@react-router/node@7.13.1':
-    resolution: {integrity: sha512-IWPPf+Q3nJ6q4bwyTf5leeGUfg8GAxSN1RKj5wp9SK915zKK+1u4TCOfOmr8hmC6IW1fcjKV0WChkM0HkReIiw==}
+  '@react-router/node@7.15.0':
+    resolution: {integrity: sha512-SgvWaWF1n3u+bpXXZUW9BSd2p/NwkIYLz4SSeDYqoX5RkYX5rcI4cHHuNJXszPu+Dm9QIri4J9g/4EV3KfgiXQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      react-router: 7.13.1
-      typescript: ^5.1.0
+      react-router: 7.15.0
+      typescript: ^5.1.0 || ^6.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -431,106 +422,106 @@ packages:
   '@remix-run/node-fetch-server@0.13.0':
     resolution: {integrity: sha512-1EsNo0ZpgXu/90AWoRZf/oE3RVTUS80tiTUpt+hv5pjtAkw7icN4WskDwz/KdAw5ARbJLMhZBrO1NqThmy/McA==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
-    resolution: {integrity: sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
-    resolution: {integrity: sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
-    resolution: {integrity: sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    resolution: {integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
-    resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
-    resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
-    resolution: {integrity: sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==}
-    engines: {node: '>=14.0.0'}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    resolution: {integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
-    resolution: {integrity: sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
-    resolution: {integrity: sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.10':
-    resolution: {integrity: sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==}
+  '@rolldown/pluginutils@1.0.0-rc.18':
+    resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
 
-  '@rolldown/pluginutils@1.0.0-rc.3':
-    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -729,18 +720,6 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
-
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
-
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
-
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -784,15 +763,16 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vanilla-extract/babel-plugin-debug-ids@1.2.2':
     resolution: {integrity: sha512-MeDWGICAF9zA/OZLOKwhoRlsUW+fiMwnfuOAqFVohL31Agj7Q/RBWAYweqjHLgFBCsdnr6XIfwjJnmb2znEWxw==}
 
-  '@vanilla-extract/compiler@0.5.1':
-    resolution: {integrity: sha512-0FyUMZYlgdvgQuv3e5sBii0Xc0f76hOMIiAaqc/KNClss6MkKrY8vib1g542uMC1fUHQ5xhViq/4sZK72GYPyQ==}
+  '@vanilla-extract/compiler@0.7.0':
+    resolution: {integrity: sha512-rZQ40HVmsxfGLjoflwwsaUBLfpbpKDoZC19oiDA0FHq4LdrYtyVbFkc0MfqkNo/qBCvaZfsRezCqk0QQxCqZ8w==}
 
-  '@vanilla-extract/css@1.19.1':
-    resolution: {integrity: sha512-RKVi4TD56volJwFh+E9w8tYJ/FyVj58fmkRv+dP+YlYptGavxK2dKj5nNp8Vr1lYZ4CVMrLZvssYjBzA288Khg==}
+  '@vanilla-extract/css@1.20.1':
+    resolution: {integrity: sha512-5I9RNo5uZW9tsBnqrWzJqELegOqTHBrZyDFnES0gR9gJJHBB9dom1N0bwITM9tKwBcfKrTX4a6DHVeQdJ2ubQA==}
 
   '@vanilla-extract/esbuild-plugin@2.3.22':
     resolution: {integrity: sha512-unxruCeuGR2BpmEuSV49++V4whdX7uPWADIiPwAe6zEOXwPrXQK+VtXjjZ/yN40vGfE7OJP/4WSDM5RuYX4LoQ==}
@@ -813,16 +793,23 @@ packages:
     peerDependencies:
       '@vanilla-extract/css': ^1.0.0
 
-  '@vanilla-extract/vite-plugin@5.2.0':
-    resolution: {integrity: sha512-FM2DP/jJG2BOdK83nZe+w5+2+Qv3oYlckApAOWMTnSG9rWBdBeh4L7PzJKcix9RctvuaRC0ogY1GOnoP99+BsQ==}
+  '@vanilla-extract/vite-plugin@5.2.2':
+    resolution: {integrity: sha512-AUyB4fDR2b/Mo0lcXhhlf6RxnDPYwFMyKKopalJ4BwQNKYzZSoTwHJ1PLPO9SKhpz7lzXc0Z18GHQZOewzl3YA==}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitejs/plugin-react@5.2.0':
-    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -834,10 +821,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ardo@3.1.0:
-    resolution: {integrity: sha512-AUryOfpcBrOMaVr8edhbc2YUocTV8HM8t7YPNYRIhpMel2pGO1DZlM3Nc1Ow7zYoDeS2xIywdDnCsjW1GDvxow==}
+  ardo@3.2.1:
+    resolution: {integrity: sha512-HMVXWQfM+8LKKxjVCUMefF9sDm0sMIiPtw1P7rYv1ez0U15kvpSbnN/gJACQ4iYe6j110W9GqQWjn8wq8SRgwA==}
     peerDependencies:
-      lucide-react: '>=0.400.0'
+      lucide-react: '>=0.400.0 <2.0.0'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0
     peerDependenciesMeta:
       lucide-react:
@@ -862,16 +849,18 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   baseline-browser-mapping@2.10.8:
     resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -930,11 +919,6 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
-
-  cssesc@3.0.0:
-    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1470,9 +1454,9 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
@@ -1546,11 +1530,19 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -1568,21 +1560,17 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
-  react-dom@19.2.4:
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
-      react: ^19.2.4
+      react: ^19.2.6
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
-  react-refresh@0.18.0:
-    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
-    engines: {node: '>=0.10.0'}
-
-  react-router@7.13.1:
-    resolution: {integrity: sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==}
+  react-router@7.15.0:
+    resolution: {integrity: sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -1591,8 +1579,8 @@ packages:
       react-dom:
         optional: true
 
-  react@19.2.4:
-    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
 
   read-package-up@12.0.0:
@@ -1663,8 +1651,8 @@ packages:
   require-like@0.1.2:
     resolution: {integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==}
 
-  rolldown@1.0.0-rc.10:
-    resolution: {integrity: sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==}
+  rolldown@1.0.0-rc.18:
+    resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1739,11 +1727,15 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tailwindcss@4.2.2:
-    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
+  tailwindcss@4.2.4:
+    resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   toml@3.0.0:
@@ -1766,12 +1758,12 @@ packages:
     resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
     engines: {node: '>=20'}
 
-  typedoc@0.28.17:
-    resolution: {integrity: sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==}
+  typedoc@0.28.19:
+    resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
     engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
     peerDependencies:
-      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1851,8 +1843,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.3:
+    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1891,14 +1883,14 @@ packages:
       yaml:
         optional: true
 
-  vite@8.0.1:
-    resolution: {integrity: sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==}
+  vite@8.0.11:
+    resolution: {integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -1940,8 +1932,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -2095,16 +2087,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -2152,18 +2134,18 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@emnapi/core@1.9.0':
+  '@emnapi/core@1.10.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.0':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2317,16 +2299,16 @@ snapshots:
 
   '@mjackson/node-fetch-server@0.2.0': {}
 
-  '@napi-rs/wasm-runtime@1.1.1':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.9.0
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@oxc-project/types@0.120.0': {}
+  '@oxc-project/types@0.128.0': {}
 
-  '@react-router/dev@7.13.1(@types/node@25.5.0)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2))(yaml@2.8.2)':
+  '@react-router/dev@7.15.0(@types/node@25.5.0)(lightningcss@1.32.0)(react-router@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4))(yaml@2.8.4)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -2335,7 +2317,7 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@react-router/node': 7.13.1(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+      '@react-router/node': 7.15.0(react-router@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
       '@remix-run/node-fetch-server': 0.13.0
       arg: 5.0.2
       babel-dead-code-elimination: 1.0.12
@@ -2352,12 +2334,12 @@ snapshots:
       pkg-types: 2.3.0
       prettier: 3.8.1
       react-refresh: 0.14.2
-      react-router: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       semver: 7.7.4
       tinyglobby: 0.2.15
       valibot: 1.3.1(typescript@5.9.3)
-      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4)
+      vite-node: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)(yaml@2.8.4)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2375,65 +2357,67 @@ snapshots:
       - tsx
       - yaml
 
-  '@react-router/node@7.13.1(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@react-router/node@7.15.0(react-router@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)':
     dependencies:
       '@mjackson/node-fetch-server': 0.2.0
-      react-router: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     optionalDependencies:
       typescript: 5.9.3
 
   '@remix-run/node-fetch-server@0.13.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.10': {}
+  '@rolldown/pluginutils@1.0.0-rc.18': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.3': {}
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
     dependencies:
@@ -2590,27 +2574,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/babel__core@7.20.5':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.28.0
-
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-
-  '@types/babel__traverse@7.28.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -2659,12 +2622,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vanilla-extract/compiler@0.5.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2)':
+  '@vanilla-extract/compiler@0.7.0(@types/node@25.5.0)(esbuild@0.27.4)(lightningcss@1.32.0)(yaml@2.8.4)':
     dependencies:
-      '@vanilla-extract/css': 1.19.1
+      '@vanilla-extract/css': 1.20.1
       '@vanilla-extract/integration': 8.0.9
-      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2)
-      vite-node: 6.0.0(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2)
+      vite: 7.3.3(@types/node@25.5.0)(lightningcss@1.32.0)(yaml@2.8.4)
+      vite-node: 6.0.0(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -2672,6 +2635,7 @@ snapshots:
       - esbuild
       - jiti
       - less
+      - lightningcss
       - sass
       - sass-embedded
       - stylus
@@ -2681,12 +2645,11 @@ snapshots:
       - tsx
       - yaml
 
-  '@vanilla-extract/css@1.19.1':
+  '@vanilla-extract/css@1.20.1':
     dependencies:
       '@emotion/hash': 0.9.2
       '@vanilla-extract/private': 1.0.9
       css-what: 6.2.2
-      cssesc: 3.0.0
       csstype: 3.2.3
       dedent: 1.7.2
       deep-object-diff: 1.1.9
@@ -2712,7 +2675,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@vanilla-extract/babel-plugin-debug-ids': 1.2.2
-      '@vanilla-extract/css': 1.19.1
+      '@vanilla-extract/css': 1.20.1
       dedent: 1.7.2
       esbuild: 0.27.4
       eval: 0.1.8
@@ -2725,15 +2688,15 @@ snapshots:
 
   '@vanilla-extract/private@1.0.9': {}
 
-  '@vanilla-extract/recipes@0.5.7(@vanilla-extract/css@1.19.1)':
+  '@vanilla-extract/recipes@0.5.7(@vanilla-extract/css@1.20.1)':
     dependencies:
-      '@vanilla-extract/css': 1.19.1
+      '@vanilla-extract/css': 1.20.1
 
-  '@vanilla-extract/vite-plugin@5.2.0(@types/node@25.5.0)(esbuild@0.27.4)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2))(yaml@2.8.2)':
+  '@vanilla-extract/vite-plugin@5.2.2(@types/node@25.5.0)(esbuild@0.27.4)(lightningcss@1.32.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4))(yaml@2.8.4)':
     dependencies:
-      '@vanilla-extract/compiler': 0.5.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2)
+      '@vanilla-extract/compiler': 0.7.0(@types/node@25.5.0)(esbuild@0.27.4)(lightningcss@1.32.0)(yaml@2.8.4)
       '@vanilla-extract/integration': 8.0.9
-      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2)
+      vite: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -2741,6 +2704,7 @@ snapshots:
       - esbuild
       - jiti
       - less
+      - lightningcss
       - sass
       - sass-embedded
       - stylus
@@ -2750,17 +2714,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@vitejs/plugin-react@5.2.0(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
-      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - supports-color
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4)
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -2768,22 +2725,22 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  ardo@3.1.0(@types/node@25.5.0)(esbuild@0.27.4)(lightningcss@1.32.0)(lucide-react@0.577.0(react@19.2.4))(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2))(yaml@2.8.2):
+  ardo@3.2.1(@types/node@25.5.0)(esbuild@0.27.4)(lightningcss@1.32.0)(lucide-react@0.577.0(react@19.2.6))(rollup@4.59.0)(typescript@5.9.3)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4))(yaml@2.8.4):
     dependencies:
       '@mdx-js/rollup': 3.1.1(rollup@4.59.0)
-      '@react-router/dev': 7.13.1(@types/node@25.5.0)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2))(yaml@2.8.2)
+      '@react-router/dev': 7.15.0(@types/node@25.5.0)(lightningcss@1.32.0)(react-router@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4))(yaml@2.8.4)
       '@shikijs/rehype': 4.0.2
-      '@vanilla-extract/css': 1.19.1
+      '@vanilla-extract/css': 1.20.1
       '@vanilla-extract/esbuild-plugin': 2.3.22(esbuild@0.27.4)
-      '@vanilla-extract/recipes': 0.5.7(@vanilla-extract/css@1.19.1)
-      '@vanilla-extract/vite-plugin': 5.2.0(@types/node@25.5.0)(esbuild@0.27.4)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2))(yaml@2.8.2)
-      '@vitejs/plugin-react': 5.2.0(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2))
+      '@vanilla-extract/recipes': 0.5.7(@vanilla-extract/css@1.20.1)
+      '@vanilla-extract/vite-plugin': 5.2.2(@types/node@25.5.0)(esbuild@0.27.4)(lightningcss@1.32.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4))(yaml@2.8.4)
+      '@vitejs/plugin-react': 6.0.1(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4))
       gray-matter: 4.0.3
       hast-util-to-jsx-runtime: 2.3.6
       minisearch: 7.2.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-router: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-router: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       read-package-up: 12.0.0
       rehype-parse: 9.0.1
       rehype-stringify: 10.0.1
@@ -2793,19 +2750,21 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       shiki: 4.0.2
-      tailwindcss: 4.2.2
-      typedoc: 0.28.17(typescript@5.9.3)
+      tailwindcss: 4.2.4
+      typedoc: 0.28.19(typescript@5.9.3)
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2)
+      vite: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4)
     optionalDependencies:
-      lucide-react: 0.577.0(react@19.2.4)
+      lucide-react: 0.577.0(react@19.2.6)
     transitivePeerDependencies:
       - '@react-router/serve'
+      - '@rolldown/plugin-babel'
       - '@types/node'
       - '@vitejs/devtools'
       - '@vitejs/plugin-rsc'
       - babel-plugin-macros
+      - babel-plugin-react-compiler
       - esbuild
       - jiti
       - less
@@ -2844,13 +2803,13 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.8: {}
 
-  brace-expansion@2.0.2:
+  brace-expansion@5.0.6:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   browserslist@4.28.1:
     dependencies:
@@ -2893,8 +2852,6 @@ snapshots:
   cookie@1.1.1: {}
 
   css-what@6.2.2: {}
-
-  cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -3040,6 +2997,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   find-up-simple@1.0.1: {}
 
@@ -3268,9 +3229,9 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.577.0(react@19.2.4):
+  lucide-react@0.577.0(react@19.2.6):
     dependencies:
-      react: 19.2.4
+      react: 19.2.6
 
   lunr@2.3.9: {}
 
@@ -3738,9 +3699,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  minimatch@9.0.9:
+  minimatch@10.2.5:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.6
 
   minisearch@7.2.0: {}
 
@@ -3815,6 +3776,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -3826,6 +3789,12 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.8:
     dependencies:
@@ -3839,24 +3808,22 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  react-dom@19.2.4(react@19.2.4):
+  react-dom@19.2.6(react@19.2.6):
     dependencies:
-      react: 19.2.4
+      react: 19.2.6
       scheduler: 0.27.0
 
   react-refresh@0.14.2: {}
 
-  react-refresh@0.18.0: {}
-
-  react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       cookie: 1.1.1
-      react: 19.2.4
+      react: 19.2.6
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      react-dom: 19.2.4(react@19.2.4)
+      react-dom: 19.2.6(react@19.2.6)
 
-  react@19.2.4: {}
+  react@19.2.6: {}
 
   read-package-up@12.0.0:
     dependencies:
@@ -3960,7 +3927,7 @@ snapshots:
       toml: 3.0.0
       unified: 11.0.5
       unist-util-mdx-define: 1.1.2
-      yaml: 2.8.2
+      yaml: 2.8.4
 
   remark-mdx@3.1.1:
     dependencies:
@@ -3994,26 +3961,26 @@ snapshots:
 
   require-like@0.1.2: {}
 
-  rolldown@1.0.0-rc.10:
+  rolldown@1.0.0-rc.18:
     dependencies:
-      '@oxc-project/types': 0.120.0
-      '@rolldown/pluginutils': 1.0.0-rc.10
+      '@oxc-project/types': 0.128.0
+      '@rolldown/pluginutils': 1.0.0-rc.18
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.10
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.10
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.10
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.10
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.10
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.10
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.10
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.10
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.10
+      '@rolldown/binding-android-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.18
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.18
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.18
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.18
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
 
   rollup@4.59.0:
     dependencies:
@@ -4109,12 +4076,17 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwindcss@4.2.2: {}
+  tailwindcss@4.2.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   toml@3.0.0: {}
 
@@ -4131,14 +4103,14 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typedoc@0.28.17(typescript@5.9.3):
+  typedoc@0.28.19(typescript@5.9.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.1.1
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       typescript: 5.9.3
-      yaml: 2.8.2
+      yaml: 2.8.4
 
   typescript@5.9.3: {}
 
@@ -4227,13 +4199,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)(yaml@2.8.2):
+  vite-node@3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 7.3.3(@types/node@25.5.0)(lightningcss@1.32.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4248,13 +4220,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@6.0.0(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2):
+  vite-node@6.0.0(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4):
     dependencies:
       cac: 7.0.0
       es-module-lexer: 2.0.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2)
+      vite: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -4269,7 +4241,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(yaml@2.8.2):
+  vite@7.3.3(@types/node@25.5.0)(lightningcss@1.32.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4281,26 +4253,26 @@ snapshots:
       '@types/node': 25.5.0
       fsevents: 2.3.3
       lightningcss: 1.32.0
-      yaml: 2.8.2
+      yaml: 2.8.4
 
-  vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.2):
+  vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(yaml@2.8.4):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.10
-      tinyglobby: 0.2.15
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0-rc.18
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.5.0
       esbuild: 0.27.4
       fsevents: 2.3.3
-      yaml: 2.8.2
+      yaml: 2.8.4
 
   web-namespaces@2.0.1: {}
 
   yallist@3.1.1: {}
 
-  yaml@2.8.2: {}
+  yaml@2.8.4: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

- Raise the workspace MSRV from Rust 1.85 to Rust 1.88 and add an explicit CI job for `cargo +1.88.0 check`.
- Document the MSRV policy as supporting a stable toolchain roughly 9-12 months behind current stable when practical.
- Remove the stale workspace package version, document the NEON reduction unsafe block, and keep current Clippy clean without using APIs beyond the new MSRV.
- Update docs tooling to Ardo 3.2.1 with matching React Router, React, and Vite versions, using Ardo's provided root layout export directly.

## Impact

No Rust public API changes are intended. The compatibility contract changes to Rust 1.88+.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo +1.88.0 check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo run -p ferrocat-bench -- conformance-report`
- `pnpm install --frozen-lockfile`
- `pnpm build`