### PR TITLE
ci: cache Rust builds and merge Linux test with coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Check Rust formatting
         run: cargo fmt --all --check
 
@@ -78,6 +81,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Build Rust docs with warnings denied
         env:
           RUSTDOCFLAGS: -D warnings
@@ -94,6 +100,9 @@ jobs:
       - name: Set up Rust 1.93.0
         uses: dtolnay/rust-toolchain@1.93.0
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Check workspace with MSRV
         run: cargo +1.93.0 check --workspace --all-targets --all-features --locked
 
@@ -104,7 +113,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-24.04
           - macos-14
           - windows-2025
 
@@ -115,11 +123,14 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Run workspace tests
         run: cargo test --workspace --all-features --locked
 
   coverage:
-    name: Coverage
+    name: Linux test + coverage
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -133,14 +144,25 @@ jobs:
         with:
           components: llvm-tools-preview
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: coverage
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Generate LCOV coverage report
-        run: cargo coverage-lcov
+      - name: Run instrumented workspace tests
+        run: >-
+          cargo llvm-cov --workspace --all-features --locked
+          --lcov --output-path target/lcov.info
+          --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'
 
       - name: Generate JSON coverage summary
-        run: cargo llvm-cov report --json --summary-only --output-path target/coverage-summary.json
+        run: >-
+          cargo llvm-cov report --json --summary-only
+          --output-path target/coverage-summary.json
+          --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'
 
       - name: Enforce crate coverage thresholds
         run: node scripts/coverage-gate.mjs target/coverage-summary.json ferrocat-po=95 ferrocat-icu=95

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Authenticate to crates.io
         id: crates-auth
         uses: rust-lang/crates-io-auth-action@v1


### PR DESCRIPTION
Add Swatinem/rust-cache to every Rust job (lint, rustdoc, MSRV, OS test matrix, coverage) and to the publish workflow's pre-publish test. The former coverage job now runs the full instrumented workspace test on Linux and filters bench/conformance out of the report via --ignore-filename-regex, replacing the separate ubuntu-24.04 test job.

## Summary

- what changed
- why it changed
- any notable tradeoffs

## Verification

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [ ] `cargo test --workspace --locked`

## Notes

- public API or semver-relevant changes documented
- benchmark impact considered for hot-path changes
- follow-up issues or ADR links, if applicable
