### PR TITLE
Add ICU formatter support diagnostics

### DIFF
--- a/crates/ferrocat-icu/README.md
+++ b/crates/ferrocat-icu/README.md
@@ -16,6 +16,7 @@ Use this crate when you want the ICU-specific surface directly:
 - `validate_icu` for lightweight validation
 - `analyze_icu` for structured argument, formatter, plural, select, and tag summaries
 - `compare_icu_messages` for source/translation compatibility diagnostics
+- `validate_icu_formatter_support` for mapping consumer runtime support policies to diagnostics
 - `normalize_message_metadata` for progressive source-side metadata around `msgid + msgctxt`
 - `extract_argument_names` and `extract_tag_names` when tags should not be mixed with data arguments
 - `extract_variables`, `has_plural`, `has_select`, and related helpers for AST inspection

--- a/crates/ferrocat-icu/src/analysis.rs
+++ b/crates/ferrocat-icu/src/analysis.rs
@@ -75,6 +75,23 @@ pub struct IcuFormatter {
     pub style_kind: IcuStyleKind,
 }
 
+/// Consumer-defined support decision for an ICU formatter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IcuFormatterSupport {
+    /// The formatter kind and style are supported by the consumer.
+    Supported,
+    /// The formatter kind is not supported by the consumer.
+    UnsupportedKind {
+        /// Severity to attach to the emitted diagnostic.
+        severity: IcuDiagnosticSeverity,
+    },
+    /// The formatter style is not supported by the consumer.
+    UnsupportedStyle {
+        /// Severity to attach to the emitted diagnostic.
+        severity: IcuDiagnosticSeverity,
+    },
+}
+
 /// One select expression discovered in an ICU message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IcuSelectSummary {
@@ -207,6 +224,53 @@ pub fn extract_argument_names(message: &IcuMessage) -> Vec<String> {
 #[must_use]
 pub fn extract_tag_names(message: &IcuMessage) -> Vec<String> {
     unique_names(analyze_icu(message).tags.iter().map(|tag| &tag.name))
+}
+
+/// Validates ICU formatter usage against a consumer-provided support policy.
+///
+/// The support callback receives each formatter discovered by [`analyze_icu`]
+/// and decides whether the formatter is supported, has an unsupported kind, or
+/// has an unsupported style. This keeps runtime-specific support policy outside
+/// of `ferrocat-icu` while standardizing emitted diagnostics.
+#[must_use]
+pub fn validate_icu_formatter_support(
+    message: &IcuMessage,
+    mut support: impl FnMut(&IcuFormatter) -> IcuFormatterSupport,
+) -> IcuCompatibilityReport {
+    let analysis = analyze_icu(message);
+    let mut report = IcuCompatibilityReport::default();
+
+    for formatter in &analysis.formatters {
+        match support(formatter) {
+            IcuFormatterSupport::Supported => {}
+            IcuFormatterSupport::UnsupportedKind { severity } => {
+                report.diagnostics.push(IcuDiagnostic::new(
+                    severity,
+                    "icu.unsupported_formatter_kind",
+                    format!(
+                        "ICU formatter `{}` uses unsupported formatter kind {:?}.",
+                        formatter.name, formatter.kind
+                    ),
+                    Some(formatter.name.clone()),
+                ));
+            }
+            IcuFormatterSupport::UnsupportedStyle { severity } => {
+                report.diagnostics.push(IcuDiagnostic::new(
+                    severity,
+                    "icu.unsupported_formatter_style",
+                    format!(
+                        "ICU formatter `{}` uses unsupported {:?} formatter style `{}`.",
+                        formatter.name,
+                        formatter.kind,
+                        formatter_style_label(formatter.style.as_deref())
+                    ),
+                    Some(formatter.name.clone()),
+                ));
+            }
+        }
+    }
+
+    report
 }
 
 /// Compares source and translation ICU messages for authoring compatibility.
@@ -389,6 +453,13 @@ fn formatter_map(analysis: &IcuAnalysis) -> BTreeMap<(String, IcuArgumentKind), 
 
 fn selector_set(selectors: &[String]) -> BTreeSet<String> {
     selectors.iter().cloned().collect()
+}
+
+fn formatter_style_label(style: Option<&str>) -> &str {
+    style
+        .map(str::trim)
+        .filter(|style| !style.is_empty())
+        .unwrap_or("<none>")
 }
 
 fn compare_arguments(
@@ -631,8 +702,9 @@ fn report_pattern_styles(analysis: &IcuAnalysis, label: &str, report: &mut IcuCo
 #[cfg(test)]
 mod tests {
     use crate::{
-        IcuArgumentKind, IcuCompatibilityOptions, IcuDiagnosticSeverity, IcuStyleKind, analyze_icu,
-        compare_icu_messages, extract_argument_names, extract_tag_names, parse_icu,
+        IcuArgumentKind, IcuCompatibilityOptions, IcuDiagnosticSeverity, IcuFormatterSupport,
+        IcuStyleKind, analyze_icu, compare_icu_messages, extract_argument_names, extract_tag_names,
+        parse_icu, validate_icu_formatter_support,
     };
 
     #[test]
@@ -750,5 +822,60 @@ mod tests {
             diagnostic.code == "icu.pattern_style_discouraged"
                 && diagnostic.severity == IcuDiagnosticSeverity::Warning
         }));
+    }
+
+    #[test]
+    fn formatter_support_validation_allows_supported_formatters() {
+        let message = parse_icu("{total, number, percent} {created, date, short}").expect("parse");
+
+        let report = validate_icu_formatter_support(&message, |_| IcuFormatterSupport::Supported);
+
+        assert!(report.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn formatter_support_validation_reports_unsupported_kinds() {
+        let message = parse_icu("{items, list, conjunction}").expect("parse");
+
+        let report = validate_icu_formatter_support(&message, |formatter| {
+            if formatter.kind == IcuArgumentKind::List {
+                IcuFormatterSupport::UnsupportedKind {
+                    severity: IcuDiagnosticSeverity::Error,
+                }
+            } else {
+                IcuFormatterSupport::Supported
+            }
+        });
+
+        assert_eq!(report.diagnostics.len(), 1);
+        assert_eq!(report.diagnostics[0].code, "icu.unsupported_formatter_kind");
+        assert_eq!(report.diagnostics[0].severity, IcuDiagnosticSeverity::Error);
+        assert_eq!(report.diagnostics[0].name.as_deref(), Some("items"));
+    }
+
+    #[test]
+    fn formatter_support_validation_reports_unsupported_styles() {
+        let message = parse_icu("{total, number, ::compact-short}").expect("parse");
+
+        let report = validate_icu_formatter_support(&message, |formatter| {
+            if formatter.style.as_deref() == Some("::compact-short") {
+                IcuFormatterSupport::UnsupportedStyle {
+                    severity: IcuDiagnosticSeverity::Warning,
+                }
+            } else {
+                IcuFormatterSupport::Supported
+            }
+        });
+
+        assert_eq!(report.diagnostics.len(), 1);
+        assert_eq!(
+            report.diagnostics[0].code,
+            "icu.unsupported_formatter_style"
+        );
+        assert_eq!(
+            report.diagnostics[0].severity,
+            IcuDiagnosticSeverity::Warning
+        );
+        assert_eq!(report.diagnostics[0].name.as_deref(), Some("total"));
     }
 }

--- a/crates/ferrocat-icu/src/lib.rs
+++ b/crates/ferrocat-icu/src/lib.rs
@@ -57,9 +57,9 @@ mod utils;
 
 pub use analysis::{
     IcuAnalysis, IcuArgument, IcuArgumentKind, IcuCompatibilityOptions, IcuCompatibilityReport,
-    IcuDiagnostic, IcuDiagnosticSeverity, IcuFormatter, IcuPluralSummary, IcuSelectSummary,
-    IcuStyleKind, IcuTagSummary, analyze_icu, compare_icu_messages, extract_argument_names,
-    extract_tag_names,
+    IcuDiagnostic, IcuDiagnosticSeverity, IcuFormatter, IcuFormatterSupport, IcuPluralSummary,
+    IcuSelectSummary, IcuStyleKind, IcuTagSummary, analyze_icu, compare_icu_messages,
+    extract_argument_names, extract_tag_names, validate_icu_formatter_support,
 };
 pub use ast::{IcuMessage, IcuNode, IcuOption, IcuPluralKind};
 pub use error::{IcuErrorKind, IcuParseError, IcuPosition};

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -81,16 +81,17 @@
 pub use ferrocat_icu::has_selectordinal as has_select_ordinal;
 pub use ferrocat_icu::{
     IcuAnalysis, IcuArgument, IcuArgumentKind, IcuCompatibilityOptions, IcuCompatibilityReport,
-    IcuDiagnostic, IcuDiagnosticSeverity, IcuErrorKind, IcuFormatter, IcuMessage, IcuNode,
-    IcuOption, IcuParseError, IcuParserOptions, IcuPluralKind, IcuPluralSummary, IcuPosition,
-    IcuSelectSummary, IcuStyleKind, IcuTagSummary, MessageArgumentFormatMetadata,
-    MessageArgumentKind, MessageArgumentMetadata, MessageArgumentMetadataInput,
-    MessageFormatStyleKind, MessageMetadata, MessageMetadataDiagnostic, MessageMetadataInput,
-    MessageMetadataValidationReport, MessageOriginMetadata, MessageSelectorKind,
-    MessageSelectorMetadata, analyze_icu, compare_icu_messages, derive_message_metadata_from_icu,
-    extract_argument_names, extract_tag_names, extract_variables, has_plural, has_select,
-    has_selectordinal, has_tag, normalize_message_metadata, parse_icu, parse_icu_with_options,
-    validate_icu, validate_message_metadata,
+    IcuDiagnostic, IcuDiagnosticSeverity, IcuErrorKind, IcuFormatter, IcuFormatterSupport,
+    IcuMessage, IcuNode, IcuOption, IcuParseError, IcuParserOptions, IcuPluralKind,
+    IcuPluralSummary, IcuPosition, IcuSelectSummary, IcuStyleKind, IcuTagSummary,
+    MessageArgumentFormatMetadata, MessageArgumentKind, MessageArgumentMetadata,
+    MessageArgumentMetadataInput, MessageFormatStyleKind, MessageMetadata,
+    MessageMetadataDiagnostic, MessageMetadataInput, MessageMetadataValidationReport,
+    MessageOriginMetadata, MessageSelectorKind, MessageSelectorMetadata, analyze_icu,
+    compare_icu_messages, derive_message_metadata_from_icu, extract_argument_names,
+    extract_tag_names, extract_variables, has_plural, has_select, has_selectordinal, has_tag,
+    normalize_message_metadata, parse_icu, parse_icu_with_options, validate_icu,
+    validate_icu_formatter_support, validate_message_metadata,
 };
 pub use ferrocat_po::{
     ApiError, BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, CatalogAuditChecks,


### PR DESCRIPTION
## Summary

- add a generic `IcuFormatterSupport` decision type
- add `validate_icu_formatter_support(...)` to turn consumer runtime support policies into standardized ICU diagnostics
- distinguish unsupported formatter kind from unsupported formatter style
- re-export the API from both `ferrocat-icu` and the umbrella `ferrocat` crate

Refs sebastian-software/palamedes#147

## Test Plan

- `cargo test -p ferrocat-icu`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`