### PR TITLE
docs(api): close formatter support docs drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,25 +103,28 @@ The public entry point is the `ferrocat` crate. It re-exports the stable Rust su
 ```rust
 use ferrocat::{SerializeOptions, parse_po, stringify_po};
 
-let mut file = parse_po(
-    r#"
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut file = parse_po(
+        r#"
 msgid "hello"
 msgstr "world"
 "#,
-)?;
+    )?;
 
-file.items[0].msgstr = "Welt".to_owned().into();
+    file.items[0].msgstr = "Welt".to_owned().into();
 
-let rendered = stringify_po(&file, &SerializeOptions::default());
-assert!(rendered.contains(r#"msgstr "Welt""#));
-# Ok::<(), Box<dyn std::error::Error>>(())
+    let rendered = stringify_po(&file, &SerializeOptions::default());
+    assert!(rendered.contains(r#"msgstr "Welt""#));
+
+    Ok(())
+}
 ```
 
 For the common "merge fresh extracted messages into an existing catalog" workflow, `merge_catalog` is the lean Gettext-style entry point. For N-way catalog overlays and `msgcat`-style set operations, use `combine_catalogs`. For release checks across a source catalog and target catalogs, use `audit_catalogs`. For application delivery, compile requested-locale artifacts with fallback and ICU diagnostics. For richer high-level flows across PO and NDJSON storage, the docs site's [API overview](https://sebastian-software.github.io/ferrocat/reference/api-overview) is the best next stop.
 
 `parse_po_borrowed` is the allocation-light PO parser for read-heavy paths. It borrows from the source buffer where possible, but it currently requires LF-only input; normalize CRLF input first or use `parse_po`, which handles line-ending normalization internally.
 
-ICU-native workflows can use `analyze_icu` and `compare_icu_messages` to catch missing arguments, formatter changes, tag mismatches, select/plural branch drift, and discouraged pattern-style formatters. Runtime artifact compilation can opt into the same source/translation checks with `icu_compatibility`.
+ICU-native workflows can use `analyze_icu`, `compare_icu_messages`, and `validate_icu_formatter_support` to catch missing arguments, formatter changes, unsupported runtime formatter kinds or styles, tag mismatches, select/plural branch drift, and discouraged pattern-style formatters. Runtime artifact compilation can opt into the same source/translation checks with `icu_compatibility`.
 
 Semantic metadata workflows can use `normalize_message_metadata` to keep simple source-as-msgid records small while deriving argument, tag, and selector facts from ICU MessageFormat v1 when needed. The metadata model keeps `msgid + msgctxt` as catalog identity, so it fits both Palamedes-style source strings and ID-style catalogs.
 

--- a/docs/app/routes/guide/getting-started.mdx
+++ b/docs/app/routes/guide/getting-started.mdx
@@ -27,18 +27,21 @@ The public workspace crates line up by responsibility:
 ```rust
 use ferrocat::{SerializeOptions, parse_po, stringify_po};
 
-let mut file = parse_po(
-    r#"
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut file = parse_po(
+        r#"
 msgid "hello"
 msgstr "world"
 "#,
-)?;
+    )?;
 
-file.items[0].msgstr = "Welt".to_owned().into();
+    file.items[0].msgstr = "Welt".to_owned().into();
 
-let rendered = stringify_po(&file, &SerializeOptions::default());
-assert!(rendered.contains(r#"msgstr "Welt""#));
-# Ok::<(), Box<dyn std::error::Error>>(())
+    let rendered = stringify_po(&file, &SerializeOptions::default());
+    assert!(rendered.contains(r#"msgstr "Welt""#));
+
+    Ok(())
+}
 ```
 
 ## Where to go next

--- a/docs/app/routes/operations/release-verification.mdx
+++ b/docs/app/routes/operations/release-verification.mdx
@@ -27,6 +27,8 @@ This checklist verifies a real Rust-only `ferrocat` release after the publish wo
 - Build a tiny smoke example that calls `parse_po` and `parse_icu` through the umbrella crate.
 - Confirm docs.rs builds for `ferrocat` and that the README example still matches the published surface.
 - Confirm the crate READMEs published for `ferrocat`, `ferrocat-po`, and `ferrocat-icu` still describe the current public surface accurately.
+- Confirm the site API overview covers any new public APIs or semver-relevant behavior added in the release.
+- Refresh dated quality snapshots when the release changes conformance counts, coverage thresholds, or the benchmark/coverage commands documented on the site.
 
 ## 4. Confirm repository metadata surface
 

--- a/docs/app/routes/quality/test-coverage.mdx
+++ b/docs/app/routes/quality/test-coverage.mdx
@@ -98,4 +98,4 @@ That same job now also exports `target/coverage-summary.json` and runs a small c
 
 For private repositories, add a GitHub Actions repository secret named `CODECOV_TOKEN`.
 
-For public repositories, tokenless upload may also work with `codecov/codecov-action@v5` if token authentication has been disabled in the Codecov organization settings. If you want the least surprising setup, keep the `CODECOV_TOKEN` secret configured either way.
+For public repositories, tokenless upload may also work with `codecov/codecov-action@v6` if token authentication has been disabled in the Codecov organization settings. If you want the least surprising setup, keep the `CODECOV_TOKEN` secret configured either way.

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -57,6 +57,7 @@ NDJSON is the line-delimited JSON storage choice. It is useful when catalogs are
 | Only validate ICU syntax | `validate_icu` |
 | Summarize ICU arguments, formatters, plurals, selects, and tags | `analyze_icu` |
 | Compare source and translated ICU message structure | `compare_icu_messages` |
+| Validate discovered ICU formatters against a runtime support policy | `validate_icu_formatter_support` |
 | Extract only data argument names or only tag names | `extract_argument_names` / `extract_tag_names` |
 | Extract variable names from a parsed ICU message | `extract_variables` |
 
@@ -424,6 +425,19 @@ formatters.
 At the catalog artifact layer, set `icu_compatibility: true` on
 `CompileCatalogArtifactOptions` or `CompileSelectedCatalogArtifactOptions` to
 collect the same diagnostics while compiling the final locale artifact.
+
+### `validate_icu_formatter_support`
+
+Use this when a host runtime supports only a subset of ICU formatter kinds or
+styles. The API analyzes a parsed message, passes each discovered formatter to a
+caller-provided support callback, and returns standard `icu.*` diagnostics for
+unsupported formatter kinds or styles.
+
+This keeps runtime-specific support policy in the host adapter while giving
+CI, editors, and build tools the same diagnostic shape as the rest of
+Ferrocat's ICU compatibility checks. For example, a JavaScript adapter can
+accept `number` and `date`, reject `list`, or reject pattern-style date formats
+before the catalog artifact ships.
 
 ### `extract_argument_names` / `extract_tag_names`
 


### PR DESCRIPTION
Closes #73.

## Summary
- Documents `validate_icu_formatter_support` in the root README and site API overview.
- Rewrites the README/getting-started Rust snippets as complete copy-pasteable `fn main() -> Result<...>` examples.
- Updates the Codecov action reference to `codecov/codecov-action@v6`.
- Adds release-verification checklist items for public API docs drift and dated quality snapshots.

## User-visible impact
- Documentation only. No Rust API or runtime behavior changes.

## Validation
- `pnpm install --frozen-lockfile` in `docs/`
- `pnpm build` in `docs/`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

## Notes
- This PR intentionally leaves broader examples/upgrading docs for the separate issue-specific PRs.