### PR TITLE
feat(icu): validate formatter support from analysis

### DIFF
--- a/crates/ferrocat-icu/README.md
+++ b/crates/ferrocat-icu/README.md
@@ -17,6 +17,7 @@ Use this crate when you want the ICU-specific surface directly:
 - `analyze_icu` for structured argument, formatter, plural, select, and tag summaries
 - `compare_icu_messages` for source/translation compatibility diagnostics
 - `validate_icu_formatter_support` for mapping consumer runtime support policies to diagnostics
+- `validate_icu_formatter_support_from_analysis` when the caller already has an `IcuAnalysis` and wants to avoid a second message walk
 - `normalize_message_metadata` for progressive source-side metadata around `msgid + msgctxt`
 - `extract_argument_names` and `extract_tag_names` when tags should not be mixed with data arguments
 - `extract_variables`, `has_plural`, `has_select`, and related helpers for AST inspection

--- a/crates/ferrocat-icu/src/analysis.rs
+++ b/crates/ferrocat-icu/src/analysis.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
 
 use crate::ast::{IcuMessage, IcuNode, IcuOption, IcuPluralKind};
 
@@ -38,6 +41,24 @@ pub enum IcuArgumentKind {
     Plural,
     /// Ordinal plural expression.
     SelectOrdinal,
+}
+
+impl fmt::Display for IcuArgumentKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Argument => "argument",
+            Self::Number => "number",
+            Self::Date => "date",
+            Self::Time => "time",
+            Self::List => "list",
+            Self::Duration => "duration",
+            Self::Ago => "ago",
+            Self::Name => "name",
+            Self::Select => "select",
+            Self::Plural => "plural",
+            Self::SelectOrdinal => "selectordinal",
+        })
+    }
 }
 
 /// Classification of an optional formatter style segment.
@@ -81,11 +102,18 @@ pub enum IcuFormatterSupport {
     /// The formatter kind and style are supported by the consumer.
     Supported,
     /// The formatter kind is not supported by the consumer.
+    ///
+    /// Use this when a runtime cannot handle the formatter category at all,
+    /// such as rejecting every `list` formatter.
     UnsupportedKind {
         /// Severity to attach to the emitted diagnostic.
         severity: IcuDiagnosticSeverity,
     },
     /// The formatter style is not supported by the consumer.
+    ///
+    /// Use this when a runtime accepts the formatter kind but rejects the
+    /// specific style. A missing style is treated as the formatter's default
+    /// style; reject it with this variant when the default style is unsupported.
     UnsupportedStyle {
         /// Severity to attach to the emitted diagnostic.
         severity: IcuDiagnosticSeverity,
@@ -235,9 +263,23 @@ pub fn extract_tag_names(message: &IcuMessage) -> Vec<String> {
 #[must_use]
 pub fn validate_icu_formatter_support(
     message: &IcuMessage,
-    mut support: impl FnMut(&IcuFormatter) -> IcuFormatterSupport,
+    support: impl FnMut(&IcuFormatter) -> IcuFormatterSupport,
 ) -> IcuCompatibilityReport {
     let analysis = analyze_icu(message);
+    validate_icu_formatter_support_from_analysis(&analysis, support)
+}
+
+/// Validates analyzed ICU formatter usage against a consumer support policy.
+///
+/// Use this when the caller already has an [`IcuAnalysis`] from [`analyze_icu`]
+/// and wants to avoid walking the parsed message a second time. The callback is
+/// invoked only for formatter arguments such as `number`, `date`, `time`, or
+/// `list`; plural and select selector arguments are not formatter callbacks.
+#[must_use]
+pub fn validate_icu_formatter_support_from_analysis(
+    analysis: &IcuAnalysis,
+    mut support: impl FnMut(&IcuFormatter) -> IcuFormatterSupport,
+) -> IcuCompatibilityReport {
     let mut report = IcuCompatibilityReport::default();
 
     for formatter in &analysis.formatters {
@@ -248,7 +290,7 @@ pub fn validate_icu_formatter_support(
                     severity,
                     "icu.unsupported_formatter_kind",
                     format!(
-                        "ICU formatter `{}` uses unsupported formatter kind {:?}.",
+                        "ICU formatter `{}` uses unsupported formatter kind `{}`.",
                         formatter.name, formatter.kind
                     ),
                     Some(formatter.name.clone()),
@@ -259,7 +301,7 @@ pub fn validate_icu_formatter_support(
                     severity,
                     "icu.unsupported_formatter_style",
                     format!(
-                        "ICU formatter `{}` uses unsupported {:?} formatter style `{}`.",
+                        "ICU formatter `{}` uses unsupported `{}` formatter style `{}`.",
                         formatter.name,
                         formatter.kind,
                         formatter_style_label(formatter.style.as_deref())
@@ -704,7 +746,7 @@ mod tests {
     use crate::{
         IcuArgumentKind, IcuCompatibilityOptions, IcuDiagnosticSeverity, IcuFormatterSupport,
         IcuStyleKind, analyze_icu, compare_icu_messages, extract_argument_names, extract_tag_names,
-        parse_icu, validate_icu_formatter_support,
+        parse_icu, validate_icu_formatter_support, validate_icu_formatter_support_from_analysis,
     };
 
     #[test]
@@ -849,6 +891,10 @@ mod tests {
 
         assert_eq!(report.diagnostics.len(), 1);
         assert_eq!(report.diagnostics[0].code, "icu.unsupported_formatter_kind");
+        assert_eq!(
+            report.diagnostics[0].message,
+            "ICU formatter `items` uses unsupported formatter kind `list`."
+        );
         assert_eq!(report.diagnostics[0].severity, IcuDiagnosticSeverity::Error);
         assert_eq!(report.diagnostics[0].name.as_deref(), Some("items"));
     }
@@ -873,9 +919,99 @@ mod tests {
             "icu.unsupported_formatter_style"
         );
         assert_eq!(
+            report.diagnostics[0].message,
+            "ICU formatter `total` uses unsupported `number` formatter style `::compact-short`."
+        );
+        assert_eq!(
             report.diagnostics[0].severity,
             IcuDiagnosticSeverity::Warning
         );
         assert_eq!(report.diagnostics[0].name.as_deref(), Some("total"));
+    }
+
+    #[test]
+    fn formatter_support_validation_reports_mixed_kind_and_style_decisions() {
+        let message = parse_icu(
+            "{total, number, ::compact-short} {created, date} {items, list, conjunction}",
+        )
+        .expect("parse");
+
+        let report = validate_icu_formatter_support(&message, |formatter| match formatter.kind {
+            IcuArgumentKind::Number if formatter.style_kind == IcuStyleKind::Skeleton => {
+                IcuFormatterSupport::UnsupportedStyle {
+                    severity: IcuDiagnosticSeverity::Warning,
+                }
+            }
+            IcuArgumentKind::Date if formatter.style.is_none() => {
+                IcuFormatterSupport::UnsupportedStyle {
+                    severity: IcuDiagnosticSeverity::Error,
+                }
+            }
+            IcuArgumentKind::List => IcuFormatterSupport::UnsupportedKind {
+                severity: IcuDiagnosticSeverity::Error,
+            },
+            _ => IcuFormatterSupport::Supported,
+        });
+
+        assert_eq!(
+            report
+                .diagnostics
+                .iter()
+                .map(|diagnostic| {
+                    (
+                        diagnostic.code.as_str(),
+                        diagnostic.severity,
+                        diagnostic.name.as_deref(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    "icu.unsupported_formatter_style",
+                    IcuDiagnosticSeverity::Warning,
+                    Some("total")
+                ),
+                (
+                    "icu.unsupported_formatter_style",
+                    IcuDiagnosticSeverity::Error,
+                    Some("created")
+                ),
+                (
+                    "icu.unsupported_formatter_kind",
+                    IcuDiagnosticSeverity::Error,
+                    Some("items")
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn formatter_support_validation_accepts_precomputed_analysis() {
+        let message = parse_icu("{total, number, integer} {created, date, short}").expect("parse");
+        let analysis = analyze_icu(&message);
+
+        let report = validate_icu_formatter_support_from_analysis(&analysis, |_| {
+            IcuFormatterSupport::Supported
+        });
+
+        assert!(report.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn formatter_support_validation_does_not_visit_plural_or_select_arguments() {
+        let message = parse_icu(
+            "{gender, select, other {{count, plural, one {# file} other {# files}}}} {created, date, short}",
+        )
+        .expect("parse");
+        let analysis = analyze_icu(&message);
+        let mut visited = Vec::new();
+
+        let report = validate_icu_formatter_support_from_analysis(&analysis, |formatter| {
+            visited.push((formatter.name.clone(), formatter.kind));
+            IcuFormatterSupport::Supported
+        });
+
+        assert!(report.diagnostics.is_empty());
+        assert_eq!(visited, vec![("created".to_owned(), IcuArgumentKind::Date)]);
     }
 }

--- a/crates/ferrocat-icu/src/analysis.rs
+++ b/crates/ferrocat-icu/src/analysis.rs
@@ -930,9 +930,46 @@ mod tests {
     }
 
     #[test]
+    fn icu_argument_kind_display_uses_icu_formatter_names() {
+        let labels = [
+            IcuArgumentKind::Argument,
+            IcuArgumentKind::Number,
+            IcuArgumentKind::Date,
+            IcuArgumentKind::Time,
+            IcuArgumentKind::List,
+            IcuArgumentKind::Duration,
+            IcuArgumentKind::Ago,
+            IcuArgumentKind::Name,
+            IcuArgumentKind::Select,
+            IcuArgumentKind::Plural,
+            IcuArgumentKind::SelectOrdinal,
+        ]
+        .into_iter()
+        .map(|kind| kind.to_string())
+        .collect::<Vec<_>>();
+
+        assert_eq!(
+            labels,
+            vec![
+                "argument",
+                "number",
+                "date",
+                "time",
+                "list",
+                "duration",
+                "ago",
+                "name",
+                "select",
+                "plural",
+                "selectordinal",
+            ]
+        );
+    }
+
+    #[test]
     fn formatter_support_validation_reports_mixed_kind_and_style_decisions() {
         let message = parse_icu(
-            "{total, number, ::compact-short} {created, date} {items, list, conjunction}",
+            "{total, number, ::compact-short} {created, date} {started, time, short} {items, list, conjunction}",
         )
         .expect("parse");
 

--- a/crates/ferrocat-icu/src/lib.rs
+++ b/crates/ferrocat-icu/src/lib.rs
@@ -60,6 +60,7 @@ pub use analysis::{
     IcuDiagnostic, IcuDiagnosticSeverity, IcuFormatter, IcuFormatterSupport, IcuPluralSummary,
     IcuSelectSummary, IcuStyleKind, IcuTagSummary, analyze_icu, compare_icu_messages,
     extract_argument_names, extract_tag_names, validate_icu_formatter_support,
+    validate_icu_formatter_support_from_analysis,
 };
 pub use ast::{IcuMessage, IcuNode, IcuOption, IcuPluralKind};
 pub use error::{IcuErrorKind, IcuParseError, IcuPosition};

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -91,7 +91,8 @@ pub use ferrocat_icu::{
     compare_icu_messages, derive_message_metadata_from_icu, extract_argument_names,
     extract_tag_names, extract_variables, has_plural, has_select, has_selectordinal, has_tag,
     normalize_message_metadata, parse_icu, parse_icu_with_options, validate_icu,
-    validate_icu_formatter_support, validate_message_metadata,
+    validate_icu_formatter_support, validate_icu_formatter_support_from_analysis,
+    validate_message_metadata,
 };
 pub use ferrocat_po::{
     ApiError, BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, CatalogAuditChecks,


### PR DESCRIPTION
Closes #46.

## Summary
- Adds `validate_icu_formatter_support_from_analysis(&IcuAnalysis, ...)` for callers that already ran `analyze_icu` and want to avoid a second AST walk.
- Keeps `validate_icu_formatter_support(&IcuMessage, ...)` as the existing convenience wrapper.
- Implements `Display` for `IcuArgumentKind` and uses user-facing formatter kind names in support diagnostics.
- Documents the `UnsupportedKind` vs `UnsupportedStyle` decision, including missing style/default-style handling.
- Adds regression coverage for mixed formatter decisions and for plural/select arguments not being passed to the formatter callback.

## User-visible impact
- New public ICU API exported by both `ferrocat-icu` and the `ferrocat` umbrella crate.
- Formatter-support diagnostic messages now use ICU-style lowercase kind names such as `list` and `number` instead of Rust debug variant names.

## Validation
- `cargo test -p ferrocat-icu --all-features`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`