### PR TITLE
docs(release): add upgrading entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ If you already know what kind of question you have, these are the fastest entry 
 
 - [Getting started](https://sebastian-software.github.io/ferrocat/guide/getting-started) for installation, quick start, and the main next steps
 - [Ferrocat and Palamedes](https://sebastian-software.github.io/ferrocat/guide/palamedes) for the relationship between the catalog engine and the JS/TS i18n framework
+- [Releases and upgrading](https://sebastian-software.github.io/ferrocat/guide/upgrading) for changelogs, lockstep versions, and pre-`1.0` upgrade notes
 - [API overview](https://sebastian-software.github.io/ferrocat/reference/api-overview) for choosing between PO core, catalog workflows, and ICU helpers
 - [Gettext task landscape](https://sebastian-software.github.io/ferrocat/reference/gettext-task-landscape) for the workflow-level map across GNU gettext, common libraries, and Ferrocat
 - [Performance docs](https://sebastian-software.github.io/ferrocat/performance) for benchmark methodology, fixtures, and history
@@ -154,6 +155,8 @@ If you already know what kind of question you have, these are the fastest entry 
 ## Core Links
 
 - [docs.rs crate docs](https://docs.rs/ferrocat)
+- [`ferrocat` changelog](https://github.com/sebastian-software/ferrocat/blob/main/crates/ferrocat/CHANGELOG.md)
+- [GitHub Releases](https://github.com/sebastian-software/ferrocat/releases)
 - [GitHub repository](https://github.com/sebastian-software/ferrocat)
 - [Palamedes i18n framework](https://github.com/sebastian-software/palamedes)
 - [Contributing guide](https://github.com/sebastian-software/ferrocat/blob/main/CONTRIBUTING.md)

--- a/docs/app/routes/guide/index.mdx
+++ b/docs/app/routes/guide/index.mdx
@@ -14,4 +14,5 @@ Start here when you want to understand Ferrocat as a product, not just as a crat
 - [Runtime Compilation](/guide/runtime-compilation) for turning catalogs into application-ready artifacts
 - [Ferrocat And Palamedes](/guide/palamedes) for how the catalog engine connects to the JS/TS i18n framework
 - [Project Status](/guide/project-status) for current strengths, roadmap themes, and compatibility policy
+- [Releases And Upgrading](/guide/upgrading) for changelog locations, lockstep versions, and safe pre-`1.0` upgrades
 - [Community](/guide/community) for contributing and operational links

--- a/docs/app/routes/guide/project-status.mdx
+++ b/docs/app/routes/guide/project-status.mdx
@@ -46,4 +46,5 @@ Today Ferrocat is Rust-first. The longer-term goal is broader: a trustworthy tra
 
 - [Conformance](/quality/conformance)
 - [External Benchmarking](/performance/benchmarking)
+- [Releases And Upgrading](/guide/upgrading)
 - [Community](/guide/community)

--- a/docs/app/routes/guide/upgrading.mdx
+++ b/docs/app/routes/guide/upgrading.mdx
@@ -1,0 +1,62 @@
+---
+title: Releases And Upgrading
+description: Where Ferrocat changelogs live and how to upgrade pre-1.0 versions safely.
+order: 45
+---
+
+# Releases And Upgrading
+
+Ferrocat is still pre-`1.0`, so public APIs are treated carefully but minor
+version upgrades can still carry semver-relevant changes. Start every upgrade
+from the changelog and keep the workspace crate versions aligned.
+
+## Where release notes live
+
+- [GitHub Releases](https://github.com/sebastian-software/ferrocat/releases)
+  gives the repository-level release view.
+- [`ferrocat` CHANGELOG](https://github.com/sebastian-software/ferrocat/blob/main/crates/ferrocat/CHANGELOG.md)
+  is the best starting point for application users of the umbrella crate.
+- Direct sub-crate users should also read the matching `ferrocat-po` or
+  `ferrocat-icu` changelog for low-level parser, catalog, or ICU changes.
+
+Release Please generates these changelogs from Conventional Commits. Breaking
+changes should be marked with `feat!:` or a `BREAKING CHANGE` note so they are
+visible in release notes and changelog sections.
+
+## Lockstep versions
+
+The public library crates are released in lockstep. In normal application code,
+prefer depending on the umbrella crate:
+
+```toml
+[dependencies]
+ferrocat = "0.13"
+```
+
+If you depend on lower-level crates directly, keep every Ferrocat crate on the
+same minor version:
+
+```toml
+[dependencies]
+ferrocat-po = "0.13"
+ferrocat-icu = "0.13"
+```
+
+Do not mix the umbrella crate and direct sub-crate dependencies at different
+pre-`1.0` minors, for example `ferrocat = "0.13"` with
+`ferrocat-po = "0.12"`. Cargo treats `0.12` and `0.13` as incompatible version
+lines, so the build can contain two copies of the Ferrocat types and then fail
+with confusing type-mismatch errors.
+
+## Upgrade routine
+
+1. Read the `ferrocat` changelog for the target version.
+2. If you use direct sub-crates, read their matching changelogs too.
+3. Update all Ferrocat crate requirements to the same minor version.
+4. Run `cargo update -p ferrocat -p ferrocat-po -p ferrocat-icu` when those
+   packages are present in your lockfile.
+5. Run your normal test suite plus the Ferrocat APIs you call in release or CI
+   paths.
+
+When a future `0.x` release needs a durable migration note, this page should
+link that note from the upgrade routine instead of leaving it buried in a PR.


### PR DESCRIPTION
Closes #74.

## Summary
- Adds a new `/guide/upgrading` docs page covering changelog locations, Release Please breaking-change notation, lockstep versions, and mixed-minor dependency pitfalls.
- Links the upgrading page from the guide index, project-status follow-up reading, and README docs paths.
- Adds the umbrella `ferrocat` changelog and GitHub Releases to README Core Links.

## User-visible impact
- Documentation only. Gives adopters a discoverable path for pre-1.0 release and upgrade questions.

## Validation
- `pnpm install --frozen-lockfile` in `docs/`
- `pnpm build` in `docs/`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

## Notes
- This PR documents current release behavior only; it does not change release automation.