### PR TITLE
docs(examples): add core workflow examples

### DIFF
--- a/crates/ferrocat-po/src/api/audit.rs
+++ b/crates/ferrocat-po/src/api/audit.rs
@@ -167,6 +167,31 @@ impl CatalogAuditReport {
 /// Returns [`ApiError::InvalidArguments`] when `source_locale` is empty or when
 /// catalogs cannot be inspected because their declared locales are missing or
 /// duplicated.
+///
+/// # Examples
+///
+/// ```rust
+/// use ferrocat_po::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog};
+///
+/// let source = parse_catalog(ParseCatalogOptions {
+///     content: "msgid \"Checkout\"\nmsgstr \"Checkout\"\n",
+///     locale: Some("en"),
+///     source_locale: "en",
+///     ..ParseCatalogOptions::default()
+/// })?
+/// .into_normalized_view()?;
+/// let target = parse_catalog(ParseCatalogOptions {
+///     content: "msgid \"Checkout\"\nmsgstr \"\"\n",
+///     locale: Some("de"),
+///     source_locale: "en",
+///     ..ParseCatalogOptions::default()
+/// })?
+/// .into_normalized_view()?;
+///
+/// let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
+/// assert!(report.has_errors());
+/// # Ok::<(), ferrocat_po::ApiError>(())
+/// ```
 pub fn audit_catalogs(
     catalogs: &[&NormalizedParsedCatalog],
     options: &CatalogAuditOptions<'_>,

--- a/crates/ferrocat-po/src/api/catalog.rs
+++ b/crates/ferrocat-po/src/api/catalog.rs
@@ -105,6 +105,28 @@ struct CombineEntry {
 ///
 /// Returns [`ApiError`] when the source locale is missing, the existing catalog
 /// cannot be parsed, or the requested storage format cannot be rendered safely.
+///
+/// # Examples
+///
+/// ```rust
+/// use ferrocat_po::{
+///     CatalogUpdateInput, SourceExtractedMessage, UpdateCatalogOptions, update_catalog,
+/// };
+///
+/// let result = update_catalog(UpdateCatalogOptions {
+///     source_locale: "en",
+///     locale: Some("de"),
+///     input: CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
+///         msgid: "Checkout".to_owned(),
+///         ..SourceExtractedMessage::default()
+///     }]),
+///     ..UpdateCatalogOptions::default()
+/// })?;
+///
+/// assert!(result.created);
+/// assert!(result.content.contains("msgid \"Checkout\""));
+/// # Ok::<(), ferrocat_po::ApiError>(())
+/// ```
 #[expect(
     clippy::needless_pass_by_value,
     reason = "Public API takes owned option structs so callers can build and move them ergonomically."
@@ -229,6 +251,24 @@ pub fn update_catalog_file(
 /// Returns [`ApiError`] when required options are missing, an input cannot be
 /// parsed, a singular/plural shape conflict is encountered, or the selected
 /// conflict strategy rejects differing translations.
+///
+/// # Examples
+///
+/// ```rust
+/// use ferrocat_po::{CatalogCombineInput, CombineCatalogOptions, combine_catalogs};
+///
+/// let base = "msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n";
+/// let template = "msgid \"Checkout\"\nmsgstr \"\"\n\nmsgid \"Cart\"\nmsgstr \"\"\n";
+/// let inputs = [
+///     CatalogCombineInput::labeled(base, "de.po"),
+///     CatalogCombineInput::labeled(template, "messages.pot"),
+/// ];
+///
+/// let combined = combine_catalogs(CombineCatalogOptions::new(&inputs, "en"))?;
+/// assert!(combined.content.contains("msgstr \"Zur Kasse\""));
+/// assert!(combined.content.contains("msgid \"Cart\""));
+/// # Ok::<(), ferrocat_po::ApiError>(())
+/// ```
 #[expect(
     clippy::needless_pass_by_value,
     reason = "Public API takes owned option structs so callers can build and move them ergonomically."
@@ -528,6 +568,23 @@ fn export_catalog_content_for_combine(
 ///
 /// Returns [`ApiError`] when the catalog content cannot be parsed, the source
 /// locale is missing, or strict ICU projection fails.
+///
+/// # Examples
+///
+/// ```rust
+/// use ferrocat_po::{ParseCatalogOptions, parse_catalog};
+///
+/// let catalog = parse_catalog(ParseCatalogOptions {
+///     content: "msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n",
+///     locale: Some("de"),
+///     source_locale: "en",
+///     ..ParseCatalogOptions::default()
+/// })?;
+///
+/// assert_eq!(catalog.locale.as_deref(), Some("de"));
+/// assert_eq!(catalog.messages.len(), 1);
+/// # Ok::<(), ferrocat_po::ApiError>(())
+/// ```
 #[expect(
     clippy::needless_pass_by_value,
     reason = "Public API takes owned option structs so callers can build and move them ergonomically."

--- a/crates/ferrocat-po/src/api/mt.rs
+++ b/crates/ferrocat-po/src/api/mt.rs
@@ -40,6 +40,15 @@ pub struct MachineTranslationMetadata {
 /// changes and is not a cryptographic signature.
 ///
 /// The emitted value is the first 128 bits encoded as unpadded Base64URL.
+///
+/// # Examples
+///
+/// ```rust
+/// use ferrocat_po::{EffectiveTranslationRef, machine_translation_hash};
+///
+/// let hash = machine_translation_hash(EffectiveTranslationRef::Singular("Hallo"));
+/// assert!(!hash.is_empty());
+/// ```
 #[must_use]
 pub fn machine_translation_hash(translation: EffectiveTranslationRef<'_>) -> String {
     let mut payload = Vec::new();

--- a/crates/ferrocat-po/src/merge.rs
+++ b/crates/ferrocat-po/src/merge.rs
@@ -182,6 +182,26 @@ struct MergeLine<'a> {
 /// # Errors
 ///
 /// Returns [`ParseError`] when the existing PO file cannot be parsed.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::borrow::Cow;
+///
+/// use ferrocat_po::{MergeExtractedMessage, merge_catalog};
+///
+/// let existing = "msgid \"Hello\"\nmsgstr \"Hallo\"\n";
+/// let extracted = [MergeExtractedMessage {
+///     msgid: Cow::Borrowed("Hello"),
+///     references: vec![Cow::Borrowed("src/app.rs:10")],
+///     ..MergeExtractedMessage::default()
+/// }];
+///
+/// let merged = merge_catalog(existing, &extracted)?;
+/// assert!(merged.contains("msgstr \"Hallo\""));
+/// assert!(merged.contains("#: src/app.rs:10"));
+/// # Ok::<(), ferrocat_po::ParseError>(())
+/// ```
 pub fn merge_catalog<'a>(
     existing_po: &'a str,
     extracted_messages: &[ExtractedMessage<'a>],

--- a/crates/ferrocat/examples/merge_extracted_messages.rs
+++ b/crates/ferrocat/examples/merge_extracted_messages.rs
@@ -1,0 +1,36 @@
+use std::borrow::Cow;
+
+use ferrocat::{MergeExtractedMessage, merge_catalog};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let existing = r#"
+msgid "Hello"
+msgstr "Hallo"
+
+msgid "Old CTA"
+msgstr "Alter CTA"
+"#;
+
+    let extracted = [
+        MergeExtractedMessage {
+            msgid: Cow::Borrowed("Hello"),
+            references: vec![Cow::Borrowed("src/app.rs:10")],
+            ..MergeExtractedMessage::default()
+        },
+        MergeExtractedMessage {
+            msgid: Cow::Borrowed("Checkout"),
+            references: vec![Cow::Borrowed("src/checkout.rs:42")],
+            extracted_comments: vec![Cow::Borrowed("Primary checkout button")],
+            ..MergeExtractedMessage::default()
+        },
+    ];
+
+    let merged = merge_catalog(existing, &extracted)?;
+
+    assert!(merged.contains("msgstr \"Hallo\""));
+    assert!(merged.contains("msgid \"Checkout\""));
+    assert!(merged.contains("#~ msgid \"Old CTA\""));
+
+    println!("{merged}");
+    Ok(())
+}

--- a/crates/ferrocat/examples/ndjson_with_mt_metadata.rs
+++ b/crates/ferrocat/examples/ndjson_with_mt_metadata.rs
@@ -1,0 +1,38 @@
+use ferrocat::{
+    CatalogStorageFormat, CatalogUpdateInput, EffectiveTranslationRef, SourceExtractedMessage,
+    UpdateCatalogOptions, machine_translation_hash, update_catalog,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let hash = machine_translation_hash(EffectiveTranslationRef::Singular("Hallo"));
+    let existing = format!(
+        concat!(
+            "---\n",
+            "format: ferrocat.ndjson.v1\n",
+            "locale: de\n",
+            "source_locale: en\n",
+            "---\n",
+            "{{\"id\":\"Hello\",\"str\":\"Hallo\",\"mt\":{{\"model\":\"example/mt\",\"confidence\":92,\"hash\":\"{hash}\"}}}}\n"
+        ),
+        hash = hash
+    );
+
+    let result = update_catalog(UpdateCatalogOptions {
+        locale: Some("de"),
+        source_locale: "en",
+        storage_format: CatalogStorageFormat::Ndjson,
+        existing: Some(&existing),
+        input: CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
+            msgid: "Hello".to_owned(),
+            ..SourceExtractedMessage::default()
+        }]),
+        ..UpdateCatalogOptions::default()
+    })?;
+
+    assert!(result.content.contains("format: ferrocat.ndjson.v1"));
+    assert!(result.content.contains("\"model\":\"example/mt\""));
+    assert!(result.content.contains(&hash));
+
+    println!("{}", result.content);
+    Ok(())
+}

--- a/crates/ferrocat/examples/release_audit.rs
+++ b/crates/ferrocat/examples/release_audit.rs
@@ -1,0 +1,35 @@
+use ferrocat::{CatalogAuditOptions, NormalizedParsedCatalog, ParseCatalogOptions, audit_catalogs};
+
+fn catalog(
+    content: &str,
+    locale: &str,
+) -> Result<NormalizedParsedCatalog, Box<dyn std::error::Error>> {
+    Ok(ferrocat::parse_catalog(ParseCatalogOptions {
+        content,
+        locale: Some(locale),
+        source_locale: "en",
+        ..ParseCatalogOptions::default()
+    })?
+    .into_normalized_view()?)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let source = catalog("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")?;
+    let target = catalog("msgid \"Checkout\"\nmsgstr \"\"\n", "de")?;
+
+    let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
+
+    assert!(report.has_errors());
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "catalog.empty_translation")
+    );
+
+    for diagnostic in &report.diagnostics {
+        println!("{}: {}", diagnostic.code, diagnostic.message);
+    }
+
+    Ok(())
+}

--- a/crates/ferrocat/examples/runtime_compile.rs
+++ b/crates/ferrocat/examples/runtime_compile.rs
@@ -1,0 +1,42 @@
+use ferrocat::{
+    CompileCatalogArtifactOptions, NormalizedParsedCatalog, ParseCatalogOptions,
+    compile_catalog_artifact, parse_catalog,
+};
+
+fn catalog(
+    content: &str,
+    locale: &str,
+) -> Result<NormalizedParsedCatalog, Box<dyn std::error::Error>> {
+    Ok(parse_catalog(ParseCatalogOptions {
+        content,
+        locale: Some(locale),
+        source_locale: "en",
+        ..ParseCatalogOptions::default()
+    })?
+    .into_normalized_view()?)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let source = catalog(
+        "msgid \"Checkout\"\nmsgstr \"Checkout\"\n\nmsgid \"Cart\"\nmsgstr \"Cart\"\n",
+        "en",
+    )?;
+    let german = catalog("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "de")?;
+
+    let options = CompileCatalogArtifactOptions {
+        source_fallback: true,
+        ..CompileCatalogArtifactOptions::new("de", "en")
+    };
+    let artifact = compile_catalog_artifact(&[&source, &german], &options)?;
+
+    assert_eq!(artifact.messages.len(), 2);
+    assert_eq!(artifact.missing.len(), 1);
+    assert!(artifact.messages.values().any(|value| value == "Zur Kasse"));
+    assert!(artifact.messages.values().any(|value| value == "Cart"));
+
+    for (key, value) in &artifact.messages {
+        println!("{key} = {value}");
+    }
+
+    Ok(())
+}

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -124,6 +124,26 @@ In practice this is the fast path workflow API: it stays close to classic Gettex
 
 Ferrocat assumes exact catalog identity here: `msgid` plus optional `msgctxt`. That works for classic ID-style catalogs and for projects that use real product copy as `msgid`. Matching messages keep translations, new messages are added, and removed messages follow the obsolete strategy. Fuzzy matching is intentionally outside the default workflow.
 
+```rust
+use std::borrow::Cow;
+
+use ferrocat::{MergeExtractedMessage, merge_catalog};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let existing = "msgid \"Hello\"\nmsgstr \"Hallo\"\n";
+    let extracted = [MergeExtractedMessage {
+        msgid: Cow::Borrowed("Hello"),
+        references: vec![Cow::Borrowed("src/app.rs:10")],
+        ..MergeExtractedMessage::default()
+    }];
+
+    let merged = merge_catalog(existing, &extracted)?;
+    assert!(merged.contains("msgstr \"Hallo\""));
+    assert!(merged.contains("#: src/app.rs:10"));
+    Ok(())
+}
+```
+
 ### `combine_catalogs`
 
 Use this when you have multiple existing catalogs or templates and want one deterministic output catalog.
@@ -138,6 +158,24 @@ This is the Rust-native counterpart to the useful parts of GNU `msgcat`, `msgcom
 - skip obsolete definitions by default, with an explicit opt-in when obsolete entries should participate
 
 Ferrocat does not emit GNU-style conflict-marker translations for differing strings. Non-empty translation conflicts are either resolved with a warning diagnostic or rejected with `ApiError::Conflict`, depending on `CatalogConflictStrategy`.
+
+```rust
+use ferrocat::{CatalogCombineInput, CombineCatalogOptions, combine_catalogs};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let base = "msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n";
+    let template = "msgid \"Checkout\"\nmsgstr \"\"\n\nmsgid \"Cart\"\nmsgstr \"\"\n";
+    let inputs = [
+        CatalogCombineInput::labeled(base, "de.po"),
+        CatalogCombineInput::labeled(template, "messages.pot"),
+    ];
+
+    let combined = combine_catalogs(CombineCatalogOptions::new(&inputs, "en"))?;
+    assert!(combined.content.contains("msgstr \"Zur Kasse\""));
+    assert!(combined.content.contains("msgid \"Cart\""));
+    Ok(())
+}
+```
 
 ### `parse_catalog`
 
@@ -173,6 +211,23 @@ That gives you exactly three supported modes:
 `parse_catalog` intentionally stays as the neutral parse step. If you want keyed lookups or effective-translation helpers, build a richer view explicitly with `ParsedCatalog::into_normalized_view()`.
 
 The normalized view supports both owned-key lookup with `CatalogMessageKey` and borrowed identity lookup with `get_by_parts(msgid, msgctxt)`, which is useful in host adapters that already have borrowed source strings.
+
+```rust
+use ferrocat::{ParseCatalogOptions, parse_catalog};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let catalog = parse_catalog(ParseCatalogOptions {
+        content: "msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n",
+        locale: Some("de"),
+        source_locale: "en",
+        ..ParseCatalogOptions::default()
+    })?;
+
+    let view = catalog.into_normalized_view()?;
+    assert!(view.contains_parts("Checkout", None));
+    Ok(())
+}
+```
 
 ### `NormalizedParsedCatalog::compile`
 
@@ -214,6 +269,31 @@ Default checks cover:
 - semantic metadata duplication, unknown source keys, and source conflicts
 
 Diagnostics are machine-readable. Examples include:
+
+```rust
+use ferrocat::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let source = parse_catalog(ParseCatalogOptions {
+        content: "msgid \"Checkout\"\nmsgstr \"Checkout\"\n",
+        locale: Some("en"),
+        source_locale: "en",
+        ..ParseCatalogOptions::default()
+    })?
+    .into_normalized_view()?;
+    let target = parse_catalog(ParseCatalogOptions {
+        content: "msgid \"Checkout\"\nmsgstr \"\"\n",
+        locale: Some("de"),
+        source_locale: "en",
+        ..ParseCatalogOptions::default()
+    })?
+    .into_normalized_view()?;
+
+    let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
+    assert!(report.has_errors());
+    Ok(())
+}
+```
 
 ```json
 {
@@ -271,6 +351,38 @@ Choose this when your downstream tooling needs locale resolution semantics centr
 This is the main boundary for Palamedes-style integrations. Ferrocat should decide the effective locale artifact; Palamedes or another host adapter should decide how that artifact becomes framework modules, sidecars, or runtime payloads.
 
 `CompileCatalogArtifactOptions` borrows locale strings and the fallback-chain slice, which keeps host-side request assembly cheap even when compilation is performance-sensitive.
+
+```rust
+use ferrocat::{
+    CompileCatalogArtifactOptions, ParseCatalogOptions, compile_catalog_artifact, parse_catalog,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let source = parse_catalog(ParseCatalogOptions {
+        content: "msgid \"Checkout\"\nmsgstr \"Checkout\"\n\nmsgid \"Cart\"\nmsgstr \"Cart\"\n",
+        locale: Some("en"),
+        source_locale: "en",
+        ..ParseCatalogOptions::default()
+    })?
+    .into_normalized_view()?;
+    let german = parse_catalog(ParseCatalogOptions {
+        content: "msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n",
+        locale: Some("de"),
+        source_locale: "en",
+        ..ParseCatalogOptions::default()
+    })?
+    .into_normalized_view()?;
+
+    let options = CompileCatalogArtifactOptions {
+        source_fallback: true,
+        ..CompileCatalogArtifactOptions::new("de", "en")
+    };
+    let artifact = compile_catalog_artifact(&[&source, &german], &options)?;
+    assert_eq!(artifact.messages.len(), 2);
+    assert_eq!(artifact.missing.len(), 1);
+    Ok(())
+}
+```
 
 Important semantics:
 
@@ -345,6 +457,30 @@ In native mode, `CatalogUpdateInput::SourceFirst` stays source-text-first; it no
 
 In `NDJSON` storage, arbitrary gettext-style custom headers are intentionally out of scope for `v1`; only the explicit frontmatter metadata and per-record fields are persisted. Machine-translation metadata uses the optional `mt` record field and remains part of `ferrocat.ndjson.v1`.
 
+```rust
+use ferrocat::{
+    CatalogStorageFormat, CatalogUpdateInput, SourceExtractedMessage, UpdateCatalogOptions,
+    update_catalog,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let result = update_catalog(UpdateCatalogOptions {
+        locale: Some("de"),
+        source_locale: "en",
+        storage_format: CatalogStorageFormat::Ndjson,
+        input: CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
+            msgid: "Checkout".to_owned(),
+            ..SourceExtractedMessage::default()
+        }]),
+        ..UpdateCatalogOptions::default()
+    })?;
+
+    assert!(result.content.starts_with("---\nformat: ferrocat.ndjson.v1\n"));
+    assert!(result.content.contains("\"id\":\"Checkout\""));
+    Ok(())
+}
+```
+
 ### Machine-translation metadata
 
 `CatalogMessage::machine_translation` stores optional translation-side metadata
@@ -372,6 +508,17 @@ NDJSON catalogs store the same metadata under `mt`:
 Parsing preserves metadata even when the hash no longer matches. High-level
 writers such as `update_catalog` verify the hash while rendering and omit the
 whole machine-translation metadata block when the translation has changed.
+
+```rust
+use ferrocat::{
+    EffectiveTranslationRef, machine_translation_hash,
+};
+
+fn main() {
+    let hash = machine_translation_hash(EffectiveTranslationRef::Singular("Hallo"));
+    assert!(!hash.is_empty());
+}
+```
 
 ### `update_catalog_file`
 


### PR DESCRIPTION
Closes #75.

## Summary
- Add runnable Cargo examples for merge, release audit, runtime compilation, and NDJSON machine-translation metadata workflows.
- Add Rustdoc examples for merge_catalog, parse_catalog, combine_catalogs, audit_catalogs, update_catalog, and machine_translation_hash.
- Expand the API overview with concrete copy-paste snippets for the same workflows.

## Validation
- cargo fmt --all --check
- cargo check -p ferrocat --examples
- cargo test -p ferrocat-po --doc --all-features
- cargo test -p ferrocat --examples
- cargo run -p ferrocat --example merge_extracted_messages
- cargo run -p ferrocat --example release_audit
- cargo run -p ferrocat --example runtime_compile
- cargo run -p ferrocat --example ndjson_with_mt_metadata
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- pnpm install --frozen-lockfile (docs)
- pnpm build (docs)
- git diff --check