### PR TITLE
docs: document published crate packaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Examples:
   - `cargo llvm-cov --workspace --all-features --locked --lcov --output-path target/lcov.info --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'`
   - `cargo llvm-cov report --json --summary-only --output-path target/coverage-summary.json --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'`
   - `node scripts/coverage-gate.mjs target/coverage-summary.json ferrocat-po=95 ferrocat-icu=95`
+  - `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked`
   - from `docs/`: `pnpm install --frozen-lockfile`
   - from `docs/`: `pnpm build`
 - If you add or change dependencies, make sure `Cargo.lock` is updated and the locked checks still pass before push.
@@ -53,6 +54,15 @@ Examples:
 - Run docs-site checks from `docs/`:
   - `pnpm install --frozen-lockfile`
   - `pnpm build`
+
+## Packaging
+
+- Release packaging checks should target the published crates explicitly:
+  `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked`.
+- Do not use `cargo package --workspace` as the release check. The workspace
+  includes private `publish = false` crates for conformance fixtures and
+  benchmarking, and Cargo still validates those manifests during workspace
+  packaging.
 
 ## Performance And Benchmarking
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,17 @@ cargo llvm-cov report --json --summary-only --output-path target/coverage-summar
 node scripts/coverage-gate.mjs target/coverage-summary.json ferrocat-po=95 ferrocat-icu=95
 ```
 
+Published crate packaging:
+
+```bash
+cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked
+```
+
+Do not use `cargo package --workspace` as the release packaging check. The
+workspace includes private `publish = false` crates for conformance fixtures and
+benchmarking, and Cargo still validates those manifests during whole-workspace
+packaging.
+
 Docs site:
 
 ```bash

--- a/docs/app/routes/operations/release-verification.mdx
+++ b/docs/app/routes/operations/release-verification.mdx
@@ -21,7 +21,21 @@ This checklist verifies a real Rust-only `ferrocat` release after the publish wo
 - Confirm internal `ferrocat*` path dependencies in the crate manifests were updated to matching versions where applicable.
 - Confirm the GitHub release tag matches the published version created by Release Please.
 
-## 3. Confirm install and docs surface
+## 3. Confirm package viability
+
+Before publishing, package the crates that are actually published:
+
+```bash
+cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked
+```
+
+Do not use `cargo package --workspace` as the release packaging check. The
+workspace also contains private `publish = false` crates for conformance
+fixtures and benchmarking. Cargo still validates those manifests during
+whole-workspace packaging, so the workspace-wide command is not the supported
+release gate.
+
+## 4. Confirm install and docs surface
 
 - In a clean scratch project, run `cargo add ferrocat`.
 - Build a tiny smoke example that calls `parse_po` and `parse_icu` through the umbrella crate.
@@ -30,18 +44,18 @@ This checklist verifies a real Rust-only `ferrocat` release after the publish wo
 - Confirm the site API overview covers any new public APIs or semver-relevant behavior added in the release.
 - Refresh dated quality snapshots when the release changes conformance counts, coverage thresholds, or the benchmark/coverage commands documented on the site.
 
-## 4. Confirm repository metadata surface
+## 5. Confirm repository metadata surface
 
 - Confirm `LICENSE`, `SECURITY.md`, and `CODE_OF_CONDUCT.md` are still present and match the current maintenance posture.
 - Confirm issue templates and the pull request template still reflect the current contributor workflow.
 - Confirm README badge links still point at the current crates.io, docs.rs, CI, and coverage surfaces.
 
-## 5. Record outcome
+## 6. Record outcome
 
 - If the release is good, record the workflow URL and version in the relevant status or changelog notes.
 - If publishing failed partway through, capture the exact crate, version, and workflow URL before retrying so the next release does not repeat the same blind spot.
 
-## 6. Rollback guidance
+## 7. Rollback guidance
 
 - If only the GitHub release failed, fix the workflow cause and rerun from the release commit.
 - If `ferrocat-icu` or `ferrocat-po` published but `ferrocat` failed, do not delete tags. Cut a follow-up release with the fix and let Release Please advance the version.


### PR DESCRIPTION
## Summary

- document the supported release packaging check for the published crates only
- explain why `cargo package --workspace` is not the release gate while private workspace crates remain unpublished
- add the packaging check to contributor, agent, and release-verification guidance

Closes #86.

## Verification

- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked --allow-dirty --no-verify`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `corepack pnpm@11.2.2 --dir docs install --frozen-lockfile`
- `corepack pnpm@11.2.2 --dir docs build`

Note: the `cargo package` command above used `--allow-dirty --no-verify` while validating this documentation-only branch because the docs edits were intentionally uncommitted during the probe. The documented release command omits those flags.
