### PR TITLE
docs: clarify host binding boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The practical problem is simple: translations change constantly, and most projec
 
 Under the hood, Ferrocat builds on proven ideas from PO catalogs, ICU MessageFormat, line-delimited JSON, and deterministic runtime compilation. You do not need to start with all of that terminology. The important part is that the catalog remains inspectable, testable, benchmarked, and portable across host-language adapters.
 
-Ferrocat is also part of the [Palamedes](https://github.com/sebastian-software/palamedes) ecosystem. Palamedes is the OSS i18n framework for JavaScript and TypeScript apps; Ferrocat supplies the shared catalog engine underneath it: exact updates, storage choices, release QA, runtime artifact compilation, and clear boundaries between catalog data and application integration.
+Ferrocat is also part of the [Palamedes](https://github.com/sebastian-software/palamedes) ecosystem. Palamedes is the OSS i18n framework for JavaScript and TypeScript apps; Ferrocat supplies the shared catalog engine underneath it: exact updates, storage choices, release QA, runtime artifact compilation, and clear boundaries between catalog data and application integration. JavaScript and TypeScript access is a Palamedes concern, including the `palamedes-node` N-API bridge in that repository; this repository stays the pure-Rust catalog engine.
 
 ## What Ferrocat Gives You
 
@@ -22,7 +22,7 @@ Ferrocat is also part of the [Palamedes](https://github.com/sebastian-software/p
 - **AI translation metadata ready.** Track machine-generated translations with model, modification time, confidence, and a change-detection hash, then drop stale metadata automatically when a human edits the text.
 - **Runtime artifacts.** Compile catalogs into host-neutral payloads with stable keys, fallback behavior, missing reports, and optional ICU compatibility diagnostics.
 - **Reviewable storage.** Use PO when translator tooling matters, or NDJSON when large teams and automation need one message per line for cleaner diffs.
-- **Room for host frameworks.** Palamedes can own JS/TS extraction and framework integration while Ferrocat owns the catalog behavior that should stay consistent underneath.
+- **Room for host frameworks.** Palamedes can own JS/TS extraction, bindings, and framework integration while Ferrocat owns the catalog behavior that should stay consistent underneath.
 - **Measured behavior.** Parser, serializer, merge, combine, audit, and runtime paths are covered by fixtures, conformance checks, and benchmark commands.
 
 ## Technical Foundation
@@ -45,6 +45,13 @@ Ferrocat is not trying to replace every part of an i18n stack. If you already kn
 | Framework-specific i18n packages | Great authoring ergonomics and runtime adapters inside one host ecosystem | Shared catalog semantics that can be reused by Palamedes or other adapters instead of reimplemented per framework |
 | Custom JSON catalogs | Easy loading and deployment | Stronger update semantics, reviewable NDJSON storage, source/translation QA, and a path back to translator-friendly PO workflows |
 | ICU-only message handling | Powerful plural, select, formatter, and rich-text syntax | Structural analysis and compatibility checks that catch missing arguments, formatter drift, tag mismatch, and branch changes before shipping |
+
+Ferrocat does not currently ship first-party WebAssembly, N-API, Python, Go, or
+other host-language bindings from this repository. Host integration is layered
+on top of the Rust API: JS/TS applications should look to Palamedes and its
+`palamedes-node` bridge, while other ecosystems can use the Rust crates
+directly, a future CLI surface, or host-specific bindings maintained at that
+layer.
 
 ## Core Workflows
 

--- a/docs/app/routes/architecture/adr/0014-ferrocat-palamedes-boundary.mdx
+++ b/docs/app/routes/architecture/adr/0014-ferrocat-palamedes-boundary.mdx
@@ -33,6 +33,7 @@ Palamedes owns JavaScript and TypeScript application integration:
 - macros and authoring ergonomics
 - source extraction and transforms
 - framework adapters
+- JS/TS package surfaces and the `palamedes-node` N-API bridge
 - bundler integration
 - runtime loading policy
 - future chunk-aware message sidecars
@@ -51,6 +52,9 @@ Concretely:
 - Ferrocat should expose task-oriented catalog APIs, not framework plugins.
 - Ferrocat should produce host-neutral runtime artifacts and structured
   diagnostics.
+- Ferrocat should remain a pure-Rust engine and should not ship first-party
+  JS/TS, WebAssembly, or N-API bindings from this repository under the current
+  architecture.
 - Ferrocat should expose ICU source/translation diagnostics that Palamedes can
   consume without moving JS/TS runtime concerns into Ferrocat.
 - Ferrocat should expose semantic metadata types and validation that Palamedes
@@ -60,9 +64,12 @@ Concretely:
 - Ferrocat should keep storage and semantic contracts documented in ADRs and
   rustdoc.
 - Palamedes should own JS/TS extraction, transforms, routing conventions,
-  bundler adapters, framework runtime integration, and developer ergonomics.
+  bundler adapters, framework runtime integration, host packaging, bindings,
+  and developer ergonomics.
 - Palamedes may depend on Ferrocat semantics, but Ferrocat should not depend on
   Palamedes packages or application-framework assumptions.
+- Other host environments should integrate through the Rust crates, a future
+  Ferrocat CLI surface, or host-specific binding projects at that layer.
 
 This relationship should be documented prominently because users can enter the
 ecosystem from either direction: app teams through Palamedes, and tooling or
@@ -75,6 +82,8 @@ Positive:
 - Ferrocat stays useful outside the Palamedes ecosystem.
 - Palamedes can move faster on framework integration without changing catalog
   contracts.
+- users can tell where to look for JS/TS access: Palamedes and
+  `palamedes-node`, not a hidden Ferrocat binding crate.
 - runtime artifact semantics are centralized instead of being reimplemented in
   every host adapter.
 - the docs can explain a coherent i18n stack without collapsing both projects
@@ -84,6 +93,8 @@ Negative:
 
 - cross-project features need clear coordination and documentation.
 - some users will need to understand two project names instead of one.
+- non-JS host ecosystems need to bring their own bindings or wait for a CLI or
+  adapter project instead of expecting one from the Ferrocat core repository.
 - examples must be careful to distinguish catalog behavior from application
   integration behavior.
 
@@ -94,6 +105,13 @@ Negative:
 Rejected because Ferrocat would absorb JavaScript, TypeScript, framework,
 bundler, and runtime concerns that are outside its catalog-infrastructure
 purpose.
+
+### Ship Ferrocat-Level N-API Or WebAssembly Bindings Now
+
+Rejected for the current architecture because it would blur the same boundary
+under a different package name. JS/TS access belongs with Palamedes, including
+the `palamedes-node` bridge, and a future host binding should have its own ADR
+if it becomes a Ferrocat repository concern.
 
 ### Keep Palamedes Fully Independent From Ferrocat
 

--- a/docs/app/routes/guide/palamedes.mdx
+++ b/docs/app/routes/guide/palamedes.mdx
@@ -17,12 +17,20 @@ Most people arrive from one of two directions:
 
 They are meant to connect. Palamedes owns the application integration. Ferrocat owns the catalog behavior that should not be reimplemented separately in every framework adapter.
 
+That boundary includes host bindings. Ferrocat does not ship first-party
+JavaScript, TypeScript, WebAssembly, or N-API bindings from this repository.
+JS/TS access is routed through Palamedes, including the `palamedes-node` N-API
+bridge in the Palamedes repository. Other host environments should treat
+Ferrocat as a Rust engine and integrate through the Rust crates, a future
+Ferrocat CLI surface, or their own host-specific binding layer.
+
 ## Division Of Responsibility
 
 | Layer | Palamedes | Ferrocat |
 |---|---|---|
 | Authoring | Macros, message collection, framework-facing developer experience | Stable message identity inputs and catalog semantics |
 | Extraction | JavaScript/TypeScript transforms and host-aware source scanning | Adapter-ready catalog update inputs, placeholder hints, and semantic metadata validation |
+| Host bindings | `palamedes-node`, JS/TS package surfaces, and host packaging | Pure Rust crates and host-neutral data contracts |
 | Catalog storage | Uses catalogs as part of the app workflow | PO, ICU-native PO, and NDJSON catalog modes |
 | Catalog maintenance | CLI workflows and project conventions | Parse, serialize, merge, combine, update, audit, and validate |
 | Runtime delivery | Framework adapters, bundler integration, client/server loading | Host-neutral compiled catalog artifacts and fallback semantics |

--- a/docs/app/routes/guide/project-status.mdx
+++ b/docs/app/routes/guide/project-status.mdx
@@ -24,12 +24,17 @@ Ferrocat is an actively developed pre-`1.0` Rust project. The goal is stable and
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
 - **Semver:** the public API is treated seriously, but carefully documented breaking changes may still happen before `1.0`
 - **Documentation:** README examples, rustdoc, and repository docs aim to stay aligned
+- **Host bindings:** Ferrocat is currently a pure-Rust engine. JS/TS access
+  belongs in Palamedes and its `palamedes-node` bridge; other hosts should use
+  the Rust crates, a future CLI surface, or their own binding layer.
 
 ## Roadmap themes
 
 - more catalog workflow APIs inspired by practical translation-maintenance jobs, especially filtering, attribute transforms, and structured completeness checks
 - deeper runtime/catalog workflows on top of the compiled catalog layer
-- broader cross-ecosystem tooling and bindings
+- broader cross-ecosystem tooling, especially a CLI and host-specific bindings
+  that stay outside the Ferrocat core crate boundary unless a future ADR
+  deliberately changes that split
 - continued conformance growth and publication-grade benchmarking discipline
 
 MessageFormat 2 is deliberately not a near-term roadmap item. Ferrocat tracks
@@ -40,7 +45,7 @@ problems without taking on a second transitional message syntax.
 
 ## Why the project direction matters
 
-Today Ferrocat is Rust-first. The longer-term goal is broader: a trustworthy translation core that can serve multiple ecosystems from one implementation, without forcing each host environment to re-implement catalog semantics, compiled key derivation, and locale resolution separately.
+Today Ferrocat is Rust-first. The longer-term goal is broader: a trustworthy translation core that can serve multiple ecosystems from one implementation, without forcing each host environment to re-implement catalog semantics, compiled key derivation, and locale resolution separately. That does not mean every host binding belongs in this repository. The core contract is the Rust API plus host-neutral formats and diagnostics; Palamedes, a CLI, or host-specific adapter projects can expose those contracts to application environments.
 
 ## Follow-up reading
 


### PR DESCRIPTION
## Summary

- clarify that Ferrocat remains a pure-Rust catalog engine rather than shipping first-party JS/TS, WebAssembly, or N-API bindings
- document that JS/TS access belongs in Palamedes, including the `palamedes-node` bridge
- update README, the Palamedes guide, Project Status, and ADR 0014 so the boundary is visible from the main docs surfaces

Closes #64.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps --locked`
- `corepack pnpm@11.2.2 --dir docs install --frozen-lockfile`
- `corepack pnpm@11.2.2 --dir docs build`
