### PR TITLE
ci: tighten workflow permissions and hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,5 +17,5 @@ printf '%s\n' "Running Rust pre-commit checks..."
 printf '%s\n' "- cargo fmt --all --check"
 cargo fmt --all --check
 
-printf '%s\n' "- cargo clippy --workspace --all-targets --all-features -- -D warnings"
-cargo clippy --workspace --all-targets --all-features -- -D warnings
+printf '%s\n' "- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings"
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,5 +7,5 @@ printf '%s\n' "Running Rust pre-push checks for the full workspace..."
 printf '%s\n' "- cargo fmt --all --check"
 cargo fmt --all --check
 
-printf '%s\n' "- cargo clippy --workspace --all-targets --all-features -- -D warnings"
-cargo clippy --workspace --all-targets --all-features -- -D warnings
+printf '%s\n' "- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings"
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -132,8 +135,6 @@ jobs:
   coverage:
     name: Linux test + coverage
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
 
     steps:
       - name: Check out repository
@@ -165,6 +166,10 @@ jobs:
           --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'
 
       - name: Enforce crate coverage thresholds
+        # The umbrella `ferrocat` crate is intentionally reported by
+        # coverage-gate but not threshold-gated while it only re-exports lower
+        # level crates plus smoke tests. Add a threshold here when executable
+        # umbrella code grows.
         run: node scripts/coverage-gate.mjs target/coverage-summary.json ferrocat-po=95 ferrocat-icu=95
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -17,6 +15,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
     env:
       PNPM_STORE_DIR: ~/.pnpm-store
 
@@ -66,6 +67,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
 
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,9 @@ concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
     runs-on: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Examples:
 
 - Keep the existing Rust hook expectations green before push:
   - `cargo fmt --all --check`
-  - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
 - For CI parity before publishing a PR, use the locked forms and the additional CI gates that apply to your change:
   - `cargo fmt --all --check`
   - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
@@ -35,6 +35,10 @@ Examples:
   - `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked`
   - from `docs/`: `pnpm install --frozen-lockfile`
   - from `docs/`: `pnpm build`
+- The coverage gate reports the umbrella `ferrocat` crate but intentionally
+  does not enforce a threshold for it while it only re-exports lower-level APIs
+  plus smoke tests. Add an explicit threshold when executable umbrella code
+  grows.
 - If you add or change dependencies, make sure `Cargo.lock` is updated and the locked checks still pass before push.
 - Keep the declared MSRV in `Cargo.toml` covered by CI. The MSRV policy is to align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,18 +14,10 @@ git config core.hooksPath .githooks
 
 `pre-push` always runs for the full workspace before a push.
 
-Both hooks run the same Rust linting shape as CI, without the CI-only
-`--locked` flag:
+Both hooks run the same locked Rust linting shape as CI:
 
 ```bash
 cargo fmt --all --check
-cargo clippy --workspace --all-targets --all-features -- -D warnings
-```
-
-CI runs the locked Clippy command, so use the locked form before opening a PR
-when dependencies or lockfile resolution matter:
-
-```bash
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 ```
 
@@ -77,6 +69,11 @@ Do not use `cargo package --workspace` as the release packaging check. The
 workspace includes private `publish = false` crates for conformance fixtures and
 benchmarking, and Cargo still validates those manifests during whole-workspace
 packaging.
+
+The coverage gate reports the umbrella `ferrocat` crate but intentionally does
+not enforce a threshold for it while that crate only re-exports lower-level
+APIs plus smoke tests. Add an explicit threshold when executable umbrella code
+grows.
 
 Docs site:
 


### PR DESCRIPTION
Refs #70.

## Summary

- add default read-only workflow token permissions and keep write/id-token permissions scoped to the jobs that need them
- align tracked Git hooks with CI by running locked Clippy locally
- document why the umbrella `ferrocat` crate is reported but not threshold-gated in coverage while it only re-exports lower-level crates
- leave workflow actions on readable version tags; SHA-pinning is intentionally left out of this smaller hygiene PR

## Verification

- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/publish.yml .github/workflows/docs-pages.yml`
- [x] `sh -n .githooks/pre-commit && sh -n .githooks/pre-push`
- [x] no SHA-pinned workflow action refs remain in `.github/workflows`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`

Note: `.github/dependabot.yml` is not present in this checkout, so the YAML parse check only covers the tracked workflow files.