### PR TITLE
ci: add cargo-deny supply-chain checks

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,28 @@
+name: Supply Chain
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: "1.93.0"
+          arguments: --workspace --all-features --locked

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,32 @@
+[graph]
+all-features = true
+
+[advisories]
+yanked = "deny"
+ignore = []
+
+[licenses]
+confidence-threshold = 0.8
+allow = [
+  "Apache-2.0",
+  "MIT",
+  "Unicode-3.0",
+]
+
+[bans]
+multiple-versions = "deny"
+wildcards = "allow"
+highlight = "all"
+deny = []
+# tempfile pulls getrandom, which currently includes both wasi preview 2 and
+# preview 3 dependency paths with different wit-bindgen versions.
+skip = [
+  { crate = "wit-bindgen@0.51.0", reason = "transitive WASI preview dependency split via getrandom" },
+]
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
Closes #66.

## Summary
- add cargo-deny configuration for advisories, licenses, sources, and duplicate dependency policy
- explicitly document/allow the license set used by current dependencies, including Unicode-3.0
- run cargo-deny on PRs and on a scheduled cadence

## Verification
- [x] cargo deny --workspace --all-features --locked check
- [x] cargo fmt --all --check
- [x] cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- [x] ruby -e 'require "yaml"; YAML.load_file(".github/workflows/supply-chain.yml")'
