### PR TITLE
release: make crate packaging and publish reruns safer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,23 @@ jobs:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --workspace --all-features --no-deps --locked
 
+  package:
+    name: Published crate packaging
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Package published crates
+        run: cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked
+
   msrv:
     name: Rust MSRV
     runs-on: ubuntu-24.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,13 +70,53 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
         run: |
+          crate_version() {
+            local crate="$1"
+            local package_id
+            package_id="$(cargo pkgid -p "$crate")"
+            echo "${package_id##*#}"
+          }
+
+          crate_version_exists() {
+            local crate="$1"
+            local version="$2"
+            local status
+            status="$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" \
+              "https://crates.io/api/v1/crates/${crate}/${version}")"
+
+            case "$status" in
+              200)
+                return 0
+                ;;
+              404)
+                return 1
+                ;;
+              *)
+                echo "Unexpected crates.io response ${status} while checking ${crate} ${version}."
+                return 1
+                ;;
+            esac
+          }
+
           publish_with_retry() {
             local crate="$1"
             local attempts="$2"
             local delay="$3"
             local attempt
+            local version
+
+            version="$(crate_version "$crate")"
+            if crate_version_exists "$crate" "$version"; then
+              echo "Skipping ${crate} ${version}; it already exists on crates.io."
+              return 0
+            fi
+
             for attempt in $(seq 1 "$attempts"); do
               if cargo publish -p "$crate" --locked; then
+                return 0
+              fi
+              if crate_version_exists "$crate" "$version"; then
+                echo "Skipping ${crate} ${version}; it appeared on crates.io after publish attempt ${attempt}."
                 return 0
               fi
               if [ "$attempt" -eq "$attempts" ]; then


### PR DESCRIPTION
Refs #67.

## Summary
- add a regular packaging check for the published crates
- make release publish reruns skip crate versions that already exist
- leave cargo-semver-checks for a separate release-policy PR

## Verification
- [x] cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked
- [x] cargo test --workspace --all-features --locked
- [x] cargo fmt --all --check
- [x] cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- [x] ruby -ryaml -e 'workflow = YAML.load_file(".github/workflows/publish.yml"); step = workflow.fetch("jobs").fetch("publish-rust").fetch("steps").find { |item| item["name"] == "Publish Rust crates in dependency order" }; puts step.fetch("run")' | bash -n
