### PR TITLE
fix(api): preserve parse and io error sources

### DIFF
--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -957,7 +957,15 @@ impl fmt::Display for ApiError {
     }
 }
 
-impl std::error::Error for ApiError {}
+impl std::error::Error for ApiError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Parse(error) => Some(error),
+            Self::Io(error) => Some(error),
+            Self::InvalidArguments(_) | Self::Conflict(_) | Self::Unsupported(_) => None,
+        }
+    }
+}
 
 impl From<ParseError> for ApiError {
     fn from(value: ParseError) -> Self {
@@ -974,6 +982,7 @@ impl From<std::io::Error> for ApiError {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::error::Error;
     use std::io;
     use std::path::Path;
 
@@ -986,6 +995,7 @@ mod tests {
         PluralEncoding, PluralSource, TranslationShape, UpdateCatalogFileOptions,
         UpdateCatalogOptions,
     };
+    use crate::ParseError;
 
     #[test]
     fn catalog_update_input_defaults_and_conversions_use_expected_variants() {
@@ -1218,8 +1228,23 @@ mod tests {
         let io_error = ApiError::from(io::Error::other("disk"));
         assert_eq!(io_error.to_string(), "disk");
         assert_eq!(
+            io_error.source().map(ToString::to_string).as_deref(),
+            Some("disk")
+        );
+
+        let parse_error = ApiError::from(ParseError::new("bad syntax"));
+        assert_eq!(
+            parse_error.source().map(ToString::to_string).as_deref(),
+            Some("bad syntax")
+        );
+        assert_eq!(
             ApiError::InvalidArguments("bad input".to_owned()).to_string(),
             "bad input"
+        );
+        assert!(
+            ApiError::InvalidArguments("bad input".to_owned())
+                .source()
+                .is_none()
         );
         assert_eq!(
             ApiError::Conflict("duplicate".to_owned()).to_string(),

--- a/crates/ferrocat-po/src/borrowed.rs
+++ b/crates/ferrocat-po/src/borrowed.rs
@@ -6,7 +6,7 @@ use crate::scan::{
 };
 use crate::text::{extract_quoted_bytes_cow, split_reference_comment};
 use crate::utf8::input_slice_as_str;
-use crate::{Header, MsgStr, ParseError, PoFile, PoItem};
+use crate::{Header, MsgStr, ParseError, ParsePosition, PoFile, PoItem};
 
 /// Borrowed PO document that reuses slices from the original input whenever
 /// possible.
@@ -270,6 +270,7 @@ impl<'a> ParserState<'a> {
 struct BorrowedLine<'a> {
     trimmed: &'a [u8],
     obsolete: bool,
+    position: ParsePosition,
 }
 
 /// Parses PO content into a borrowed representation.
@@ -298,6 +299,7 @@ pub fn parse_po_borrowed(input: &str) -> Result<BorrowedPoFile<'_>, ParseError> 
             BorrowedLine {
                 trimmed: line.trimmed,
                 obsolete: line.obsolete,
+                position: line.position,
             },
             &mut state,
             &mut file,
@@ -318,7 +320,7 @@ fn parse_line<'a>(
 ) -> Result<(), ParseError> {
     match classify_line(line.trimmed) {
         LineKind::Continuation => {
-            append_continuation(line.trimmed, line.obsolete, state)?;
+            append_continuation(line.trimmed, line.obsolete, line.position, state)?;
             Ok(())
         }
         LineKind::Comment(kind) => {
@@ -328,6 +330,7 @@ fn parse_line<'a>(
         LineKind::Keyword(keyword) => parse_keyword_line(
             line.trimmed,
             line.obsolete,
+            line.position,
             keyword,
             state,
             file,
@@ -394,6 +397,7 @@ fn ferrocat_mt_metadata_value(trimmed: &[u8]) -> Option<&[u8]> {
 fn parse_keyword_line<'a>(
     line_bytes: &'a [u8],
     obsolete: bool,
+    position: ParsePosition,
     keyword: Keyword,
     state: &mut ParserState<'a>,
     file: &mut BorrowedPoFile<'a>,
@@ -402,7 +406,10 @@ fn parse_keyword_line<'a>(
     match keyword {
         Keyword::IdPlural => {
             state.obsolete_line_count += usize::from(obsolete);
-            state.item.msgid_plural = Some(extract_quoted_bytes_cow(line_bytes)?);
+            state.item.msgid_plural = Some(at_line_position(
+                extract_quoted_bytes_cow(line_bytes),
+                position,
+            )?);
             state.context = Some(Context::IdPlural);
             state.content_line_count += 1;
             state.has_keyword = true;
@@ -410,7 +417,7 @@ fn parse_keyword_line<'a>(
         Keyword::Id => {
             finish_item(state, file, current_nplurals);
             state.obsolete_line_count += usize::from(obsolete);
-            state.item.msgid = extract_quoted_bytes_cow(line_bytes)?;
+            state.item.msgid = at_line_position(extract_quoted_bytes_cow(line_bytes), position)?;
             state.context = Some(Context::Id);
             state.content_line_count += 1;
             state.has_keyword = true;
@@ -419,11 +426,15 @@ fn parse_keyword_line<'a>(
             let plural_index = parse_plural_index(line_bytes).unwrap_or(0);
             state.plural_index = plural_index;
             state.obsolete_line_count += usize::from(obsolete);
-            state.set_msgstr(plural_index, extract_quoted_bytes_cow(line_bytes)?);
+            state.set_msgstr(
+                plural_index,
+                at_line_position(extract_quoted_bytes_cow(line_bytes), position)?,
+            );
             if is_header_candidate(state) {
-                state
-                    .header_entries
-                    .extend(parse_header_fragment(line_bytes)?);
+                state.header_entries.extend(at_line_position(
+                    parse_header_fragment(line_bytes),
+                    position,
+                )?);
             }
             state.context = Some(Context::Str);
             state.content_line_count += 1;
@@ -432,7 +443,10 @@ fn parse_keyword_line<'a>(
         Keyword::Ctxt => {
             finish_item(state, file, current_nplurals);
             state.obsolete_line_count += usize::from(obsolete);
-            state.item.msgctxt = Some(extract_quoted_bytes_cow(line_bytes)?);
+            state.item.msgctxt = Some(at_line_position(
+                extract_quoted_bytes_cow(line_bytes),
+                position,
+            )?);
             state.context = Some(Context::Ctxt);
             state.content_line_count += 1;
             state.has_keyword = true;
@@ -445,19 +459,21 @@ fn parse_keyword_line<'a>(
 fn append_continuation<'a>(
     line_bytes: &'a [u8],
     obsolete: bool,
+    position: ParsePosition,
     state: &mut ParserState<'a>,
 ) -> Result<(), ParseError> {
     state.obsolete_line_count += usize::from(obsolete);
     state.content_line_count += 1;
-    let value = extract_quoted_bytes_cow(line_bytes)?;
+    let value = at_line_position(extract_quoted_bytes_cow(line_bytes), position)?;
 
     match state.context {
         Some(Context::Str) => {
             state.append_msgstr(state.plural_index, value);
             if is_header_candidate(state) {
-                state
-                    .header_entries
-                    .extend(parse_header_fragment(line_bytes)?);
+                state.header_entries.extend(at_line_position(
+                    parse_header_fragment(line_bytes),
+                    position,
+                )?);
             }
         }
         Some(Context::Id) => state.item.msgid.to_mut().push_str(value.as_ref()),
@@ -473,6 +489,14 @@ fn append_continuation<'a>(
     }
 
     Ok(())
+}
+
+#[inline]
+fn at_line_position<T>(
+    result: Result<T, ParseError>,
+    position: ParsePosition,
+) -> Result<T, ParseError> {
+    result.map_err(|error| error.with_position_if_missing(position))
 }
 
 fn finish_item<'a>(
@@ -725,6 +749,18 @@ msgstr "world"
         let error = parse_po_borrowed("msgid \"foo\"\r\nmsgstr \"bar\"\r\n")
             .expect_err("crlf should be rejected");
         assert!(error.to_string().contains("LF-only"));
+    }
+
+    #[test]
+    fn parse_errors_include_line_position() {
+        let error = parse_po_borrowed("msgid \"ok\"\nmsgstr \"bad\"quote\"\n")
+            .expect_err("unescaped quote should fail");
+        let position = error.position().expect("position metadata");
+
+        assert_eq!(error.message(), "unescaped quote in string literal");
+        assert_eq!(position.offset(), 11);
+        assert_eq!(position.line(), 2);
+        assert_eq!(position.column(), 1);
     }
 
     #[test]

--- a/crates/ferrocat-po/src/borrowed.rs
+++ b/crates/ferrocat-po/src/borrowed.rs
@@ -431,10 +431,8 @@ fn parse_keyword_line<'a>(
                 at_line_position(extract_quoted_bytes_cow(line_bytes), position)?,
             );
             if is_header_candidate(state) {
-                state.header_entries.extend(at_line_position(
-                    parse_header_fragment(line_bytes),
-                    position,
-                )?);
+                let headers = at_line_position(parse_header_fragment(line_bytes), position)?;
+                state.header_entries.extend(headers);
             }
             state.context = Some(Context::Str);
             state.content_line_count += 1;
@@ -470,10 +468,8 @@ fn append_continuation<'a>(
         Some(Context::Str) => {
             state.append_msgstr(state.plural_index, value);
             if is_header_candidate(state) {
-                state.header_entries.extend(at_line_position(
-                    parse_header_fragment(line_bytes),
-                    position,
-                )?);
+                let headers = at_line_position(parse_header_fragment(line_bytes), position)?;
+                state.header_entries.extend(headers);
             }
         }
         Some(Context::Id) => state.item.msgid.to_mut().push_str(value.as_ref()),
@@ -761,6 +757,49 @@ msgstr "world"
         assert_eq!(position.offset(), 11);
         assert_eq!(position.line(), 2);
         assert_eq!(position.column(), 1);
+    }
+
+    #[test]
+    fn parse_errors_include_line_position_for_plural_and_context_keywords() {
+        let plural_error =
+            parse_po_borrowed("msgid \"file\"\nmsgid_plural \"bad\"quote\"\nmsgstr[0] \"\"\n")
+                .expect_err("unescaped plural quote should fail");
+        let plural_position = plural_error.position().expect("plural position metadata");
+        assert_eq!(plural_error.message(), "unescaped quote in string literal");
+        assert_eq!(plural_position.line(), 2);
+        assert_eq!(plural_position.column(), 1);
+
+        let context_error = parse_po_borrowed("msgctxt \"bad\"quote\"\nmsgid \"x\"\nmsgstr \"\"\n")
+            .expect_err("unescaped context quote should fail");
+        let context_position = context_error.position().expect("context position metadata");
+        assert_eq!(context_error.message(), "unescaped quote in string literal");
+        assert_eq!(context_position.line(), 1);
+        assert_eq!(context_position.column(), 1);
+    }
+
+    #[test]
+    fn parses_owned_header_fragments_in_keyword_and_continuation_lines() {
+        let input = concat!(
+            "msgid \"\"\n",
+            "msgstr \"Project-Id-Version: ferrocat\\t1\\n\"\n",
+            "\"Language: de\\t\\n\"\n",
+        );
+        let file = parse_po_borrowed(input).expect("borrowed parse with owned headers");
+
+        assert_eq!(file.headers.len(), 2);
+        assert_eq!(
+            file.headers[0].key,
+            Cow::<str>::Owned("Project-Id-Version".to_owned())
+        );
+        assert_eq!(
+            file.headers[0].value,
+            Cow::<str>::Owned("ferrocat\t1".to_owned())
+        );
+        assert_eq!(
+            file.headers[1].key,
+            Cow::<str>::Owned("Language".to_owned())
+        );
+        assert_eq!(file.headers[1].value, Cow::<str>::Owned("de".to_owned()));
     }
 
     #[test]

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -366,10 +366,52 @@ impl Default for SerializeOptions {
     }
 }
 
+/// One-based line/column context plus the byte offset for a parse error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParsePosition {
+    offset: usize,
+    line: usize,
+    column: usize,
+}
+
+impl ParsePosition {
+    /// Creates a new parse position.
+    ///
+    /// `offset` is zero-based and counts bytes from the parsed input after any
+    /// parser-specific pre-processing, while `line` and `column` are one-based.
+    #[must_use]
+    pub const fn new(offset: usize, line: usize, column: usize) -> Self {
+        Self {
+            offset,
+            line,
+            column,
+        }
+    }
+
+    /// Returns the zero-based byte offset in the parsed input.
+    #[must_use]
+    pub const fn offset(self) -> usize {
+        self.offset
+    }
+
+    /// Returns the one-based line number.
+    #[must_use]
+    pub const fn line(self) -> usize {
+        self.line
+    }
+
+    /// Returns the one-based column number.
+    #[must_use]
+    pub const fn column(self) -> usize {
+        self.column
+    }
+}
+
 /// Error returned when parsing or unescaping PO content fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseError {
     message: String,
+    position: Option<ParsePosition>,
 }
 
 impl ParseError {
@@ -378,7 +420,34 @@ impl ParseError {
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            position: None,
         }
+    }
+
+    /// Creates a new parse error with source position metadata.
+    #[must_use]
+    pub fn with_position(message: impl Into<String>, position: ParsePosition) -> Self {
+        Self {
+            message: message.into(),
+            position: Some(position),
+        }
+    }
+
+    /// Returns the human-readable error message.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Returns source position metadata when the parser could attach it.
+    #[must_use]
+    pub const fn position(&self) -> Option<ParsePosition> {
+        self.position
+    }
+
+    pub(crate) fn with_position_if_missing(mut self, position: ParsePosition) -> Self {
+        self.position.get_or_insert(position);
+        self
     }
 }
 
@@ -392,7 +461,24 @@ impl std::error::Error for ParseError {}
 
 #[cfg(test)]
 mod tests {
-    use super::MsgStr;
+    use super::{MsgStr, ParseError, ParsePosition};
+
+    #[test]
+    fn parse_error_accessors_preserve_message_and_optional_position() {
+        let error = ParseError::new("invalid PO string");
+        assert_eq!(error.message(), "invalid PO string");
+        assert_eq!(error.position(), None);
+        assert_eq!(error.to_string(), "invalid PO string");
+
+        let position = ParsePosition::new(12, 2, 3);
+        let positioned = ParseError::with_position("invalid PO string", position);
+        assert_eq!(positioned.message(), "invalid PO string");
+        assert_eq!(positioned.position(), Some(position));
+        assert_eq!(positioned.position().map(ParsePosition::offset), Some(12));
+        assert_eq!(positioned.position().map(ParsePosition::line), Some(2));
+        assert_eq!(positioned.position().map(ParsePosition::column), Some(3));
+        assert_eq!(positioned.to_string(), "invalid PO string");
+    }
 
     #[test]
     fn msgstr_get_returns_none_for_empty_values() {

--- a/crates/ferrocat-po/src/merge.rs
+++ b/crates/ferrocat-po/src/merge.rs
@@ -7,7 +7,7 @@ use crate::scan::{
 use crate::serialize::{write_keyword, write_prefixed_line};
 use crate::text::{escape_string_into, unescape_string, validate_quoted_content};
 use crate::utf8::input_slice_as_str;
-use crate::{BorrowedMsgStr, ParseError, SerializeOptions};
+use crate::{BorrowedMsgStr, ParseError, ParsePosition, SerializeOptions};
 
 /// Borrowed extracted message input for the lightweight merge helper.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -174,6 +174,7 @@ impl<'a> ParserState<'a> {
 struct MergeLine<'a> {
     trimmed: &'a [u8],
     obsolete: bool,
+    position: ParsePosition,
 }
 
 /// Merges extracted messages into an existing PO catalog while preserving the
@@ -290,6 +291,7 @@ fn parse_merge_po(input: &str) -> Result<MergeBorrowedFile<'_>, ParseError> {
             MergeLine {
                 trimmed: line.trimmed,
                 obsolete: line.obsolete,
+                position: line.position,
             },
             &mut state,
             &mut file,
@@ -309,7 +311,7 @@ fn parse_line<'a>(
 ) -> Result<(), ParseError> {
     match classify_line(line.trimmed) {
         LineKind::Continuation => {
-            append_continuation(line.trimmed, line.obsolete, state)?;
+            append_continuation(line.trimmed, line.obsolete, line.position, state)?;
             Ok(())
         }
         LineKind::Comment(kind) => {
@@ -319,6 +321,7 @@ fn parse_line<'a>(
         LineKind::Keyword(keyword) => parse_keyword_line(
             line.trimmed,
             line.obsolete,
+            line.position,
             keyword,
             state,
             file,
@@ -378,6 +381,7 @@ fn ferrocat_mt_metadata_value(trimmed: &[u8]) -> Option<&[u8]> {
 fn parse_keyword_line<'a>(
     line_bytes: &'a [u8],
     obsolete: bool,
+    position: ParsePosition,
     keyword: Keyword,
     state: &mut ParserState<'a>,
     file: &mut MergeBorrowedFile<'a>,
@@ -386,7 +390,10 @@ fn parse_keyword_line<'a>(
     match keyword {
         Keyword::IdPlural => {
             state.obsolete_line_count += usize::from(obsolete);
-            state.item.msgid_plural = Some(extract_merge_quoted_cow(line_bytes)?);
+            state.item.msgid_plural = Some(at_line_position(
+                extract_merge_quoted_cow(line_bytes),
+                position,
+            )?);
             state.context = Some(Context::IdPlural);
             state.content_line_count += 1;
             state.has_keyword = true;
@@ -394,7 +401,7 @@ fn parse_keyword_line<'a>(
         Keyword::Id => {
             finish_item(state, file, current_nplurals);
             state.obsolete_line_count += usize::from(obsolete);
-            state.item.msgid = extract_merge_quoted_cow(line_bytes)?;
+            state.item.msgid = at_line_position(extract_merge_quoted_cow(line_bytes), position)?;
             state.context = Some(Context::Id);
             state.content_line_count += 1;
             state.has_keyword = true;
@@ -403,11 +410,15 @@ fn parse_keyword_line<'a>(
             let plural_index = parse_plural_index(line_bytes).unwrap_or(0);
             state.plural_index = plural_index;
             state.obsolete_line_count += usize::from(obsolete);
-            state.set_msgstr(plural_index, extract_merge_quoted_cow(line_bytes)?);
+            state.set_msgstr(
+                plural_index,
+                at_line_position(extract_merge_quoted_cow(line_bytes), position)?,
+            );
             if is_header_candidate(state) {
-                state
-                    .header_entries
-                    .extend(parse_header_fragment(line_bytes)?);
+                state.header_entries.extend(at_line_position(
+                    parse_header_fragment(line_bytes),
+                    position,
+                )?);
             }
             state.context = Some(Context::Str);
             state.content_line_count += 1;
@@ -416,7 +427,10 @@ fn parse_keyword_line<'a>(
         Keyword::Ctxt => {
             finish_item(state, file, current_nplurals);
             state.obsolete_line_count += usize::from(obsolete);
-            state.item.msgctxt = Some(extract_merge_quoted_cow(line_bytes)?);
+            state.item.msgctxt = Some(at_line_position(
+                extract_merge_quoted_cow(line_bytes),
+                position,
+            )?);
             state.context = Some(Context::Ctxt);
             state.content_line_count += 1;
             state.has_keyword = true;
@@ -429,19 +443,21 @@ fn parse_keyword_line<'a>(
 fn append_continuation<'a>(
     line_bytes: &'a [u8],
     obsolete: bool,
+    position: ParsePosition,
     state: &mut ParserState<'a>,
 ) -> Result<(), ParseError> {
     state.obsolete_line_count += usize::from(obsolete);
     state.content_line_count += 1;
-    let value = extract_merge_quoted_cow(line_bytes)?;
+    let value = at_line_position(extract_merge_quoted_cow(line_bytes), position)?;
 
     match state.context {
         Some(Context::Str) => {
             state.append_msgstr(state.plural_index, value);
             if is_header_candidate(state) {
-                state
-                    .header_entries
-                    .extend(parse_header_fragment(line_bytes)?);
+                state.header_entries.extend(at_line_position(
+                    parse_header_fragment(line_bytes),
+                    position,
+                )?);
             }
         }
         Some(Context::Id) => state.item.msgid.to_mut().push_str(value.as_ref()),
@@ -457,6 +473,14 @@ fn append_continuation<'a>(
     }
 
     Ok(())
+}
+
+#[inline]
+fn at_line_position<T>(
+    result: Result<T, ParseError>,
+    position: ParsePosition,
+) -> Result<T, ParseError> {
+    result.map_err(|error| error.with_position_if_missing(position))
 }
 
 fn finish_item<'a>(

--- a/crates/ferrocat-po/src/merge.rs
+++ b/crates/ferrocat-po/src/merge.rs
@@ -415,10 +415,8 @@ fn parse_keyword_line<'a>(
                 at_line_position(extract_merge_quoted_cow(line_bytes), position)?,
             );
             if is_header_candidate(state) {
-                state.header_entries.extend(at_line_position(
-                    parse_header_fragment(line_bytes),
-                    position,
-                )?);
+                let headers = at_line_position(parse_header_fragment(line_bytes), position)?;
+                state.header_entries.extend(headers);
             }
             state.context = Some(Context::Str);
             state.content_line_count += 1;
@@ -454,10 +452,8 @@ fn append_continuation<'a>(
         Some(Context::Str) => {
             state.append_msgstr(state.plural_index, value);
             if is_header_candidate(state) {
-                state.header_entries.extend(at_line_position(
-                    parse_header_fragment(line_bytes),
-                    position,
-                )?);
+                let headers = at_line_position(parse_header_fragment(line_bytes), position)?;
+                state.header_entries.extend(headers);
             }
         }
         Some(Context::Id) => state.item.msgid.to_mut().push_str(value.as_ref()),
@@ -1458,5 +1454,49 @@ mod tests {
             }]),
             None
         );
+    }
+
+    #[test]
+    fn merge_parse_errors_include_line_position_for_plural_and_context_keywords() {
+        let plural_error = merge_catalog(
+            "msgid \"file\"\nmsgid_plural \"bad\"quote\"\nmsgstr[0] \"\"\n",
+            &[],
+        )
+        .expect_err("unescaped plural quote should fail");
+        let plural_position = plural_error.position().expect("plural position metadata");
+        assert_eq!(plural_error.message(), "unescaped quote in string literal");
+        assert_eq!(plural_position.line(), 2);
+        assert_eq!(plural_position.column(), 1);
+
+        let context_error =
+            merge_catalog("msgctxt \"bad\"quote\"\nmsgid \"x\"\nmsgstr \"\"\n", &[])
+                .expect_err("unescaped context quote should fail");
+        let context_position = context_error.position().expect("context position metadata");
+        assert_eq!(context_error.message(), "unescaped quote in string literal");
+        assert_eq!(context_position.line(), 1);
+        assert_eq!(context_position.column(), 1);
+    }
+
+    #[test]
+    fn merge_parses_owned_header_fragments_in_keyword_and_continuation_lines() {
+        let existing = concat!(
+            "msgid \"\"\n",
+            "msgstr \"Project-Id-Version: ferrocat\\t1\\n\"\n",
+            "\"Language: de\\t\\n\"\n",
+            "\n",
+            "msgid \"hello\"\n",
+            "msgstr \"world\"\n",
+        );
+        let merged = merge_catalog(
+            existing,
+            &[ExtractedMessage {
+                msgid: Cow::Borrowed("hello"),
+                ..ExtractedMessage::default()
+            }],
+        )
+        .expect("merge with owned header fragments");
+
+        assert!(merged.contains("Project-Id-Version: ferrocat\\t1\\n"));
+        assert!(merged.contains("Language: de\\n"));
     }
 }

--- a/crates/ferrocat-po/src/parse.rs
+++ b/crates/ferrocat-po/src/parse.rs
@@ -8,7 +8,7 @@ use crate::scan::{
 };
 use crate::text::{extract_quoted_bytes_cow, split_reference_comment};
 use crate::utf8::input_slice_as_str;
-use crate::{Header, MsgStr, ParseError, PoFile, PoItem};
+use crate::{Header, MsgStr, ParseError, ParsePosition, PoFile, PoItem};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Context {
@@ -126,6 +126,7 @@ impl ParserState {
 struct BorrowedLine<'a> {
     trimmed: &'a [u8],
     obsolete: bool,
+    position: ParsePosition,
 }
 
 /// Parses PO content into the owned [`PoFile`] representation.
@@ -156,6 +157,7 @@ pub fn parse_po(input: &str) -> Result<PoFile, ParseError> {
             BorrowedLine {
                 trimmed: line.trimmed,
                 obsolete: line.obsolete,
+                position: line.position,
             },
             &mut state,
             &mut file,
@@ -181,7 +183,7 @@ fn parse_line(
 ) -> Result<(), ParseError> {
     match classify_line(line.trimmed) {
         LineKind::Continuation => {
-            append_continuation(line.trimmed, line.obsolete, state)?;
+            append_continuation(line.trimmed, line.obsolete, line.position, state)?;
             Ok(())
         }
         LineKind::Comment(kind) => {
@@ -191,6 +193,7 @@ fn parse_line(
         LineKind::Keyword(keyword) => parse_keyword_line(
             line.trimmed,
             line.obsolete,
+            line.position,
             keyword,
             state,
             file,
@@ -258,6 +261,7 @@ fn ferrocat_mt_metadata_value(trimmed: &[u8]) -> Option<&[u8]> {
 fn parse_keyword_line(
     line_bytes: &[u8],
     obsolete: bool,
+    position: ParsePosition,
     keyword: Keyword,
     state: &mut ParserState,
     file: &mut PoFile,
@@ -266,7 +270,9 @@ fn parse_keyword_line(
     match keyword {
         Keyword::IdPlural => {
             state.obsolete_line_count += usize::from(obsolete);
-            state.item.msgid_plural = Some(extract_quoted_bytes_cow(line_bytes)?.into_owned());
+            state.item.msgid_plural = Some(
+                at_line_position(extract_quoted_bytes_cow(line_bytes), position)?.into_owned(),
+            );
             state.context = Some(Context::IdPlural);
             state.content_line_count += 1;
             state.has_keyword = true;
@@ -274,7 +280,8 @@ fn parse_keyword_line(
         Keyword::Id => {
             finish_item(state, file, current_nplurals);
             state.obsolete_line_count += usize::from(obsolete);
-            state.item.msgid = extract_quoted_bytes_cow(line_bytes)?.into_owned();
+            state.item.msgid =
+                at_line_position(extract_quoted_bytes_cow(line_bytes), position)?.into_owned();
             state.context = Some(Context::Id);
             state.content_line_count += 1;
             state.has_keyword = true;
@@ -285,7 +292,7 @@ fn parse_keyword_line(
             state.obsolete_line_count += usize::from(obsolete);
             state.set_msgstr(
                 plural_index,
-                extract_quoted_bytes_cow(line_bytes)?.into_owned(),
+                at_line_position(extract_quoted_bytes_cow(line_bytes), position)?.into_owned(),
             );
             state.context = Some(Context::Str);
             state.content_line_count += 1;
@@ -294,7 +301,9 @@ fn parse_keyword_line(
         Keyword::Ctxt => {
             finish_item(state, file, current_nplurals);
             state.obsolete_line_count += usize::from(obsolete);
-            state.item.msgctxt = Some(extract_quoted_bytes_cow(line_bytes)?.into_owned());
+            state.item.msgctxt = Some(
+                at_line_position(extract_quoted_bytes_cow(line_bytes), position)?.into_owned(),
+            );
             state.context = Some(Context::Ctxt);
             state.content_line_count += 1;
             state.has_keyword = true;
@@ -307,11 +316,12 @@ fn parse_keyword_line(
 fn append_continuation(
     line_bytes: &[u8],
     obsolete: bool,
+    position: ParsePosition,
     state: &mut ParserState,
 ) -> Result<(), ParseError> {
     state.obsolete_line_count += usize::from(obsolete);
     state.content_line_count += 1;
-    let value = extract_quoted_bytes_cow(line_bytes)?;
+    let value = at_line_position(extract_quoted_bytes_cow(line_bytes), position)?;
 
     match state.context {
         Some(Context::Str) => {
@@ -330,6 +340,14 @@ fn append_continuation(
     }
 
     Ok(())
+}
+
+#[inline]
+fn at_line_position<T>(
+    result: Result<T, ParseError>,
+    position: ParsePosition,
+) -> Result<T, ParseError> {
+    result.map_err(|error| error.with_position_if_missing(position))
 }
 
 fn finish_item(state: &mut ParserState, file: &mut PoFile, current_nplurals: &mut usize) {
@@ -549,6 +567,18 @@ msgstr ""
             po.items[2].msgid,
             "define('some/test/module', function () {\n\t'use strict';\n\treturn {};\n});\n"
         );
+    }
+
+    #[test]
+    fn parse_errors_include_line_position() {
+        let error = parse_po("msgid \"ok\"\n  msgstr \"bad\"quote\"\n")
+            .expect_err("unescaped quote should fail");
+        let position = error.position().expect("position metadata");
+
+        assert_eq!(error.message(), "unescaped quote in string literal");
+        assert_eq!(position.offset(), 13);
+        assert_eq!(position.line(), 2);
+        assert_eq!(position.column(), 3);
     }
 
     #[test]

--- a/crates/ferrocat-po/src/scan.rs
+++ b/crates/ferrocat-po/src/scan.rs
@@ -1,5 +1,7 @@
 use memchr::Memchr;
 
+use crate::ParsePosition;
+
 mod backend {
     use memchr::{memchr, memchr3, memrchr};
 
@@ -148,12 +150,14 @@ pub enum LineKind {
 pub struct Line<'a> {
     pub trimmed: &'a [u8],
     pub obsolete: bool,
+    pub position: ParsePosition,
 }
 
 pub struct LineScanner<'a> {
     bytes: &'a [u8],
     newlines: Memchr<'a>,
     offset: usize,
+    line_number: usize,
     finished: bool,
 }
 
@@ -163,6 +167,7 @@ impl<'a> LineScanner<'a> {
             bytes,
             newlines: Memchr::new(b'\n', bytes),
             offset: 0,
+            line_number: 1,
             finished: false,
         }
     }
@@ -183,6 +188,9 @@ impl<'a> Iterator for LineScanner<'a> {
             if self.finished && self.offset == self.bytes.len() {
                 return None;
             }
+            let raw_offset = self.offset;
+            let line_number = self.line_number;
+            self.line_number += 1;
             let raw = &self.bytes[self.offset..next_newline];
 
             if next_newline < self.bytes.len() {
@@ -192,6 +200,7 @@ impl<'a> Iterator for LineScanner<'a> {
             }
 
             let mut trimmed = trim_ascii_start(raw);
+            let mut content_offset = raw_offset + raw.len() - trimmed.len();
             if trimmed.is_empty() {
                 if next_newline == self.bytes.len() {
                     return None;
@@ -201,7 +210,9 @@ impl<'a> Iterator for LineScanner<'a> {
 
             let mut obsolete = false;
             if trimmed.starts_with(b"#~") {
-                trimmed = trim_ascii_start(&trimmed[2..]);
+                let after_marker = &trimmed[2..];
+                trimmed = trim_ascii_start(after_marker);
+                content_offset += 2 + after_marker.len() - trimmed.len();
                 obsolete = true;
                 if trimmed.is_empty() {
                     if next_newline == self.bytes.len() {
@@ -211,7 +222,13 @@ impl<'a> Iterator for LineScanner<'a> {
                 }
             }
 
-            return Some(Line { trimmed, obsolete });
+            let column = content_offset - raw_offset + 1;
+
+            return Some(Line {
+                trimmed,
+                obsolete,
+                position: ParsePosition::new(content_offset, line_number, column),
+            });
         }
 
         None
@@ -372,10 +389,16 @@ mod tests {
         let first = scanner.next().expect("first line");
         assert_eq!(first.trimmed, b"msgid \"x\"  ");
         assert!(!first.obsolete);
+        assert_eq!(first.position.offset(), 2);
+        assert_eq!(first.position.line(), 1);
+        assert_eq!(first.position.column(), 3);
 
         let second = scanner.next().expect("second line");
         assert_eq!(second.trimmed, b"msgstr \"y\"");
         assert!(second.obsolete);
+        assert_eq!(second.position.offset(), 17);
+        assert_eq!(second.position.line(), 2);
+        assert_eq!(second.position.column(), 4);
 
         assert!(scanner.next().is_none());
     }

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -628,7 +628,7 @@ part of this source-side metadata format.
 
 ## Error Surface
 
-`ApiError` and the lower-level `ParseError` are intentionally small today. `ApiError` distinguishes parse, I/O, invalid-argument, conflict, and unsupported-operation failures; PO `ParseError` currently carries a human-readable message but not a line/column position. Adding structured PO error kinds or source positions would be a semver-relevant API change and should ship with matching rustdoc, README/API docs, and an ADR update.
+`ApiError` and the lower-level `ParseError` are intentionally small today. `ApiError` distinguishes parse, I/O, invalid-argument, conflict, and unsupported-operation failures, and its `std::error::Error::source()` implementation preserves underlying parse and I/O causes. PO `ParseError` keeps the existing human-readable display message and exposes `message()` plus optional `position()` metadata for tooling. Position metadata reports a zero-based byte offset plus one-based line and column when the parser can attach source context.
 
 ## Practical Rule Of Thumb
 


### PR DESCRIPTION
Refs #53.

## Summary
- preserve underlying parse/io causes through std::error::Error::source()
- add optional position metadata to PO ParseError
- keep existing ParseError construction compatible while exposing accessors for tooling

## Verification
- [x] cargo test -p ferrocat-po
- [x] cargo fmt --all --check
- [x] cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- [x] cargo test --workspace --all-features --locked
- [x] RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- [x] from docs/: pnpm install --frozen-lockfile && pnpm build
