### PR TITLE
test(fuzz): add parser fuzz and property coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/ferrocat-conformance",
     "crates/ferrocat-bench",
 ]
+exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/ferrocat-icu/Cargo.toml
+++ b/crates/ferrocat-icu/Cargo.toml
@@ -27,6 +27,7 @@ all-features = true
 
 [dev-dependencies]
 ferrocat-conformance = { path = "../ferrocat-conformance" }
+proptest = "1"
 serde_json = "1.0.145"
 
 [lints]

--- a/crates/ferrocat-icu/tests/property_icu.rs
+++ b/crates/ferrocat-icu/tests/property_icu.rs
@@ -1,0 +1,47 @@
+use ferrocat_icu::{parse_icu, stringify_icu};
+use proptest::prelude::*;
+
+fn identifier_strategy() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9_]{0,12}"
+}
+
+fn literal_strategy() -> impl Strategy<Value = String> {
+    "[A-Za-z0-9 .,!?_-]{0,32}"
+}
+
+fn simple_message_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![
+        literal_strategy(),
+        (
+            literal_strategy(),
+            identifier_strategy(),
+            literal_strategy()
+        )
+            .prop_map(|(prefix, name, suffix)| format!("{prefix}{{{name}}}{suffix}")),
+        identifier_strategy().prop_map(|name| format!("{{{name}, number, integer}}")),
+        (
+            identifier_strategy(),
+            literal_strategy(),
+            literal_strategy(),
+        )
+            .prop_map(|(name, one, other)| {
+                format!("{{{name}, plural, one {{{one}}} other {{{other}}}}}")
+            }),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn stringify_icu_roundtrips_generated_messages(input in simple_message_strategy()) {
+        let parsed = parse_icu(&input).expect("generated ICU message should parse");
+        let rendered = stringify_icu(&parsed);
+        let reparsed = parse_icu(&rendered).expect("rendered ICU message should parse");
+
+        prop_assert_eq!(reparsed, parsed);
+    }
+}

--- a/crates/ferrocat-po/Cargo.toml
+++ b/crates/ferrocat-po/Cargo.toml
@@ -49,6 +49,7 @@ all-features = true
 
 [dev-dependencies]
 ferrocat-conformance = { path = "../ferrocat-conformance" }
+proptest = "1"
 serde_json = "1.0.145"
 
 [lints]

--- a/crates/ferrocat-po/tests/property_po.rs
+++ b/crates/ferrocat-po/tests/property_po.rs
@@ -1,0 +1,101 @@
+use std::collections::BTreeMap;
+
+use ferrocat_po::{
+    CatalogSemantics, CatalogStorageFormat, ParseCatalogOptions, PluralEncoding, SerializeOptions,
+    parse_catalog, parse_po, parse_po_borrowed, stringify_po,
+};
+use proptest::prelude::*;
+
+fn msgid_strategy() -> impl Strategy<Value = String> {
+    "[A-Za-z0-9 .,!?_/-]{1,32}"
+        .prop_filter("msgid must not be blank", |value| !value.trim().is_empty())
+}
+
+fn msgstr_strategy() -> impl Strategy<Value = String> {
+    "[A-Za-z0-9 .,!?_/-]{0,32}"
+}
+
+fn entries_strategy() -> impl Strategy<Value = Vec<(String, String)>> {
+    prop::collection::btree_map(msgid_strategy(), msgstr_strategy(), 1..8)
+        .prop_map(BTreeMap::into_iter)
+        .prop_map(Iterator::collect)
+}
+
+fn render_po(entries: &[(String, String)]) -> String {
+    let mut out =
+        String::from("msgid \"\"\nmsgstr \"\"\n\"Content-Type: text/plain; charset=utf-8\\n\"\n\n");
+    for (index, (msgid, msgstr)) in entries.iter().enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
+        out.push_str("msgid \"");
+        out.push_str(msgid);
+        out.push_str("\"\nmsgstr \"");
+        out.push_str(msgstr);
+        out.push_str("\"\n");
+    }
+    out
+}
+
+fn render_ndjson(entries: &[(String, String)]) -> String {
+    let mut out =
+        String::from("---\nformat: ferrocat.ndjson.v1\nlocale: de\nsource_locale: en\n---\n");
+    for (msgid, msgstr) in entries {
+        out.push_str(&serde_json::json!({ "id": msgid, "str": msgstr }).to_string());
+        out.push('\n');
+    }
+    out
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn stringify_po_roundtrips_generated_catalog(entries in entries_strategy()) {
+        let input = render_po(&entries);
+        let parsed = parse_po(&input).expect("generated PO should parse");
+        let rendered = stringify_po(&parsed, &SerializeOptions::default());
+        let reparsed = parse_po(&rendered).expect("rendered PO should parse");
+
+        prop_assert_eq!(reparsed, parsed);
+    }
+
+    #[test]
+    fn borrowed_parser_matches_owned_parser_for_lf_only_generated_catalog(entries in entries_strategy()) {
+        let input = render_po(&entries);
+        let owned = parse_po(&input).expect("generated PO should parse");
+        let borrowed = parse_po_borrowed(&input)
+            .expect("generated LF-only PO should parse as borrowed")
+            .into_owned();
+
+        prop_assert_eq!(borrowed, owned);
+    }
+
+    #[test]
+    fn catalog_api_accepts_equivalent_generated_po_and_ndjson(entries in entries_strategy()) {
+        let po = parse_catalog(ParseCatalogOptions {
+            content: &render_po(&entries),
+            locale: Some("de"),
+            source_locale: "en",
+            storage_format: CatalogStorageFormat::Po,
+            semantics: CatalogSemantics::IcuNative,
+            plural_encoding: PluralEncoding::Icu,
+            ..ParseCatalogOptions::default()
+        })
+        .expect("generated PO catalog should parse");
+        let ndjson = parse_catalog(ParseCatalogOptions {
+            content: &render_ndjson(&entries),
+            source_locale: "en",
+            storage_format: CatalogStorageFormat::Ndjson,
+            semantics: CatalogSemantics::IcuNative,
+            plural_encoding: PluralEncoding::Icu,
+            ..ParseCatalogOptions::default()
+        })
+        .expect("generated NDJSON catalog should parse");
+
+        prop_assert_eq!(po.messages.len(), ndjson.messages.len());
+    }
+}

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+/target
+/artifacts
+/corpus
+/coverage

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -9,39 +9,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "autocfg"
-version = "1.5.1"
+name = "arbitrary"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -75,15 +72,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -128,66 +116,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "ferrocat"
-version = "0.13.0"
+name = "ferrocat-fuzz"
+version = "0.0.0"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
+ "libfuzzer-sys",
 ]
-
-[[package]]
-name = "ferrocat-bench"
-version = "0.13.0"
-dependencies = [
- "ferrocat-conformance",
- "ferrocat-icu",
- "ferrocat-po",
- "libc",
- "serde",
- "serde_json",
- "sha2",
- "tempfile",
- "time",
-]
-
-[[package]]
-name = "ferrocat-cli"
-version = "0.13.0"
-dependencies = [
- "ferrocat-po",
- "serde_json",
- "tempfile",
-]
-
-[[package]]
-name = "ferrocat-conformance"
-version = "0.13.0"
 
 [[package]]
 name = "ferrocat-icu"
 version = "0.13.0"
 dependencies = [
- "ferrocat-conformance",
- "proptest",
  "serde",
- "serde_json",
 ]
 
 [[package]]
 name = "ferrocat-po"
 version = "0.13.0"
 dependencies = [
- "ferrocat-conformance",
  "ferrocat-icu",
  "icu_locale",
  "icu_plurals",
  "memchr",
- "proptest",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed_decimal"
@@ -199,12 +161,6 @@ dependencies = [
  "smallvec",
  "writeable",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -377,6 +333,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +353,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -402,30 +378,15 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "num-conv"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "once_cell"
@@ -442,21 +403,6 @@ dependencies = [
  "serde_core",
  "writeable",
  "zerovec",
-]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -477,31 +423,6 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -525,50 +446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,18 +456,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
-]
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
 ]
 
 [[package]]
@@ -631,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -654,10 +519,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
+name = "shlex"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "stable_deref_trait"
@@ -667,9 +538,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -701,37 +572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,15 +584,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -773,19 +607,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -950,9 +775,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -969,26 +794,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,63 @@
+[package]
+name = "ferrocat-fuzz"
+version = "0.0.0"
+edition = "2024"
+rust-version = "1.93.0"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+ferrocat-icu = { path = "../crates/ferrocat-icu" }
+ferrocat-po = { path = "../crates/ferrocat-po" }
+libfuzzer-sys = "0.4"
+
+[[bin]]
+name = "parse_po"
+path = "fuzz_targets/parse_po.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_po_borrowed"
+path = "fuzz_targets/parse_po_borrowed.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_catalog_po"
+path = "fuzz_targets/parse_catalog_po.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_catalog_ndjson"
+path = "fuzz_targets/parse_catalog_ndjson.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_icu"
+path = "fuzz_targets/parse_icu.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "merge_catalog"
+path = "fuzz_targets/merge_catalog.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "update_catalog"
+path = "fuzz_targets/update_catalog.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,23 @@
+# Ferrocat Fuzz Targets
+
+This directory contains local `cargo-fuzz` harnesses for parser and catalog
+entry points that accept untrusted catalog content.
+
+The first target set is intentionally local-only. Scheduled CI fuzzing should
+be added after these harnesses have produced stable, useful corpora.
+
+Run a target with:
+
+```bash
+cargo fuzz run parse_po
+```
+
+Available targets:
+
+- `parse_po`
+- `parse_po_borrowed`
+- `parse_catalog_po`
+- `parse_catalog_ndjson`
+- `parse_icu`
+- `merge_catalog`
+- `update_catalog`

--- a/fuzz/fuzz_targets/merge_catalog.rs
+++ b/fuzz/fuzz_targets/merge_catalog.rs
@@ -1,0 +1,17 @@
+#![no_main]
+
+use std::borrow::Cow;
+
+use ferrocat_po::{MergeExtractedMessage, merge_catalog};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = std::str::from_utf8(data) {
+        let extracted = [MergeExtractedMessage {
+            msgid: Cow::Borrowed("fuzz.message"),
+            references: vec![Cow::Borrowed("fuzz.rs:1")],
+            ..MergeExtractedMessage::default()
+        }];
+        let _ = merge_catalog(input, &extracted);
+    }
+});

--- a/fuzz/fuzz_targets/parse_catalog_ndjson.rs
+++ b/fuzz/fuzz_targets/parse_catalog_ndjson.rs
@@ -1,0 +1,19 @@
+#![no_main]
+
+use ferrocat_po::{
+    CatalogSemantics, CatalogStorageFormat, ParseCatalogOptions, PluralEncoding, parse_catalog,
+};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = std::str::from_utf8(data) {
+        let _ = parse_catalog(ParseCatalogOptions {
+            content: input,
+            source_locale: "en",
+            storage_format: CatalogStorageFormat::Ndjson,
+            semantics: CatalogSemantics::IcuNative,
+            plural_encoding: PluralEncoding::Icu,
+            ..ParseCatalogOptions::default()
+        });
+    }
+});

--- a/fuzz/fuzz_targets/parse_catalog_po.rs
+++ b/fuzz/fuzz_targets/parse_catalog_po.rs
@@ -1,0 +1,19 @@
+#![no_main]
+
+use ferrocat_po::{
+    CatalogSemantics, CatalogStorageFormat, ParseCatalogOptions, PluralEncoding, parse_catalog,
+};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = std::str::from_utf8(data) {
+        let _ = parse_catalog(ParseCatalogOptions {
+            content: input,
+            source_locale: "en",
+            storage_format: CatalogStorageFormat::Po,
+            semantics: CatalogSemantics::IcuNative,
+            plural_encoding: PluralEncoding::Icu,
+            ..ParseCatalogOptions::default()
+        });
+    }
+});

--- a/fuzz/fuzz_targets/parse_icu.rs
+++ b/fuzz/fuzz_targets/parse_icu.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = std::str::from_utf8(data) {
+        let _ = ferrocat_icu::parse_icu(input);
+    }
+});

--- a/fuzz/fuzz_targets/parse_po.rs
+++ b/fuzz/fuzz_targets/parse_po.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = std::str::from_utf8(data) {
+        let _ = ferrocat_po::parse_po(input);
+    }
+});

--- a/fuzz/fuzz_targets/parse_po_borrowed.rs
+++ b/fuzz/fuzz_targets/parse_po_borrowed.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = std::str::from_utf8(data) {
+        let _ = ferrocat_po::parse_po_borrowed(input);
+    }
+});

--- a/fuzz/fuzz_targets/update_catalog.rs
+++ b/fuzz/fuzz_targets/update_catalog.rs
@@ -1,0 +1,25 @@
+#![no_main]
+
+use ferrocat_po::{
+    CatalogSemantics, CatalogStorageFormat, PluralEncoding, SourceExtractedMessage,
+    UpdateCatalogOptions, update_catalog,
+};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = std::str::from_utf8(data) {
+        let extracted = vec![SourceExtractedMessage {
+            msgid: "fuzz.message".to_owned(),
+            ..SourceExtractedMessage::default()
+        }];
+        let _ = update_catalog(UpdateCatalogOptions {
+            source_locale: "en",
+            input: extracted.into(),
+            existing: Some(input),
+            storage_format: CatalogStorageFormat::Po,
+            semantics: CatalogSemantics::IcuNative,
+            plural_encoding: PluralEncoding::Icu,
+            ..UpdateCatalogOptions::default()
+        });
+    }
+});


### PR DESCRIPTION
## Summary

- Closes #65.
- Adds property tests for PO parse/stringify roundtrips, borrowed-vs-owned PO parsing, catalog API PO/NDJSON equivalence, and ICU parse/stringify roundtrips.
- Adds a local cargo-fuzz package with harnesses for PO, borrowed PO, catalog PO/NDJSON, ICU, merge, and update entry points.
- Keeps fuzzing local-only for now; scheduled CI fuzzing can follow once useful corpora stabilize.

## Verification

- [x] cargo fmt --all --check
- [x] cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- [x] cargo test --workspace --all-features --locked
- [x] RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- [x] cargo +1.93.0 check --workspace --all-targets --all-features --locked
- [x] cargo check --manifest-path fuzz/Cargo.toml --bins --locked
- [x] cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked
- [x] git diff --check

## Notes

- No public API or semver-relevant behavior changes.
- Benchmark impact is not expected; this is test/fuzz harness coverage only.
- The package check needed network access for crates.io index verification.