### PR TITLE
ci(release): add semver checks for published crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,27 @@ jobs:
       - name: Package published crates
         run: cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked
 
+  semver:
+    name: Semver compatibility (${{ matrix.crate }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        crate:
+          - ferrocat-icu
+          - ferrocat-po
+          - ferrocat
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Check public API compatibility
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: ${{ matrix.crate }}
+          feature-group: all-features
+
   msrv:
     name: Rust MSRV
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

- Closes #67.
- Adds a CI semver compatibility job for the three published crates: ferrocat-icu, ferrocat-po, and ferrocat.
- Uses obi1kenobi/cargo-semver-checks-action@v2 with feature-group: all-features and a crate matrix.
- Keeps the scope narrow: packaging and idempotent publish retries remain handled by #94.

## Verification

- [x] ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
- [x] git diff --check
- [x] cargo fmt --all --check
- [x] cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

## Notes

- No public Rust API or semver-relevant behavior changes in this PR.
- actionlint is not installed in this local environment, so workflow-specific validation is left to GitHub Actions.
- No benchmark impact expected; this only adds a release-guard CI job.