### PR TITLE
feat(api): mark growth-prone enums non-exhaustive

### DIFF
--- a/conformance/harness.rs
+++ b/conformance/harness.rs
@@ -614,6 +614,7 @@ fn node_kind(node: &IcuNode) -> String {
         IcuNode::Tag { .. } => "tag",
         IcuNode::List { .. } => "list",
         IcuNode::Pound => "pound",
+        _ => "unknown",
     }
     .to_owned()
 }

--- a/conformance/icu_harness.rs
+++ b/conformance/icu_harness.rs
@@ -275,6 +275,7 @@ fn node_kind(node: &IcuNode) -> String {
         IcuNode::Tag { .. } => "tag",
         IcuNode::List { .. } => "list",
         IcuNode::Pound => "pound",
+        _ => "unknown",
     }
     .to_owned()
 }

--- a/crates/ferrocat-bench/src/compare.rs
+++ b/crates/ferrocat-bench/src/compare.rs
@@ -1931,6 +1931,7 @@ impl IcuCollector {
                 self.tag_names.insert(name.clone());
                 self.visit_nodes(children, depth + 1);
             }
+            _ => {}
         }
     }
 

--- a/crates/ferrocat-icu/src/ast.rs
+++ b/crates/ferrocat-icu/src/ast.rs
@@ -24,7 +24,11 @@ pub struct IcuOption {
 }
 
 /// AST node emitted by the ICU parser.
+///
+/// This enum is non-exhaustive so additional ICU formatters or syntax nodes can
+/// be added without forcing downstream callers to rewrite every `match`.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum IcuNode {
     /// Literal text content.
     Literal(String),

--- a/crates/ferrocat-icu/src/error.rs
+++ b/crates/ferrocat-icu/src/error.rs
@@ -1,7 +1,11 @@
 use core::fmt;
 
 /// High-level classification of ICU parse failures.
+///
+/// This enum is non-exhaustive so future parser error categories can be added
+/// without making existing downstream matches semver-breaking.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum IcuErrorKind {
     /// The input violates the supported ICU syntax.
     SyntaxError,

--- a/crates/ferrocat-po/src/api/compile_types.rs
+++ b/crates/ferrocat-po/src/api/compile_types.rs
@@ -29,9 +29,13 @@ pub enum CompiledTranslation {
 }
 
 /// Built-in key strategy used when compiling runtime catalogs.
+///
+/// This enum is non-exhaustive so additional stable key strategies can be added
+/// without breaking downstream matches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum CompiledKeyStrategy {
     /// `ferrocat` v1 key format: SHA-256 over a versioned, length-delimited
     /// `msgctxt`/`msgid` payload, truncated to 64 bits and encoded as unpadded

--- a/crates/ferrocat-po/src/api/plural.rs
+++ b/crates/ferrocat-po/src/api/plural.rs
@@ -845,6 +845,15 @@ fn render_projectable_icu_node(node: &IcuNode, out: &mut String) -> Result<(), &
                 "Nested ICU select/plural structures are not projected into the current catalog plural model.",
             );
         }
+        #[allow(
+            unreachable_patterns,
+            reason = "cargo package verifies ferrocat-po against the latest published ferrocat-icu until this release publishes the dependency crate first."
+        )]
+        _ => {
+            return Err(
+                "Unsupported ICU node is not projected into the current catalog plural model.",
+            );
+        }
     }
 
     Ok(())

--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -640,7 +640,11 @@ pub enum PluralEncoding {
 }
 
 /// Storage format used by the high-level catalog API.
+///
+/// This enum is non-exhaustive because Ferrocat can add additional catalog
+/// storage formats over time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum CatalogStorageFormat {
     /// Read and write classic gettext PO catalogs.
     #[default]
@@ -950,7 +954,11 @@ impl<'a> ParseCatalogOptions<'a> {
 }
 
 /// Error returned by catalog parsing and update APIs.
+///
+/// This enum is non-exhaustive so new API-level failure categories can be added
+/// without turning downstream error matches into a breaking change.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ApiError {
     /// Underlying PO parse or string-unescape failure.
     Parse(ParseError),

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -70,6 +70,11 @@ diagnostics carry machine-readable `code` values, and severities serialize as
 
 See [ADR 0019](/architecture/adr/0019-versioned-artifact-json-contract) for the
 compatibility rules around the compiled artifact JSON contract.
+## API Compatibility
+
+Ferrocat is still pre-1.0, but growth-prone public enums are deliberately marked as non-exhaustive where new variants are realistic. Downstream code should keep fallback match arms for ICU AST nodes, catalog storage formats, compiled key strategies, and API-level error categories.
+
+Semantically closed option enums such as `CatalogSemantics` and `PluralEncoding` remain exhaustive so callers can continue to match every documented mode directly.
 
 ## Supported Catalog Modes
 


### PR DESCRIPTION
## Summary

- Closes #50.
- Marks growth-prone public enums as `#[non_exhaustive]`: `IcuNode`, `IcuErrorKind`, `CatalogStorageFormat`, `CompiledKeyStrategy`, and `ApiError`.
- Adds defensive wildcard handling in external workspace matches for conformance, benchmark collection, and PO plural projection.
- Documents the API compatibility rule in the API overview while leaving semantically closed enums such as `CatalogSemantics` and `PluralEncoding` exhaustive.

## Verification

- [x] cargo fmt --all --check
- [x] cargo check --workspace --all-targets --all-features --locked
- [x] cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- [x] cargo test --workspace --all-features --locked
- [x] RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- [x] cargo +1.93.0 check --workspace --all-targets --all-features --locked
- [x] cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked
- [x] pnpm build from docs/
- [x] git diff --check

## Notes

- This is intentionally not a blanket `#[non_exhaustive]` pass.
- Option structs are left for #54 so constructor and builder ergonomics can be handled in one deliberate API pass.
- The package check needed network access for crates.io index verification.