### PR TITLE
feat(api)!: collapse redundant option fields into CatalogMode

### DIFF
--- a/conformance/harness.rs
+++ b/conformance/harness.rs
@@ -8,8 +8,8 @@ use ferrocat_conformance::{
 };
 use ferrocat_icu::{IcuNode, IcuPluralKind, parse_icu};
 use ferrocat_po::{
-    MergeExtractedMessage, ParseCatalogOptions, PluralEncoding, PoFile, PoItem, SerializeOptions,
-    merge_catalog, parse_catalog, parse_po, stringify_po,
+    MergeExtractedMessage, ParseCatalogOptions, PoFile, PoItem, SerializeOptions, merge_catalog,
+    parse_catalog, parse_po, stringify_po,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -289,9 +289,7 @@ fn evaluate_po_plural_header(case: &ConformanceCase) -> Result<String, String> {
             content: &input,
             locale: Some(locale),
             source_locale: &source_locale,
-            storage_format: ferrocat_po::CatalogStorageFormat::Po,
-            semantics: ferrocat_po::CatalogSemantics::GettextCompat,
-            plural_encoding: PluralEncoding::Gettext,
+            mode: ferrocat_po::CatalogMode::GettextPo,
             strict: false,
         })
         .map_err(|error| format!("parse_catalog failed unexpectedly: {error:?}"))?;

--- a/crates/ferrocat-bench/src/compare.rs
+++ b/crates/ferrocat-bench/src/compare.rs
@@ -12,11 +12,10 @@ use std::time::Instant;
 
 use ferrocat_icu::{IcuMessage, IcuNode, IcuOption, IcuPluralKind, parse_icu};
 use ferrocat_po::{
-    BorrowedMsgStr, BorrowedPoFile, CatalogMessage, CatalogMessageExtra, CatalogOrigin,
-    CatalogSemantics, CatalogStorageFormat, ExtractedMessage, MergeExtractedMessage, MsgStr,
-    ParseCatalogOptions, ParsedCatalog, PluralEncoding, PoFile, SerializeOptions, TranslationShape,
-    UpdateCatalogOptions, merge_catalog, parse_catalog, parse_po, parse_po_borrowed, stringify_po,
-    update_catalog,
+    BorrowedMsgStr, BorrowedPoFile, CatalogMessage, CatalogMessageExtra, CatalogMode,
+    CatalogOrigin, ExtractedMessage, MergeExtractedMessage, MsgStr, ParseCatalogOptions,
+    ParsedCatalog, PoFile, SerializeOptions, TranslationShape, UpdateCatalogOptions, merge_catalog,
+    parse_catalog, parse_po, parse_po_borrowed, stringify_po, update_catalog,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -538,9 +537,7 @@ impl PreparedScenario {
                     content: &po_content,
                     locale: fixture_locale(&first.fixture).as_deref(),
                     source_locale: "en",
-                    storage_format: CatalogStorageFormat::Po,
-                    semantics: CatalogSemantics::IcuNative,
-                    plural_encoding: PluralEncoding::Icu,
+                    mode: CatalogMode::IcuPo,
                     strict: false,
                 })
                 .map_err(|error| format!("failed to parse catalog fixture: {error}"))?;
@@ -828,12 +825,12 @@ impl PreparedScenario {
         ndjson: bool,
     ) -> Result<ExecutionResult, String> {
         let locale = fixture_locale(&self.fixture);
-        let (content, storage_format, bytes_per_iteration) = if ndjson {
+        let (content, mode, bytes_per_iteration) = if ndjson {
             (
                 self.catalog_ndjson_content.as_deref().ok_or_else(|| {
                     "internal parse-catalog-ndjson requires NDJSON content".to_owned()
                 })?,
-                CatalogStorageFormat::Ndjson,
+                CatalogMode::IcuNdjson,
                 self.catalog_ndjson_content.as_ref().map_or(0, String::len),
             )
         } else {
@@ -841,7 +838,7 @@ impl PreparedScenario {
                 self.po_content
                     .as_deref()
                     .ok_or_else(|| "internal parse-catalog-po requires PO content".to_owned())?,
-                CatalogStorageFormat::Po,
+                CatalogMode::IcuPo,
                 self.po_content.as_ref().map_or(0, String::len),
             )
         };
@@ -853,9 +850,7 @@ impl PreparedScenario {
                 content,
                 locale: locale.as_deref(),
                 source_locale: "en",
-                storage_format,
-                semantics: CatalogSemantics::IcuNative,
-                plural_encoding: PluralEncoding::Icu,
+                mode,
                 strict: false,
             })
             .map_err(|error| format!("parse_catalog failed: {error}"))?;
@@ -976,16 +971,13 @@ impl PreparedScenario {
         let start = Instant::now();
         let mut bytes_processed = 0usize;
         let locale = fixture_locale(&self.fixture);
-        let plural_encoding = fixture_plural_encoding(&self.fixture);
+        let mode = fixture_catalog_mode(&self.fixture);
         for _ in 0..iterations {
             let updated = update_catalog(UpdateCatalogOptions {
                 locale: locale.as_deref(),
-                source_locale: "en",
-                input: fixture.api_messages.clone().into(),
+                mode,
                 existing: Some(fixture.existing_po.as_str()),
-                semantics: semantics_for_plural_encoding(plural_encoding),
-                plural_encoding,
-                ..UpdateCatalogOptions::default()
+                ..UpdateCatalogOptions::new("en", fixture.api_messages.clone())
             })
             .map_err(|error| format!("update_catalog failed: {error}"))?;
             bytes_processed += updated.content.len();
@@ -1431,18 +1423,11 @@ fn fixture_locale_metadata(locale: &str) -> (&'static str, &'static str) {
     }
 }
 
-fn fixture_plural_encoding(name: &str) -> PluralEncoding {
+fn fixture_catalog_mode(name: &str) -> CatalogMode {
     if name.starts_with("gettext-") {
-        PluralEncoding::Gettext
+        CatalogMode::GettextPo
     } else {
-        PluralEncoding::Icu
-    }
-}
-
-fn semantics_for_plural_encoding(plural_encoding: PluralEncoding) -> CatalogSemantics {
-    match plural_encoding {
-        PluralEncoding::Icu => CatalogSemantics::IcuNative,
-        PluralEncoding::Gettext => CatalogSemantics::GettextCompat,
+        CatalogMode::IcuPo
     }
 }
 

--- a/crates/ferrocat-bench/src/fixtures.rs
+++ b/crates/ferrocat-bench/src/fixtures.rs
@@ -1804,8 +1804,7 @@ fn scan_stats(content: &str) -> FixtureStats {
 mod tests {
     use ferrocat_icu::parse_icu;
     use ferrocat_po::{
-        CatalogSemantics, CatalogStorageFormat, ParseCatalogOptions, PluralEncoding,
-        UpdateCatalogOptions, parse_catalog, update_catalog,
+        CatalogMode, ParseCatalogOptions, UpdateCatalogOptions, parse_catalog, update_catalog,
     };
 
     use super::{fixture_by_name, icu_fixture_by_name, merge_fixture_by_name};
@@ -1909,9 +1908,7 @@ mod tests {
             content: fixture.content(),
             locale: Some("de"),
             source_locale: "en",
-            storage_format: CatalogStorageFormat::Po,
-            semantics: CatalogSemantics::IcuNative,
-            plural_encoding: PluralEncoding::Icu,
+            mode: CatalogMode::IcuPo,
             strict: false,
         })
         .expect("parse catalog");
@@ -1940,12 +1937,8 @@ mod tests {
         let fixture = merge_fixture_by_name("catalog-icu-projectable").expect("fixture exists");
         let result = update_catalog(UpdateCatalogOptions {
             locale: Some("de"),
-            source_locale: "en",
-            input: fixture.api_extracted_messages().to_vec().into(),
             existing: Some(fixture.existing_po()),
-            semantics: CatalogSemantics::IcuNative,
-            plural_encoding: PluralEncoding::Icu,
-            ..UpdateCatalogOptions::default()
+            ..UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
         })
         .expect("update catalog");
 
@@ -1958,12 +1951,8 @@ mod tests {
         let fixture = merge_fixture_by_name("catalog-icu-unsupported").expect("fixture exists");
         let result = update_catalog(UpdateCatalogOptions {
             locale: Some("de"),
-            source_locale: "en",
-            input: fixture.api_extracted_messages().to_vec().into(),
             existing: Some(fixture.existing_po()),
-            semantics: CatalogSemantics::IcuNative,
-            plural_encoding: PluralEncoding::Icu,
-            ..UpdateCatalogOptions::default()
+            ..UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
         })
         .expect("update catalog");
 

--- a/crates/ferrocat-bench/src/main.rs
+++ b/crates/ferrocat-bench/src/main.rs
@@ -12,11 +12,11 @@ use conformance_harness::{evaluate_all_cases, summarize_evaluations};
 use ferrocat_conformance::{ConformanceCase, Expectation, ExpectedArtifact, load_all_manifests};
 use ferrocat_icu::{extract_variables, parse_icu, validate_icu};
 use ferrocat_po::{
-    CatalogCombineInput, CatalogMessage, CatalogMessageExtra, CatalogSemantics,
-    CatalogStorageFormat, CombineCatalogOptions, Header, MsgStr, ParseCatalogOptions,
-    ParsedCatalog, PluralEncoding, PoFile, PoItem, SerializeOptions, TranslationShape,
-    UpdateCatalogFileOptions, UpdateCatalogOptions, combine_catalogs, merge_catalog, parse_catalog,
-    parse_po, parse_po_borrowed, stringify_po, update_catalog, update_catalog_file,
+    CatalogCombineInput, CatalogMessage, CatalogMessageExtra, CatalogMode, CombineCatalogOptions,
+    Header, MsgStr, ParseCatalogOptions, ParsedCatalog, PoFile, PoItem, SerializeOptions,
+    TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions, combine_catalogs,
+    merge_catalog, parse_catalog, parse_po, parse_po_borrowed, stringify_po, update_catalog,
+    update_catalog_file,
 };
 use fixtures::{
     Fixture, IcuFixture, MergeFixture, fixture_by_name, icu_fixture_by_name, merge_fixture_by_name,
@@ -333,9 +333,7 @@ fn bench_parse_catalog_po(fixture: &Fixture, config: BenchConfig) -> Result<(), 
                 content: fixture.content(),
                 locale: inferred_fixture_locale(fixture.name()),
                 source_locale: "en",
-                storage_format: CatalogStorageFormat::Po,
-                semantics: CatalogSemantics::IcuNative,
-                plural_encoding: PluralEncoding::Icu,
+                mode: CatalogMode::IcuPo,
                 strict: false,
             })
             .map_err(|error| error.to_string())?;
@@ -369,9 +367,7 @@ fn bench_parse_catalog_ndjson(fixture: &Fixture, config: BenchConfig) -> Result<
                 content: &content,
                 locale,
                 source_locale: "en",
-                storage_format: CatalogStorageFormat::Ndjson,
-                semantics: CatalogSemantics::IcuNative,
-                plural_encoding: PluralEncoding::Icu,
+                mode: CatalogMode::IcuNdjson,
                 strict: false,
             })
             .map_err(|error| error.to_string())?;
@@ -576,12 +572,8 @@ fn bench_update_catalog(fixture: &MergeFixture, config: BenchConfig) -> Result<(
         for _ in 0..config.iterations {
             let rendered = update_catalog(UpdateCatalogOptions {
                 locale: Some("de"),
-                source_locale: "en",
-                input: fixture.api_extracted_messages().to_vec().into(),
                 existing: Some(fixture.existing_po()),
-                semantics: CatalogSemantics::IcuNative,
-                plural_encoding: PluralEncoding::Icu,
-                ..UpdateCatalogOptions::default()
+                ..UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
             })
             .map_err(|error| error.to_string())?;
             bytes += rendered.content.len();
@@ -620,12 +612,10 @@ fn bench_update_catalog_file(fixture: &MergeFixture, config: BenchConfig) -> Res
             fs::write(&path, fixture.existing_po()).map_err(|error| error.to_string())?;
             let rendered = update_catalog_file(UpdateCatalogFileOptions {
                 target_path: &path,
-                locale: Some("de"),
-                source_locale: "en",
-                input: fixture.api_extracted_messages().to_vec().into(),
-                semantics: CatalogSemantics::IcuNative,
-                plural_encoding: PluralEncoding::Icu,
-                ..UpdateCatalogFileOptions::default()
+                options: UpdateCatalogOptions {
+                    locale: Some("de"),
+                    ..UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
+                },
             })
             .map_err(|error| error.to_string())?;
             bytes += rendered.content.len();
@@ -671,13 +661,11 @@ fn bench_update_catalog_file_ndjson(
             fs::write(&path, &existing_ndjson).map_err(|error| error.to_string())?;
             let rendered = update_catalog_file(UpdateCatalogFileOptions {
                 target_path: &path,
-                locale: Some("de"),
-                source_locale: "en",
-                input: fixture.api_extracted_messages().to_vec().into(),
-                storage_format: CatalogStorageFormat::Ndjson,
-                semantics: CatalogSemantics::IcuNative,
-                plural_encoding: PluralEncoding::Icu,
-                ..UpdateCatalogFileOptions::default()
+                options: UpdateCatalogOptions {
+                    locale: Some("de"),
+                    mode: CatalogMode::IcuNdjson,
+                    ..UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
+                },
             })
             .map_err(|error| error.to_string())?;
             bytes += rendered.content.len();
@@ -719,9 +707,8 @@ fn bench_combine_catalogs(fixture: &MergeFixture, config: BenchConfig) -> Result
                 inputs: &inputs,
                 locale: Some("de"),
                 source_locale: "en",
-                semantics: CatalogSemantics::IcuNative,
-                plural_encoding: PluralEncoding::Icu,
-                ..CombineCatalogOptions::default()
+                mode: CatalogMode::IcuPo,
+                ..CombineCatalogOptions::new(&[], "en")
             })
             .map_err(|error| error.to_string())?;
             bytes += rendered.content.len();
@@ -1048,9 +1035,7 @@ fn merge_fixture_existing_ndjson(fixture: &MergeFixture) -> Result<String, Strin
         content: fixture.existing_po(),
         locale,
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
+        mode: CatalogMode::IcuPo,
         strict: false,
     })
     .map_err(|error| error.to_string())?;
@@ -1062,9 +1047,7 @@ fn fixture_parsed_catalog(fixture: &Fixture) -> Result<ParsedCatalog, String> {
         content: fixture.content(),
         locale: inferred_fixture_locale(fixture.name()),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
+        mode: CatalogMode::IcuPo,
         strict: false,
     })
     .map_err(|error| error.to_string())
@@ -1301,9 +1284,7 @@ const fn f64_from_usize(value: usize) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use ferrocat_po::{
-        CatalogSemantics, CatalogStorageFormat, ParseCatalogOptions, PluralEncoding, parse_catalog,
-    };
+    use ferrocat_po::{CatalogMode, ParseCatalogOptions, parse_catalog};
 
     use super::{
         fixture_by_name, fixture_ndjson_content, fixture_parsed_catalog, render_po_catalog,
@@ -1318,9 +1299,7 @@ mod tests {
             content: &ndjson,
             locale,
             source_locale: "en",
-            storage_format: CatalogStorageFormat::Ndjson,
-            semantics: CatalogSemantics::IcuNative,
-            plural_encoding: PluralEncoding::Icu,
+            mode: CatalogMode::IcuNdjson,
             strict: false,
         })
         .expect("parse NDJSON catalog");
@@ -1339,9 +1318,7 @@ mod tests {
             content: &rendered,
             locale: Some("de"),
             source_locale: "en",
-            storage_format: CatalogStorageFormat::Po,
-            semantics: CatalogSemantics::IcuNative,
-            plural_encoding: PluralEncoding::Icu,
+            mode: CatalogMode::IcuPo,
             strict: false,
         })
         .expect("reparse rendered PO");

--- a/crates/ferrocat-cli/src/main.rs
+++ b/crates/ferrocat-cli/src/main.rs
@@ -5,9 +5,8 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use ferrocat_po::{
-    CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary, CatalogStorageFormat,
-    DiagnosticSeverity, NormalizedParsedCatalog, ParseCatalogOptions, audit_catalogs,
-    parse_catalog,
+    CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary, CatalogMode, DiagnosticSeverity,
+    NormalizedParsedCatalog, ParseCatalogOptions, audit_catalogs, parse_catalog,
 };
 
 const EXIT_AUDIT_FAILED: u8 = 1;
@@ -249,10 +248,10 @@ impl CliStorageFormat {
         }
     }
 
-    const fn catalog_format(self) -> CatalogStorageFormat {
+    const fn catalog_mode(self) -> CatalogMode {
         match self {
-            Self::Po => CatalogStorageFormat::Po,
-            Self::Ndjson => CatalogStorageFormat::Ndjson,
+            Self::Po => CatalogMode::IcuPo,
+            Self::Ndjson => CatalogMode::IcuNdjson,
         }
     }
 }
@@ -386,8 +385,8 @@ fn load_catalog(
         content: &content,
         locale: Some(locale),
         source_locale,
-        storage_format: storage_format.catalog_format(),
-        ..ParseCatalogOptions::default()
+        mode: storage_format.catalog_mode(),
+        ..ParseCatalogOptions::new(&content, source_locale)
     })
     .and_then(ferrocat_po::ParsedCatalog::into_normalized_view)
     .map_err(|error| CliError::runtime(format!("failed to parse {}: {error}", path.display())))

--- a/crates/ferrocat-po/src/api.rs
+++ b/crates/ferrocat-po/src/api.rs
@@ -32,12 +32,13 @@ pub use self::ndjson::{
 pub use self::types::{
     ApiError, CatalogCombineInput, CatalogCombineResult, CatalogCombineSelection,
     CatalogCombineStats, CatalogConflictStrategy, CatalogMessage, CatalogMessageExtra,
-    CatalogMessageKey, CatalogOrigin, CatalogSemantics, CatalogStats, CatalogStorageFormat,
-    CatalogUpdateInput, CatalogUpdateResult, CombineCatalogOptions, Diagnostic, DiagnosticSeverity,
-    EffectiveTranslation, EffectiveTranslationRef, ExtractedMessage, ExtractedPluralMessage,
-    ExtractedSingularMessage, NormalizedParsedCatalog, ObsoleteStrategy, OrderBy,
-    ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode, PluralEncoding, PluralSource,
-    SourceExtractedMessage, TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions,
+    CatalogMessageKey, CatalogMode, CatalogOrigin, CatalogSemantics, CatalogStats,
+    CatalogStorageFormat, CatalogUpdateInput, CatalogUpdateResult, CombineCatalogOptions,
+    Diagnostic, DiagnosticSeverity, EffectiveTranslation, EffectiveTranslationRef,
+    ExtractedMessage, ExtractedPluralMessage, ExtractedSingularMessage, NormalizedParsedCatalog,
+    ObsoleteStrategy, OrderBy, ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode,
+    PluralEncoding, PluralSource, RenderOptions, SourceExtractedMessage, TranslationShape,
+    UpdateCatalogFileOptions, UpdateCatalogOptions,
 };
 
 fn validate_source_locale(source_locale: &str) -> Result<(), ApiError> {
@@ -49,37 +50,9 @@ fn validate_source_locale(source_locale: &str) -> Result<(), ApiError> {
     Ok(())
 }
 
-fn validate_catalog_semantics(
-    semantics: CatalogSemantics,
-    storage_format: CatalogStorageFormat,
-    plural_encoding: PluralEncoding,
-) -> Result<(), ApiError> {
-    match semantics {
-        CatalogSemantics::IcuNative if plural_encoding != PluralEncoding::Icu => {
-            Err(ApiError::InvalidArguments(
-                "CatalogSemantics::IcuNative requires PluralEncoding::Icu".to_owned(),
-            ))
-        }
-        CatalogSemantics::GettextCompat if plural_encoding != PluralEncoding::Gettext => {
-            Err(ApiError::InvalidArguments(
-                "CatalogSemantics::GettextCompat requires PluralEncoding::Gettext".to_owned(),
-            ))
-        }
-        CatalogSemantics::GettextCompat if storage_format == CatalogStorageFormat::Ndjson => {
-            Err(ApiError::Unsupported(
-                "CatalogSemantics::GettextCompat is not supported for NDJSON catalogs".to_owned(),
-            ))
-        }
-        _ => Ok(()),
-    }
-}
-
 #[cfg(test)]
 mod unit_tests {
-    use super::{
-        ApiError, CatalogSemantics, CatalogStorageFormat, PluralEncoding,
-        validate_catalog_semantics, validate_source_locale,
-    };
+    use super::{ApiError, validate_source_locale};
 
     #[test]
     fn validate_source_locale_rejects_empty_values() {
@@ -88,62 +61,6 @@ mod unit_tests {
         assert!(matches!(
             validate_source_locale(" \n\t "),
             Err(ApiError::InvalidArguments(message)) if message.contains("must not be empty")
-        ));
-    }
-
-    #[test]
-    fn validate_catalog_semantics_accepts_only_supported_combinations() {
-        assert!(
-            validate_catalog_semantics(
-                CatalogSemantics::IcuNative,
-                CatalogStorageFormat::Po,
-                PluralEncoding::Icu
-            )
-            .is_ok()
-        );
-        assert!(
-            validate_catalog_semantics(
-                CatalogSemantics::IcuNative,
-                CatalogStorageFormat::Ndjson,
-                PluralEncoding::Icu
-            )
-            .is_ok()
-        );
-        assert!(
-            validate_catalog_semantics(
-                CatalogSemantics::GettextCompat,
-                CatalogStorageFormat::Po,
-                PluralEncoding::Gettext
-            )
-            .is_ok()
-        );
-
-        assert!(matches!(
-            validate_catalog_semantics(
-                CatalogSemantics::IcuNative,
-                CatalogStorageFormat::Po,
-                PluralEncoding::Gettext
-            ),
-            Err(ApiError::InvalidArguments(message))
-                if message.contains("IcuNative requires PluralEncoding::Icu")
-        ));
-        assert!(matches!(
-            validate_catalog_semantics(
-                CatalogSemantics::GettextCompat,
-                CatalogStorageFormat::Po,
-                PluralEncoding::Icu
-            ),
-            Err(ApiError::InvalidArguments(message))
-                if message.contains("GettextCompat requires PluralEncoding::Gettext")
-        ));
-        assert!(matches!(
-            validate_catalog_semantics(
-                CatalogSemantics::GettextCompat,
-                CatalogStorageFormat::Ndjson,
-                PluralEncoding::Gettext
-            ),
-            Err(ApiError::Unsupported(message))
-                if message.contains("not supported for NDJSON")
         ));
     }
 }

--- a/crates/ferrocat-po/src/api/audit.rs
+++ b/crates/ferrocat-po/src/api/audit.rs
@@ -186,17 +186,13 @@ impl CatalogAuditReport {
 /// use ferrocat_po::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog};
 ///
 /// let source = parse_catalog(ParseCatalogOptions {
-///     content: "msgid \"Checkout\"\nmsgstr \"Checkout\"\n",
 ///     locale: Some("en"),
-///     source_locale: "en",
-///     ..ParseCatalogOptions::default()
+///     ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
 /// })?
 /// .into_normalized_view()?;
 /// let target = parse_catalog(ParseCatalogOptions {
-///     content: "msgid \"Checkout\"\nmsgstr \"\"\n",
 ///     locale: Some("de"),
-///     source_locale: "en",
-///     ..ParseCatalogOptions::default()
+///     ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"\"\n", "en")
 /// })?
 /// .into_normalized_view()?;
 ///

--- a/crates/ferrocat-po/src/api/catalog.rs
+++ b/crates/ferrocat-po/src/api/catalog.rs
@@ -30,8 +30,8 @@ use super::{
     CatalogMessageExtra, CatalogOrigin, CatalogSemantics, CatalogStats, CatalogStorageFormat,
     CatalogUpdateInput, CatalogUpdateResult, CombineCatalogOptions, Diagnostic, DiagnosticSeverity,
     EffectiveTranslationRef, ExtractedMessage, ObsoleteStrategy, OrderBy, ParseCatalogOptions,
-    ParsedCatalog, PlaceholderCommentMode, PluralEncoding, PluralSource, TranslationShape,
-    UpdateCatalogFileOptions, UpdateCatalogOptions,
+    ParsedCatalog, PlaceholderCommentMode, PluralEncoding, PluralSource, RenderOptions,
+    TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions,
 };
 use crate::{Header, MsgStr, PoFile, PoItem, SerializeOptions, parse_po, stringify_po};
 
@@ -124,17 +124,16 @@ struct MergeCatalogContext<'a> {
 ///
 /// ```rust
 /// use ferrocat_po::{
-///     CatalogUpdateInput, SourceExtractedMessage, UpdateCatalogOptions, update_catalog,
+///     CatalogMode, CatalogUpdateInput, SourceExtractedMessage, UpdateCatalogOptions, update_catalog,
 /// };
 ///
 /// let result = update_catalog(UpdateCatalogOptions {
-///     source_locale: "en",
 ///     locale: Some("de"),
 ///     input: CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
 ///         msgid: "Checkout".to_owned(),
 ///         ..SourceExtractedMessage::default()
 ///     }]),
-///     ..UpdateCatalogOptions::default()
+///     ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
 /// })?;
 ///
 /// assert!(result.created);
@@ -147,11 +146,6 @@ struct MergeCatalogContext<'a> {
 )]
 pub fn update_catalog(options: UpdateCatalogOptions<'_>) -> Result<CatalogUpdateResult, ApiError> {
     super::validate_source_locale(options.source_locale)?;
-    super::validate_catalog_semantics(
-        options.semantics,
-        options.storage_format,
-        options.plural_encoding,
-    )?;
 
     let created = options.existing.is_none();
     let original = options.existing.unwrap_or("");
@@ -160,10 +154,10 @@ pub fn update_catalog(options: UpdateCatalogOptions<'_>) -> Result<CatalogUpdate
             content,
             options.locale,
             options.source_locale,
-            options.semantics,
-            options.plural_encoding,
+            options.mode.semantics(),
+            options.mode.plural_encoding(),
             false,
-            options.storage_format,
+            options.mode.storage_format(),
         )?,
         Some(_) | None => Catalog {
             locale: options.locale.map(str::to_owned),
@@ -185,7 +179,7 @@ pub fn update_catalog(options: UpdateCatalogOptions<'_>) -> Result<CatalogUpdate
     let merge_context = MergeCatalogContext {
         locale: locale.as_deref(),
         source_locale: options.source_locale,
-        semantics: options.semantics,
+        semantics: options.mode.semantics(),
         overwrite_source_translations: options.overwrite_source_translations,
         obsolete_strategy: options.obsolete_strategy,
     };
@@ -193,7 +187,7 @@ pub fn update_catalog(options: UpdateCatalogOptions<'_>) -> Result<CatalogUpdate
         merge_catalogs(existing, &normalized, merge_context, &mut diagnostics);
     merged.locale.clone_from(&locale);
     apply_storage_defaults(&mut merged, &options, locale.as_deref(), &mut diagnostics)?;
-    sort_messages(&mut merged.messages, options.order_by);
+    sort_messages(&mut merged.messages, options.render.order_by);
     let content = export_catalog_content(&merged, &options, locale.as_deref(), &mut diagnostics)?;
 
     Ok(CatalogUpdateResult {
@@ -215,7 +209,7 @@ pub fn update_catalog(options: UpdateCatalogOptions<'_>) -> Result<CatalogUpdate
 pub fn update_catalog_file(
     options: UpdateCatalogFileOptions<'_>,
 ) -> Result<CatalogUpdateResult, ApiError> {
-    super::validate_source_locale(options.source_locale)?;
+    super::validate_source_locale(options.options.source_locale)?;
     if options.target_path.as_os_str().is_empty() {
         return Err(ApiError::InvalidArguments(
             "target_path must not be empty".to_owned(),
@@ -228,22 +222,9 @@ pub fn update_catalog_file(
         Err(error) => return Err(ApiError::io_with_path(options.target_path, error)),
     };
 
-    let result = update_catalog(UpdateCatalogOptions {
-        locale: options.locale,
-        source_locale: options.source_locale,
-        input: options.input,
-        existing: existing.as_deref(),
-        storage_format: options.storage_format,
-        semantics: options.semantics,
-        plural_encoding: options.plural_encoding,
-        obsolete_strategy: options.obsolete_strategy,
-        overwrite_source_translations: options.overwrite_source_translations,
-        order_by: options.order_by,
-        include_origins: options.include_origins,
-        include_line_numbers: options.include_line_numbers,
-        print_placeholders_in_comments: options.print_placeholders_in_comments,
-        custom_header_attributes: options.custom_header_attributes,
-    })?;
+    let mut update_options = options.options;
+    update_options.existing = existing.as_deref();
+    let result = update_catalog(update_options)?;
 
     if result.created || result.updated {
         atomic_write(options.target_path, &result.content)?;
@@ -291,11 +272,6 @@ pub fn combine_catalogs(
     options: CombineCatalogOptions<'_>,
 ) -> Result<CatalogCombineResult, ApiError> {
     super::validate_source_locale(options.source_locale)?;
-    super::validate_catalog_semantics(
-        options.semantics,
-        options.storage_format,
-        options.plural_encoding,
-    )?;
     if options.inputs.is_empty() {
         return Err(ApiError::InvalidArguments(
             "inputs must not be empty".to_owned(),
@@ -319,10 +295,10 @@ pub fn combine_catalogs(
             input.content,
             options.locale,
             options.source_locale,
-            options.semantics,
-            options.plural_encoding,
+            options.mode.semantics(),
+            options.mode.plural_encoding(),
             false,
-            options.storage_format,
+            options.mode.storage_format(),
         )?;
 
         if input_index == 0 {
@@ -532,12 +508,12 @@ fn apply_storage_defaults_for_combine(
     locale: Option<&str>,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<(), ApiError> {
-    match options.storage_format {
+    match options.mode.storage_format() {
         CatalogStorageFormat::Po => {
             apply_header_defaults(
                 &mut catalog.headers,
                 locale,
-                options.semantics,
+                options.mode.semantics(),
                 diagnostics,
                 &BTreeMap::new(),
             );
@@ -557,19 +533,16 @@ fn export_catalog_content_for_combine(
 ) -> Result<String, ApiError> {
     let export_options = UpdateCatalogOptions {
         locale: options.locale,
-        source_locale: options.source_locale,
-        input: CatalogUpdateInput::default(),
-        existing: None,
-        storage_format: options.storage_format,
-        semantics: options.semantics,
-        plural_encoding: options.plural_encoding,
+        mode: options.mode,
         obsolete_strategy: ObsoleteStrategy::Keep,
-        overwrite_source_translations: false,
-        order_by: options.order_by,
-        include_origins: options.include_origins,
-        include_line_numbers: options.include_line_numbers,
-        print_placeholders_in_comments: PlaceholderCommentMode::default(),
-        custom_header_attributes: None,
+        render: RenderOptions {
+            order_by: options.order_by,
+            include_origins: options.include_origins,
+            include_line_numbers: options.include_line_numbers,
+            print_placeholders_in_comments: PlaceholderCommentMode::default(),
+            custom_header_attributes: None,
+        },
+        ..UpdateCatalogOptions::new(options.source_locale, CatalogUpdateInput::default())
     };
     let mut diagnostics = Vec::new();
     export_catalog_content(catalog, &export_options, locale, &mut diagnostics)
@@ -589,10 +562,8 @@ fn export_catalog_content_for_combine(
 /// use ferrocat_po::{ParseCatalogOptions, parse_catalog};
 ///
 /// let catalog = parse_catalog(ParseCatalogOptions {
-///     content: "msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n",
 ///     locale: Some("de"),
-///     source_locale: "en",
-///     ..ParseCatalogOptions::default()
+///     ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
 /// })?;
 ///
 /// assert_eq!(catalog.locale.as_deref(), Some("de"));
@@ -605,19 +576,14 @@ fn export_catalog_content_for_combine(
 )]
 pub fn parse_catalog(options: ParseCatalogOptions<'_>) -> Result<ParsedCatalog, ApiError> {
     super::validate_source_locale(options.source_locale)?;
-    super::validate_catalog_semantics(
-        options.semantics,
-        options.storage_format,
-        options.plural_encoding,
-    )?;
     let catalog = parse_catalog_to_internal(
         options.content,
         options.locale,
         options.source_locale,
-        options.semantics,
-        options.plural_encoding,
+        options.mode.semantics(),
+        options.mode.plural_encoding(),
         options.strict,
-        options.storage_format,
+        options.mode.storage_format(),
     )?;
     let messages = catalog
         .messages
@@ -627,7 +593,7 @@ pub fn parse_catalog(options: ParseCatalogOptions<'_>) -> Result<ParsedCatalog, 
 
     Ok(ParsedCatalog {
         locale: catalog.locale,
-        semantics: options.semantics,
+        semantics: options.mode.semantics(),
         headers: catalog.headers,
         messages,
         diagnostics: catalog.diagnostics,
@@ -1028,15 +994,16 @@ fn apply_storage_defaults(
     locale: Option<&str>,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<(), ApiError> {
-    match options.storage_format {
+    match options.mode.storage_format() {
         CatalogStorageFormat::Po => {
             let empty_custom_headers = BTreeMap::new();
             apply_header_defaults(
                 &mut catalog.headers,
                 locale,
-                options.semantics,
+                options.mode.semantics(),
                 diagnostics,
                 options
+                    .render
                     .custom_header_attributes
                     .unwrap_or(&empty_custom_headers),
             );
@@ -1044,6 +1011,7 @@ fn apply_storage_defaults(
         }
         CatalogStorageFormat::Ndjson => {
             if options
+                .render
                 .custom_header_attributes
                 .is_some_and(|headers| !headers.is_empty())
             {
@@ -1063,7 +1031,7 @@ fn export_catalog_content(
     locale: Option<&str>,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<String, ApiError> {
-    match options.storage_format {
+    match options.mode.storage_format() {
         CatalogStorageFormat::Po => {
             let file = export_catalog_to_po(catalog, options, locale, diagnostics)?;
             Ok(stringify_po(&file, &SerializeOptions::default()))
@@ -1072,7 +1040,7 @@ fn export_catalog_content(
             catalog,
             locale,
             options.source_locale,
-            &options.print_placeholders_in_comments,
+            &options.render.print_placeholders_in_comments,
         )),
     }
 }
@@ -1130,7 +1098,7 @@ fn export_message_to_po(
             translation_by_category,
             variable,
         } => {
-            if options.semantics == CatalogSemantics::IcuNative {
+            if options.mode.semantics() == CatalogSemantics::IcuNative {
                 let mut item = base_po_item(message, options, 1);
                 item.msgid = synthesize_icu_plural(variable, &plural_source_branches(source));
                 item.msgstr =
@@ -1183,7 +1151,7 @@ fn base_po_item(
     append_placeholder_comments(
         &mut item.extracted_comments,
         &message.placeholders,
-        &options.print_placeholders_in_comments,
+        &options.render.print_placeholders_in_comments,
     );
     if let Some(metadata) = valid_machine_translation_metadata(message) {
         item.metadata.push((
@@ -1191,12 +1159,12 @@ fn base_po_item(
             format_po_machine_translation_metadata(metadata),
         ));
     }
-    item.references = if options.include_origins {
+    item.references = if options.render.include_origins {
         message
             .origins
             .iter()
             .map(|origin| {
-                if options.include_line_numbers {
+                if options.render.include_line_numbers {
                     origin.line.map_or_else(
                         || origin.file.clone(),
                         |line| format!("{}:{line}", origin.file),

--- a/crates/ferrocat-po/src/api/compile.rs
+++ b/crates/ferrocat-po/src/api/compile.rs
@@ -41,10 +41,8 @@ impl NormalizedParsedCatalog {
     /// use ferrocat_po::{CompileCatalogOptions, ParseCatalogOptions, parse_catalog};
     ///
     /// let parsed = parse_catalog(ParseCatalogOptions {
-    ///     content: "msgid \"Hello\"\nmsgstr \"Hallo\"\n",
-    ///     source_locale: "en",
     ///     locale: Some("de"),
-    ///     ..ParseCatalogOptions::default()
+    ///     ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
     /// })?;
     /// let normalized = parsed.into_normalized_view()?;
     /// let compiled = normalized.compile(&CompileCatalogOptions::default())?;
@@ -174,7 +172,7 @@ pub fn compile_catalog_artifact_selected(
     index: &CompiledCatalogIdIndex,
     options: &CompileSelectedCatalogArtifactOptions<'_>,
 ) -> Result<CompiledCatalogArtifact, ApiError> {
-    let artifact_options = options.artifact_options();
+    let artifact_options = &options.options;
     let locales = prepare_compiled_catalog_artifact_catalogs(
         catalogs,
         artifact_options.requested_locale,
@@ -200,7 +198,7 @@ pub fn compile_catalog_artifact_selected(
         source_keys.insert(source_key.clone());
     }
 
-    compile_catalog_artifact_from_source_keys(&locales, source_keys, &artifact_options)
+    compile_catalog_artifact_from_source_keys(&locales, source_keys, artifact_options)
 }
 
 fn compiled_translation_for_message(

--- a/crates/ferrocat-po/src/api/compile_types.rs
+++ b/crates/ferrocat-po/src/api/compile_types.rs
@@ -97,31 +97,22 @@ pub struct CompileCatalogArtifactOptions<'a> {
     pub semantics: CatalogSemantics,
 }
 
-impl Default for CompileCatalogArtifactOptions<'_> {
-    fn default() -> Self {
+impl<'a> CompileCatalogArtifactOptions<'a> {
+    /// Creates artifact compile options with required locales set.
+    ///
+    /// Optional fields use the same defaults that the previous `Default`
+    /// implementation provided.
+    #[must_use]
+    pub fn new(requested_locale: &'a str, source_locale: &'a str) -> Self {
         Self {
-            requested_locale: "",
-            source_locale: "",
+            requested_locale,
+            source_locale,
             fallback_chain: &[],
             key_strategy: CompiledKeyStrategy::FerrocatV1,
             source_fallback: false,
             strict_icu: false,
             icu_compatibility: false,
             semantics: CatalogSemantics::IcuNative,
-        }
-    }
-}
-
-impl<'a> CompileCatalogArtifactOptions<'a> {
-    /// Creates artifact compile options with required locales set.
-    ///
-    /// Optional fields use the same defaults as [`CompileCatalogArtifactOptions::default`].
-    #[must_use]
-    pub fn new(requested_locale: &'a str, source_locale: &'a str) -> Self {
-        Self {
-            requested_locale,
-            source_locale,
-            ..Self::default()
         }
     }
 }
@@ -129,46 +120,17 @@ impl<'a> CompileCatalogArtifactOptions<'a> {
 /// Options controlling selected-subset compiled catalog artifact generation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompileSelectedCatalogArtifactOptions<'a> {
-    /// Locale for which the runtime artifact should be produced.
-    pub requested_locale: &'a str,
-    /// Source locale used for explicit source fallback behavior.
-    pub source_locale: &'a str,
-    /// Ordered fallback locales consulted after the requested locale.
-    pub fallback_chain: &'a [String],
-    /// Built-in strategy used to derive stable runtime keys.
-    pub key_strategy: CompiledKeyStrategy,
-    /// Whether source text should be used when no non-source translation exists.
-    pub source_fallback: bool,
-    /// Whether invalid final ICU messages should fail compilation instead of producing diagnostics.
-    pub strict_icu: bool,
-    /// Whether final ICU messages should be checked against source ICU structure.
-    pub icu_compatibility: bool,
-    /// High-level semantics used by the input catalog set.
-    pub semantics: CatalogSemantics,
     /// Requested compiled runtime IDs to include in the artifact.
     pub compiled_ids: &'a [String],
-}
-
-impl Default for CompileSelectedCatalogArtifactOptions<'_> {
-    fn default() -> Self {
-        Self {
-            requested_locale: "",
-            source_locale: "",
-            fallback_chain: &[],
-            key_strategy: CompiledKeyStrategy::FerrocatV1,
-            source_fallback: false,
-            strict_icu: false,
-            icu_compatibility: false,
-            semantics: CatalogSemantics::IcuNative,
-            compiled_ids: &[],
-        }
-    }
+    /// Shared artifact compile options applied to the selected IDs.
+    pub options: CompileCatalogArtifactOptions<'a>,
 }
 
 impl<'a> CompileSelectedCatalogArtifactOptions<'a> {
     /// Creates selected artifact compile options with required locales and IDs set.
     ///
-    /// Optional fields use the same defaults as [`CompileSelectedCatalogArtifactOptions::default`].
+    /// Optional fields use the same defaults that the previous `Default`
+    /// implementation provided.
     #[must_use]
     pub fn new(
         requested_locale: &'a str,
@@ -176,23 +138,8 @@ impl<'a> CompileSelectedCatalogArtifactOptions<'a> {
         compiled_ids: &'a [String],
     ) -> Self {
         Self {
-            requested_locale,
-            source_locale,
             compiled_ids,
-            ..Self::default()
-        }
-    }
-
-    pub(super) fn artifact_options(&self) -> CompileCatalogArtifactOptions<'_> {
-        CompileCatalogArtifactOptions {
-            requested_locale: self.requested_locale,
-            source_locale: self.source_locale,
-            fallback_chain: self.fallback_chain,
-            key_strategy: self.key_strategy,
-            source_fallback: self.source_fallback,
-            strict_icu: self.strict_icu,
-            icu_compatibility: self.icu_compatibility,
-            semantics: self.semantics,
+            options: CompileCatalogArtifactOptions::new(requested_locale, source_locale),
         }
     }
 }
@@ -601,10 +548,13 @@ mod tests {
 
         let selected_ids = vec!["abc123".to_owned()];
         let selected = CompileSelectedCatalogArtifactOptions::new("de", "en", &selected_ids);
-        assert_eq!(selected.requested_locale, "de");
-        assert_eq!(selected.source_locale, "en");
+        assert_eq!(selected.options.requested_locale, "de");
+        assert_eq!(selected.options.source_locale, "en");
         assert_eq!(selected.compiled_ids, selected_ids.as_slice());
-        assert_eq!(selected.key_strategy, CompiledKeyStrategy::FerrocatV1);
+        assert_eq!(
+            selected.options.key_strategy,
+            CompiledKeyStrategy::FerrocatV1
+        );
     }
 
     #[cfg(feature = "serde")]

--- a/crates/ferrocat-po/src/api/tests/audit.rs
+++ b/crates/ferrocat-po/src/api/tests/audit.rs
@@ -4,19 +4,15 @@ use ferrocat_icu::{
 };
 
 use super::{
-    CatalogAuditOptions, CatalogSemantics, CatalogStorageFormat, DiagnosticSeverity,
-    ParseCatalogOptions, PluralEncoding, audit_catalogs, parse_catalog,
+    CatalogAuditOptions, CatalogMode, DiagnosticSeverity, ParseCatalogOptions, audit_catalogs,
+    parse_catalog,
 };
 
 fn catalog(content: &str, locale: &str) -> super::super::NormalizedParsedCatalog {
     parse_catalog(ParseCatalogOptions {
-        content,
-        source_locale: "en",
         locale: Some(locale),
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
-        ..ParseCatalogOptions::default()
+        mode: CatalogMode::IcuPo,
+        ..ParseCatalogOptions::new(content, "en")
     })
     .expect("parse catalog")
     .into_normalized_view()

--- a/crates/ferrocat-po/src/api/tests/catalog.rs
+++ b/crates/ferrocat-po/src/api/tests/catalog.rs
@@ -11,7 +11,7 @@ fn update_catalog_creates_new_source_locale_messages() {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -35,7 +35,7 @@ fn update_catalog_preserves_non_source_translations() {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -54,7 +54,7 @@ fn parse_catalog_reads_po_machine_translation_metadata() {
         content: &content,
         source_locale: "en",
         locale: Some("de"),
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect("parse");
 
@@ -83,7 +83,7 @@ fn update_catalog_keeps_valid_po_machine_translation_metadata() {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -112,7 +112,7 @@ fn update_catalog_drops_stale_po_machine_translation_metadata() {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -121,7 +121,7 @@ fn update_catalog_drops_stale_po_machine_translation_metadata() {
         content: existing,
         source_locale: "en",
         locale: Some("de"),
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect("parse stale metadata");
     assert!(parsed.messages[0].machine_translation.is_some());
@@ -137,7 +137,7 @@ fn parse_catalog_rejects_machine_translation_confidence_above_100() {
         ),
         source_locale: "en",
         locale: Some("de"),
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect_err("confidence above 100 should fail");
 
@@ -163,12 +163,12 @@ fn update_catalog_roundtrips_valid_ndjson_machine_translation_metadata() {
         source_locale: "en",
         locale: Some("de"),
         existing: Some(&existing),
-        storage_format: CatalogStorageFormat::Ndjson,
+        mode: CatalogMode::IcuNdjson,
         input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -198,12 +198,12 @@ fn update_catalog_drops_stale_ndjson_machine_translation_metadata() {
         source_locale: "en",
         locale: Some("de"),
         existing: Some(existing),
-        storage_format: CatalogStorageFormat::Ndjson,
+        mode: CatalogMode::IcuNdjson,
         input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -230,7 +230,7 @@ fn overwrite_source_translations_refreshes_source_locale() {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -251,7 +251,7 @@ fn obsolete_strategy_delete_removes_missing_messages() {
             msgid: "keep".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -271,7 +271,7 @@ fn obsolete_strategy_mark_marks_missing_active_messages() {
             msgid: "keep".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -304,7 +304,7 @@ fn duplicate_conflicts_fail_hard() {
                 ..ExtractedPluralMessage::default()
             }),
         ]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect_err("conflict");
 
@@ -325,7 +325,7 @@ fn plural_icu_export_uses_structural_input() {
             placeholders: BTreeMap::from([("count".to_owned(), vec!["count".to_owned()])]),
             ..ExtractedPluralMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -343,7 +343,7 @@ fn source_first_plain_messages_normalize_as_singular() {
             msgid: "Welcome".to_owned(),
             ..SourceExtractedMessage::default()
         }]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -363,7 +363,7 @@ fn source_first_simple_icu_plural_stays_singular_in_native_mode() {
             placeholders: BTreeMap::from([("items".to_owned(), vec!["items".to_owned()])]),
             ..SourceExtractedMessage::default()
         }]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -388,7 +388,7 @@ fn source_first_nested_icu_plural_stays_singular_without_projection_warning() {
             msgid: "{count, plural, one {{gender, select, male {He has one file} other {They have one file}}} other {{gender, select, male {He has # files} other {They have # files}}}}".to_owned(),
             ..SourceExtractedMessage::default()
         }]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -412,9 +412,7 @@ fn parse_catalog_projects_gettext_plural_into_structured_shape() {
         ),
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         strict: false,
     })
     .expect("parse");
@@ -448,9 +446,7 @@ fn normalized_view_indexes_messages_by_key() {
         ),
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         strict: false,
     })
     .expect("parse");
@@ -479,9 +475,7 @@ fn normalized_view_rejects_duplicate_keys() {
         ),
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         strict: false,
     })
     .expect("parse");
@@ -506,9 +500,7 @@ fn normalized_view_can_apply_source_locale_fallbacks() {
         ),
         locale: Some("en"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         strict: false,
     })
     .expect("parse");
@@ -541,9 +533,7 @@ fn normalized_view_skips_source_fallback_for_non_source_locale_catalogs() {
         content: concat!("msgid \"Hello\"\n", "msgstr \"\"\n"),
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         strict: false,
     })
     .expect("parse");
@@ -569,9 +559,7 @@ fn parse_catalog_uses_icu_plural_categories_for_french_gettext() {
         ),
         locale: Some("fr"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         strict: false,
     })
     .expect("parse");
@@ -607,9 +595,7 @@ fn parse_catalog_prefers_gettext_slot_count_when_it_disagrees_with_locale_catego
         ),
         locale: Some("fr"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         strict: false,
     })
     .expect("parse");
@@ -636,9 +622,7 @@ fn parse_catalog_reports_plural_forms_locale_mismatch() {
         ),
         locale: Some("fr"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         strict: false,
     })
     .expect("parse");
@@ -661,11 +645,8 @@ fn parse_catalog_accepts_safe_gettext_plural_forms_for_french() {
             "\"Plural-Forms: nplurals=2; plural=(n > 1);\\n\"\n",
         ),
         locale: Some("fr"),
-        source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
-        strict: false,
+        mode: CatalogMode::GettextPo,
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect("parse");
 
@@ -686,9 +667,7 @@ fn parse_catalog_keeps_simple_icu_plural_as_singular_in_native_mode() {
         ),
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
+        mode: CatalogMode::IcuPo,
         strict: false,
     })
     .expect("parse");
@@ -709,9 +688,7 @@ fn parse_catalog_keeps_nested_icu_plural_as_singular_without_projection_warning(
         ),
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
+        mode: CatalogMode::IcuPo,
         strict: false,
     })
     .expect("parse");
@@ -732,9 +709,7 @@ fn parse_catalog_strict_keeps_malformed_icu_plural_as_singular_in_native_mode() 
         ),
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
+        mode: CatalogMode::IcuPo,
         strict: true,
     })
     .expect("strict parse");
@@ -758,9 +733,7 @@ fn parse_catalog_ndjson_matches_po_semantics() {
         ),
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
+        mode: CatalogMode::IcuPo,
         strict: false,
     })
     .expect("parse po");
@@ -776,9 +749,7 @@ fn parse_catalog_ndjson_matches_po_semantics() {
         ),
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Ndjson,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
+        mode: CatalogMode::IcuNdjson,
         strict: false,
     })
     .expect("parse ndjson");
@@ -797,9 +768,8 @@ fn parse_catalog_ndjson_rejects_unknown_record_fields() {
             "---\n",
             "{\"id\":\"About us\",\"str\":\"Ueber uns\",\"oops\":true}\n",
         ),
-        source_locale: "en",
-        storage_format: CatalogStorageFormat::Ndjson,
-        ..ParseCatalogOptions::default()
+        mode: CatalogMode::IcuNdjson,
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect_err("unknown ndjson fields should fail");
 
@@ -819,9 +789,8 @@ fn parse_catalog_ndjson_rejects_source_locale_mismatch() {
             "---\n",
             "{\"id\":\"About us\",\"str\":\"Ueber uns\"}\n",
         ),
-        source_locale: "en",
-        storage_format: CatalogStorageFormat::Ndjson,
-        ..ParseCatalogOptions::default()
+        mode: CatalogMode::IcuNdjson,
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect_err("source locale mismatch should fail");
 
@@ -839,26 +808,28 @@ fn update_catalog_file_writes_only_when_changed() {
 
     let first = update_catalog_file(UpdateCatalogFileOptions {
         target_path: &path,
-        source_locale: "en",
-        locale: Some("en"),
-        input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
-            msgid: "Hello".to_owned(),
-            ..ExtractedSingularMessage::default()
-        })]),
-        ..UpdateCatalogFileOptions::default()
+        options: UpdateCatalogOptions {
+            locale: Some("en"),
+            input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
+                msgid: "Hello".to_owned(),
+                ..ExtractedSingularMessage::default()
+            })]),
+            ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
+        },
     })
     .expect("first write");
     assert!(first.created);
 
     let second = update_catalog_file(UpdateCatalogFileOptions {
         target_path: &path,
-        source_locale: "en",
-        locale: Some("en"),
-        input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
-            msgid: "Hello".to_owned(),
-            ..ExtractedSingularMessage::default()
-        })]),
-        ..UpdateCatalogFileOptions::default()
+        options: UpdateCatalogOptions {
+            locale: Some("en"),
+            input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
+                msgid: "Hello".to_owned(),
+                ..ExtractedSingularMessage::default()
+            })]),
+            ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
+        },
     })
     .expect("second write");
     assert!(!second.created);
@@ -875,13 +846,16 @@ fn update_catalog_file_read_error_includes_path_context() {
 
     let error = update_catalog_file(UpdateCatalogFileOptions {
         target_path: &temp_dir,
-        source_locale: "en",
-        locale: Some("en"),
-        input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
-            msgid: "Hello".to_owned(),
-            ..ExtractedSingularMessage::default()
-        })]),
-        ..UpdateCatalogFileOptions::default()
+        options: UpdateCatalogOptions {
+            locale: Some("en"),
+            ..UpdateCatalogOptions::new(
+                "en",
+                structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
+                    msgid: "Hello".to_owned(),
+                    ..ExtractedSingularMessage::default()
+                })]),
+            )
+        },
     })
     .expect_err("directory read should fail");
 
@@ -896,7 +870,7 @@ fn update_catalog_ndjson_renders_frontmatter_and_roundtrips() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("de"),
-        storage_format: CatalogStorageFormat::Ndjson,
+        mode: CatalogMode::IcuNdjson,
         input: structured_input(vec![
             ExtractedMessage::Singular(ExtractedSingularMessage {
                 msgid: "About us".to_owned(),
@@ -918,7 +892,7 @@ fn update_catalog_ndjson_renders_frontmatter_and_roundtrips() {
                 ..ExtractedPluralMessage::default()
             }),
         ]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update ndjson");
 
@@ -933,9 +907,7 @@ fn update_catalog_ndjson_renders_frontmatter_and_roundtrips() {
         content: &result.content,
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Ndjson,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
+        mode: CatalogMode::IcuNdjson,
         strict: false,
     })
     .expect("reparse ndjson");
@@ -957,28 +929,30 @@ fn update_catalog_file_ndjson_writes_only_when_changed() {
 
     let first = update_catalog_file(UpdateCatalogFileOptions {
         target_path: &path,
-        source_locale: "en",
-        locale: Some("en"),
-        storage_format: CatalogStorageFormat::Ndjson,
-        input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
-            msgid: "Hello".to_owned(),
-            ..ExtractedSingularMessage::default()
-        })]),
-        ..UpdateCatalogFileOptions::default()
+        options: UpdateCatalogOptions {
+            locale: Some("en"),
+            mode: CatalogMode::IcuNdjson,
+            input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
+                msgid: "Hello".to_owned(),
+                ..ExtractedSingularMessage::default()
+            })]),
+            ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
+        },
     })
     .expect("first ndjson write");
     assert!(first.created);
 
     let second = update_catalog_file(UpdateCatalogFileOptions {
         target_path: &path,
-        source_locale: "en",
-        locale: Some("en"),
-        storage_format: CatalogStorageFormat::Ndjson,
-        input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
-            msgid: "Hello".to_owned(),
-            ..ExtractedSingularMessage::default()
-        })]),
-        ..UpdateCatalogFileOptions::default()
+        options: UpdateCatalogOptions {
+            locale: Some("en"),
+            mode: CatalogMode::IcuNdjson,
+            input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
+                msgid: "Hello".to_owned(),
+                ..ExtractedSingularMessage::default()
+            })]),
+            ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
+        },
     })
     .expect("second ndjson write");
     assert!(!second.created);
@@ -995,8 +969,7 @@ fn update_catalog_gettext_export_emits_plural_slots() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("de"),
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         input: structured_input(vec![ExtractedMessage::Plural(ExtractedPluralMessage {
             msgid: "books".to_owned(),
             source: PluralSource {
@@ -1006,7 +979,7 @@ fn update_catalog_gettext_export_emits_plural_slots() {
             placeholders: BTreeMap::from([("count".to_owned(), vec!["count".to_owned()])]),
             ..ExtractedPluralMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -1021,8 +994,7 @@ fn update_catalog_gettext_export_uses_safe_plural_profile_for_french() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("fr"),
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         input: structured_input(vec![ExtractedMessage::Plural(ExtractedPluralMessage {
             msgid: "files".to_owned(),
             source: PluralSource {
@@ -1032,7 +1004,7 @@ fn update_catalog_gettext_export_uses_safe_plural_profile_for_french() {
             placeholders: BTreeMap::from([("count".to_owned(), vec!["count".to_owned()])]),
             ..ExtractedPluralMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -1051,13 +1023,12 @@ fn update_catalog_gettext_sets_safe_plural_forms_header_for_two_form_locale() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("de"),
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -1073,15 +1044,15 @@ fn update_catalog_gettext_sets_safe_plural_forms_header_for_two_form_locale() {
 #[test]
 fn update_catalog_gettext_sets_safe_plural_forms_header_for_multi_form_locale() {
     let result = update_catalog(UpdateCatalogOptions {
-        source_locale: "en",
         locale: Some("pl"),
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
-        input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
-            msgid: "Hello".to_owned(),
-            ..ExtractedSingularMessage::default()
-        })]),
-        ..UpdateCatalogOptions::default()
+        mode: CatalogMode::GettextPo,
+        ..UpdateCatalogOptions::new(
+            "en",
+            structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
+                msgid: "Hello".to_owned(),
+                ..ExtractedSingularMessage::default()
+            })]),
+        )
     })
     .expect("update");
 
@@ -1106,13 +1077,12 @@ fn update_catalog_gettext_reports_when_no_safe_plural_forms_header_is_known() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("ga"),
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
             msgid: "Bonjour".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -1129,8 +1099,7 @@ fn update_catalog_gettext_completes_partial_plural_forms_header_when_safe() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("de"),
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         existing: Some(concat!(
             "msgid \"\"\n",
             "msgstr \"\"\n",
@@ -1141,7 +1110,7 @@ fn update_catalog_gettext_completes_partial_plural_forms_header_when_safe() {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -1166,8 +1135,7 @@ fn update_catalog_gettext_preserves_existing_complete_plural_forms_header() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("de"),
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         existing: Some(concat!(
             "msgid \"\"\n",
             "msgstr \"\"\n",
@@ -1178,7 +1146,7 @@ fn update_catalog_gettext_preserves_existing_complete_plural_forms_header() {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -1210,8 +1178,7 @@ fn update_catalog_gettext_preserves_previous_plural_variable_and_translations() 
         source_locale: "en",
         locale: Some("de"),
         existing: Some(existing),
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         input: structured_input(vec![ExtractedMessage::Plural(ExtractedPluralMessage {
             msgid: "books".to_owned(),
             source: PluralSource {
@@ -1220,7 +1187,7 @@ fn update_catalog_gettext_preserves_previous_plural_variable_and_translations() 
             },
             ..ExtractedPluralMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -1228,9 +1195,7 @@ fn update_catalog_gettext_preserves_previous_plural_variable_and_translations() 
         content: &result.content,
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         strict: false,
     })
     .expect("parse updated catalog");
@@ -1262,12 +1227,15 @@ fn update_catalog_applies_custom_header_attributes() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("de"),
-        custom_header_attributes: Some(&headers),
+        render: RenderOptions {
+            custom_header_attributes: Some(&headers),
+            ..RenderOptions::default()
+        },
         input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 
@@ -1299,7 +1267,7 @@ fn update_catalog_rejects_empty_extracted_msgid() {
             msgid: String::new(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect_err("empty msgid should fail");
 
@@ -1336,7 +1304,7 @@ fn update_catalog_merges_duplicate_source_first_metadata() {
                 ..SourceExtractedMessage::default()
             },
         ]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("merge duplicates");
 
@@ -1367,7 +1335,7 @@ fn update_catalog_obsolete_keep_reactivates_missing_messages() {
         existing: Some(existing),
         obsolete_strategy: ObsoleteStrategy::Keep,
         input: structured_input(Vec::new()),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("keep obsolete");
 
@@ -1382,9 +1350,12 @@ fn update_catalog_origin_sort_and_placeholder_options_are_applied() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("en"),
-        order_by: OrderBy::Origin,
-        include_line_numbers: false,
-        print_placeholders_in_comments: PlaceholderCommentMode::Enabled { limit: 1 },
+        render: RenderOptions {
+            order_by: OrderBy::Origin,
+            include_line_numbers: false,
+            print_placeholders_in_comments: PlaceholderCommentMode::Enabled { limit: 1 },
+            ..RenderOptions::default()
+        },
         input: structured_input(vec![
             ExtractedMessage::Singular(ExtractedSingularMessage {
                 msgid: "Second".to_owned(),
@@ -1407,7 +1378,7 @@ fn update_catalog_origin_sort_and_placeholder_options_are_applied() {
                 ..ExtractedSingularMessage::default()
             }),
         ]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update with origin sort");
 
@@ -1423,13 +1394,16 @@ fn update_catalog_origin_sort_and_placeholder_options_are_applied() {
     let without_placeholders = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("en"),
-        print_placeholders_in_comments: PlaceholderCommentMode::Disabled,
+        render: RenderOptions {
+            print_placeholders_in_comments: PlaceholderCommentMode::Disabled,
+            ..RenderOptions::default()
+        },
         input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
             msgid: "Hello".to_owned(),
             placeholders: BTreeMap::from([("name".to_owned(), vec!["name".to_owned()])]),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update without placeholder comments");
     assert!(!without_placeholders.content.contains("placeholder"));
@@ -1442,13 +1416,16 @@ fn update_catalog_ndjson_rejects_custom_header_attributes() {
     let error = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("en"),
-        storage_format: CatalogStorageFormat::Ndjson,
-        custom_header_attributes: Some(&headers),
+        mode: CatalogMode::IcuNdjson,
+        render: RenderOptions {
+            custom_header_attributes: Some(&headers),
+            ..RenderOptions::default()
+        },
         input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
             msgid: "Hello".to_owned(),
             ..ExtractedSingularMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect_err("custom ndjson headers should fail");
 
@@ -1459,9 +1436,7 @@ fn update_catalog_ndjson_rejects_custom_header_attributes() {
 fn update_catalog_file_rejects_empty_target_path() {
     let error = update_catalog_file(UpdateCatalogFileOptions {
         target_path: std::path::Path::new(""),
-        source_locale: "en",
-        input: structured_input(Vec::new()),
-        ..UpdateCatalogFileOptions::default()
+        options: UpdateCatalogOptions::new("en", structured_input(Vec::new())),
     })
     .expect_err("empty path should fail");
 
@@ -1481,9 +1456,7 @@ fn parse_catalog_rejects_classic_plural_shape_in_native_mode() {
         ),
         locale: Some("en"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
+        mode: CatalogMode::IcuPo,
         strict: false,
     })
     .expect_err("classic plural should fail in native mode");
@@ -1497,9 +1470,7 @@ fn parse_catalog_rejects_classic_plural_shape_in_native_mode() {
         ),
         locale: Some("en"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
+        mode: CatalogMode::IcuPo,
         strict: false,
     })
     .expect_err("plural msgstr should fail in native mode");
@@ -1517,9 +1488,7 @@ fn parse_catalog_reports_plural_expression_without_nplurals() {
         ),
         locale: Some("de"),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
+        mode: CatalogMode::GettextPo,
         strict: false,
     })
     .expect("parse");
@@ -1551,7 +1520,7 @@ fn combine_catalogs_use_first_preserves_existing_translations_and_adds_missing()
         inputs: &inputs,
         source_locale: "en",
         locale: Some("de"),
-        ..CombineCatalogOptions::default()
+        ..CombineCatalogOptions::new(&[], "en")
     })
     .expect("combine");
 
@@ -1582,7 +1551,7 @@ fn combine_catalogs_use_last_overlays_conflicting_translation() {
         source_locale: "en",
         locale: Some("de"),
         conflict_strategy: CatalogConflictStrategy::UseLast,
-        ..CombineCatalogOptions::default()
+        ..CombineCatalogOptions::new(&[], "en")
     })
     .expect("combine");
 
@@ -1607,7 +1576,7 @@ fn combine_catalogs_error_rejects_conflicting_translation() {
         source_locale: "en",
         locale: Some("de"),
         conflict_strategy: CatalogConflictStrategy::Error,
-        ..CombineCatalogOptions::default()
+        ..CombineCatalogOptions::new(&[], "en")
     })
     .expect_err("conflict");
 
@@ -1638,7 +1607,7 @@ fn combine_catalogs_selection_rules_filter_by_definition_count() {
         source_locale: "en",
         locale: Some("de"),
         selection: CatalogCombineSelection::Unique,
-        ..CombineCatalogOptions::default()
+        ..CombineCatalogOptions::new(&[], "en")
     })
     .expect("unique combine");
     let unique = parse_po(&unique.content).expect("parse unique");
@@ -1650,7 +1619,7 @@ fn combine_catalogs_selection_rules_filter_by_definition_count() {
         source_locale: "en",
         locale: Some("de"),
         selection: CatalogCombineSelection::MoreThan(1),
-        ..CombineCatalogOptions::default()
+        ..CombineCatalogOptions::new(&[], "en")
     })
     .expect("common combine");
     let common = parse_po(&common.content).expect("parse common");
@@ -1662,7 +1631,7 @@ fn combine_catalogs_selection_rules_filter_by_definition_count() {
         source_locale: "en",
         locale: Some("de"),
         selection: CatalogCombineSelection::LessThan(2),
-        ..CombineCatalogOptions::default()
+        ..CombineCatalogOptions::new(&[], "en")
     })
     .expect("less-than combine");
     let less_than_two = parse_po(&less_than_two.content).expect("parse less-than");
@@ -1696,7 +1665,7 @@ fn combine_catalogs_treats_contexts_as_distinct_identities() {
         inputs: &inputs,
         source_locale: "en",
         locale: Some("de"),
-        ..CombineCatalogOptions::default()
+        ..CombineCatalogOptions::new(&[], "en")
     })
     .expect("combine");
 
@@ -1724,9 +1693,8 @@ fn combine_catalogs_rejects_singular_plural_shape_conflicts() {
         inputs: &inputs,
         source_locale: "en",
         locale: Some("de"),
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
-        ..CombineCatalogOptions::default()
+        mode: CatalogMode::GettextPo,
+        ..CombineCatalogOptions::new(&[], "en")
     })
     .expect_err("shape conflict");
 
@@ -1746,7 +1714,7 @@ fn combine_catalogs_skips_obsolete_by_default_and_can_include_them() {
         inputs: &inputs,
         source_locale: "en",
         locale: Some("de"),
-        ..CombineCatalogOptions::default()
+        ..CombineCatalogOptions::new(&[], "en")
     })
     .expect("combine without obsolete");
     let skipped = parse_po(&skipped.content).expect("parse skipped");
@@ -1758,7 +1726,7 @@ fn combine_catalogs_skips_obsolete_by_default_and_can_include_them() {
         source_locale: "en",
         locale: Some("de"),
         include_obsolete: true,
-        ..CombineCatalogOptions::default()
+        ..CombineCatalogOptions::new(&[], "en")
     })
     .expect("combine with obsolete");
     let included = parse_po(&included.content).expect("parse included");
@@ -1792,9 +1760,8 @@ fn combine_catalogs_gettext_compat_preserves_plural_slots() {
         inputs: &inputs,
         source_locale: "en",
         locale: Some("de"),
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
-        ..CombineCatalogOptions::default()
+        mode: CatalogMode::GettextPo,
+        ..CombineCatalogOptions::new(&[], "en")
     })
     .expect("combine");
 
@@ -1810,7 +1777,7 @@ fn parse_catalog_requires_source_locale() {
     let error = parse_catalog(ParseCatalogOptions {
         content: "",
         source_locale: "",
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect_err("missing source locale");
 
@@ -1840,7 +1807,7 @@ fn warnings_use_expected_namespace() {
             placeholders,
             ..ExtractedPluralMessage::default()
         })]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })
     .expect("update");
 

--- a/crates/ferrocat-po/src/api/tests/compile.rs
+++ b/crates/ferrocat-po/src/api/tests/compile.rs
@@ -71,20 +71,12 @@ fn compile_catalog_artifact_matches_between_po_and_ndjson_storage() {
 
     let po_artifact = compile_catalog_artifact(
         &[&po_requested, &source],
-        &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            ..CompileCatalogArtifactOptions::default()
-        },
+        &CompileCatalogArtifactOptions::new("de", "en"),
     )
     .expect("compile po artifact");
     let ndjson_artifact = compile_catalog_artifact(
         &[&ndjson_requested, &source],
-        &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            ..CompileCatalogArtifactOptions::default()
-        },
+        &CompileCatalogArtifactOptions::new("de", "en"),
     )
     .expect("compile ndjson artifact");
 
@@ -289,11 +281,7 @@ fn compile_catalog_artifact_returns_requested_locale_message_map() {
 
     let artifact = compile_catalog_artifact(
         &[&requested, &source],
-        &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            ..CompileCatalogArtifactOptions::default()
-        },
+        &CompileCatalogArtifactOptions::new("de", "en"),
     )
     .expect("compile artifact");
 
@@ -330,11 +318,7 @@ fn compile_catalog_artifact_synthesizes_plural_icu_strings() {
 
     let artifact = compile_catalog_artifact(
         &[&requested, &source],
-        &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            ..CompileCatalogArtifactOptions::default()
-        },
+        &CompileCatalogArtifactOptions::new("de", "en"),
     )
     .expect("compile artifact");
 
@@ -374,11 +358,9 @@ fn compile_catalog_artifact_uses_fallback_chain_before_source_locale() {
     let artifact = compile_catalog_artifact(
         &[&requested, &first_fallback, &second_fallback, &source],
         &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
             fallback_chain: &["fr".to_owned(), "it".to_owned()],
             source_fallback: true,
-            ..CompileCatalogArtifactOptions::default()
+            ..CompileCatalogArtifactOptions::new("de", "en")
         },
     )
     .expect("compile artifact");
@@ -410,11 +392,7 @@ fn compile_catalog_artifact_reports_missing_message_without_source_fallback() {
 
     let artifact = compile_catalog_artifact(
         &[&requested, &source],
-        &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            ..CompileCatalogArtifactOptions::default()
-        },
+        &CompileCatalogArtifactOptions::new("de", "en"),
     )
     .expect("compile artifact");
 
@@ -443,10 +421,8 @@ fn compile_catalog_artifact_can_fill_from_source_locale_when_enabled() {
     let artifact = compile_catalog_artifact(
         &[&requested, &source],
         &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
             source_fallback: true,
-            ..CompileCatalogArtifactOptions::default()
+            ..CompileCatalogArtifactOptions::new("de", "en")
         },
     )
     .expect("compile artifact");
@@ -471,15 +447,9 @@ fn compile_catalog_artifact_materializes_empty_source_locale_messages() {
         PluralEncoding::Icu,
     );
 
-    let artifact = compile_catalog_artifact(
-        &[&source],
-        &CompileCatalogArtifactOptions {
-            requested_locale: "en",
-            source_locale: "en",
-            ..CompileCatalogArtifactOptions::default()
-        },
-    )
-    .expect("compile artifact");
+    let artifact =
+        compile_catalog_artifact(&[&source], &CompileCatalogArtifactOptions::new("en", "en"))
+            .expect("compile artifact");
 
     let key = compiled_key_for(
         CompiledKeyStrategy::FerrocatV1,
@@ -503,11 +473,7 @@ fn compile_catalog_artifact_skips_obsolete_messages() {
 
     let artifact = compile_catalog_artifact(
         &[&requested, &source],
-        &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            ..CompileCatalogArtifactOptions::default()
-        },
+        &CompileCatalogArtifactOptions::new("de", "en"),
     )
     .expect("compile artifact");
 
@@ -531,10 +497,8 @@ fn compile_catalog_artifact_requires_requested_and_unique_catalog_locales() {
     let missing_requested = compile_catalog_artifact(
         &[&source],
         &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
             semantics: CatalogSemantics::GettextCompat,
-            ..CompileCatalogArtifactOptions::default()
+            ..CompileCatalogArtifactOptions::new("de", "en")
         },
     )
     .expect_err("missing requested locale");
@@ -542,11 +506,7 @@ fn compile_catalog_artifact_requires_requested_and_unique_catalog_locales() {
 
     let duplicate_locale = compile_catalog_artifact(
         &[&source, &duplicate],
-        &CompileCatalogArtifactOptions {
-            requested_locale: "en",
-            source_locale: "en",
-            ..CompileCatalogArtifactOptions::default()
-        },
+        &CompileCatalogArtifactOptions::new("en", "en"),
     )
     .expect_err("duplicate locale");
     assert!(matches!(duplicate_locale, ApiError::InvalidArguments(_)));
@@ -572,10 +532,8 @@ fn compile_catalog_artifact_rejects_invalid_locale_sets_and_fallback_chains() {
     let no_locale = parse_catalog(ParseCatalogOptions {
         content: "msgid \"Hello\"\nmsgstr \"Hallo\"\n",
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
-        ..ParseCatalogOptions::default()
+        mode: CatalogMode::IcuPo,
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect("parse no-locale catalog")
     .into_normalized_view()
@@ -584,90 +542,57 @@ fn compile_catalog_artifact_rejects_invalid_locale_sets_and_fallback_chains() {
         content: "msgid \"Hello\"\nmsgstr \"Hallo\"\n",
         locale: Some("  "),
         source_locale: "en",
-        storage_format: CatalogStorageFormat::Po,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
-        ..ParseCatalogOptions::default()
+        mode: CatalogMode::IcuPo,
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect("parse empty-locale catalog")
     .into_normalized_view()
     .expect("normalize empty-locale catalog");
 
     let cases = [
-        (
-            Vec::new(),
-            CompileCatalogArtifactOptions {
-                requested_locale: "de",
-                source_locale: "en",
-                ..CompileCatalogArtifactOptions::default()
-            },
-        ),
+        (Vec::new(), CompileCatalogArtifactOptions::new("de", "en")),
         (
             vec![&requested, &source],
-            CompileCatalogArtifactOptions {
-                requested_locale: "",
-                source_locale: "en",
-                ..CompileCatalogArtifactOptions::default()
-            },
+            CompileCatalogArtifactOptions::new("", "en"),
         ),
         (
             vec![&no_locale],
-            CompileCatalogArtifactOptions {
-                requested_locale: "de",
-                source_locale: "en",
-                ..CompileCatalogArtifactOptions::default()
-            },
+            CompileCatalogArtifactOptions::new("de", "en"),
         ),
         (
             vec![&empty_locale],
-            CompileCatalogArtifactOptions {
-                requested_locale: "de",
-                source_locale: "en",
-                ..CompileCatalogArtifactOptions::default()
-            },
+            CompileCatalogArtifactOptions::new("de", "en"),
         ),
         (
             vec![&requested],
-            CompileCatalogArtifactOptions {
-                requested_locale: "de",
-                source_locale: "en",
-                ..CompileCatalogArtifactOptions::default()
-            },
+            CompileCatalogArtifactOptions::new("de", "en"),
         ),
         (
             vec![&requested, &source],
             CompileCatalogArtifactOptions {
-                requested_locale: "de",
-                source_locale: "en",
                 fallback_chain: &["de".to_owned()],
-                ..CompileCatalogArtifactOptions::default()
+                ..CompileCatalogArtifactOptions::new("de", "en")
             },
         ),
         (
             vec![&requested, &source],
             CompileCatalogArtifactOptions {
-                requested_locale: "de",
-                source_locale: "en",
                 fallback_chain: &["en".to_owned()],
-                ..CompileCatalogArtifactOptions::default()
+                ..CompileCatalogArtifactOptions::new("de", "en")
             },
         ),
         (
             vec![&requested, &source, &fallback],
             CompileCatalogArtifactOptions {
-                requested_locale: "de",
-                source_locale: "en",
                 fallback_chain: &["de-AT".to_owned(), "de-AT".to_owned()],
-                ..CompileCatalogArtifactOptions::default()
+                ..CompileCatalogArtifactOptions::new("de", "en")
             },
         ),
         (
             vec![&requested, &source],
             CompileCatalogArtifactOptions {
-                requested_locale: "de",
-                source_locale: "en",
                 fallback_chain: &["fr".to_owned()],
-                ..CompileCatalogArtifactOptions::default()
+                ..CompileCatalogArtifactOptions::new("de", "en")
             },
         ),
     ];
@@ -694,10 +619,8 @@ fn compile_catalog_artifact_collects_or_raises_invalid_icu_messages() {
     let artifact = compile_catalog_artifact(
         &[&requested, &source],
         &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
             semantics: CatalogSemantics::GettextCompat,
-            ..CompileCatalogArtifactOptions::default()
+            ..CompileCatalogArtifactOptions::new("de", "en")
         },
     )
     .expect("compile artifact");
@@ -707,11 +630,9 @@ fn compile_catalog_artifact_collects_or_raises_invalid_icu_messages() {
     let error = compile_catalog_artifact(
         &[&requested, &source],
         &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
             strict_icu: true,
             semantics: CatalogSemantics::GettextCompat,
-            ..CompileCatalogArtifactOptions::default()
+            ..CompileCatalogArtifactOptions::new("de", "en")
         },
     )
     .expect_err("strict invalid icu should fail");
@@ -733,11 +654,7 @@ fn compile_catalog_artifact_icu_compatibility_is_optional() {
 
     let default_artifact = compile_catalog_artifact(
         &[&requested, &source],
-        &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            ..CompileCatalogArtifactOptions::default()
-        },
+        &CompileCatalogArtifactOptions::new("de", "en"),
     )
     .expect("compile default artifact");
     assert!(default_artifact.diagnostics.is_empty());
@@ -745,10 +662,8 @@ fn compile_catalog_artifact_icu_compatibility_is_optional() {
     let checked_artifact = compile_catalog_artifact(
         &[&requested, &source],
         &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
             icu_compatibility: true,
-            ..CompileCatalogArtifactOptions::default()
+            ..CompileCatalogArtifactOptions::new("de", "en")
         },
     )
     .expect("compile checked artifact");
@@ -783,11 +698,11 @@ fn compile_catalog_artifact_selected_uses_icu_compatibility_diagnostics() {
         &[&requested, &source],
         &index,
         &CompileSelectedCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
             compiled_ids: &compiled_ids,
-            icu_compatibility: true,
-            ..CompileSelectedCatalogArtifactOptions::default()
+            options: CompileCatalogArtifactOptions {
+                icu_compatibility: true,
+                ..CompileCatalogArtifactOptions::new("de", "en")
+            },
         },
     )
     .expect("compile selected artifact");
@@ -822,11 +737,9 @@ fn strict_icu_remains_a_hard_syntax_error_with_compatibility_enabled() {
     let error = compile_catalog_artifact(
         &[&requested, &source],
         &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
             strict_icu: true,
             icu_compatibility: true,
-            ..CompileCatalogArtifactOptions::default()
+            ..CompileCatalogArtifactOptions::new("de", "en")
         },
     )
     .expect_err("strict syntax failure");
@@ -1066,12 +979,11 @@ fn compile_catalog_artifact_selected_returns_only_requested_ids() {
     let artifact = compile_catalog_artifact_selected(
         &[&requested, &source],
         &index,
-        &CompileSelectedCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            compiled_ids: &[hello_id.clone(), hello_id.clone()],
-            ..CompileSelectedCatalogArtifactOptions::default()
-        },
+        &CompileSelectedCatalogArtifactOptions::new(
+            "de",
+            "en",
+            &[hello_id.clone(), hello_id.clone()],
+        ),
     )
     .expect("compile selected artifact");
 
@@ -1103,12 +1015,7 @@ fn compile_catalog_artifact_selected_reports_unknown_compiled_ids() {
     let error = compile_catalog_artifact_selected(
         &[&requested, &source],
         &index,
-        &CompileSelectedCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            compiled_ids: &["missing-id".to_owned()],
-            ..CompileSelectedCatalogArtifactOptions::default()
-        },
+        &CompileSelectedCatalogArtifactOptions::new("de", "en", &["missing-id".to_owned()]),
     )
     .expect_err("unknown compiled id");
 
@@ -1139,12 +1046,7 @@ fn compile_catalog_artifact_selected_rejects_ids_absent_from_catalog_set() {
     let error = compile_catalog_artifact_selected(
         &[&requested, &source],
         &index,
-        &CompileSelectedCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            compiled_ids: &[hello_id],
-            ..CompileSelectedCatalogArtifactOptions::default()
-        },
+        &CompileSelectedCatalogArtifactOptions::new("de", "en", &[hello_id]),
     )
     .expect_err("compiled id absent from provided catalogs");
 
@@ -1192,12 +1094,12 @@ fn compile_catalog_artifact_selected_preserves_fallback_and_validation_semantics
         &[&requested, &source],
         &index,
         &CompileSelectedCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            source_fallback: true,
-            semantics: CatalogSemantics::GettextCompat,
             compiled_ids: &[hello_id.clone(), broken_id.clone()],
-            ..CompileSelectedCatalogArtifactOptions::default()
+            options: CompileCatalogArtifactOptions {
+                source_fallback: true,
+                semantics: CatalogSemantics::GettextCompat,
+                ..CompileCatalogArtifactOptions::new("de", "en")
+            },
         },
     )
     .expect("compile selected artifact");

--- a/crates/ferrocat-po/src/api/tests/mod.rs
+++ b/crates/ferrocat-po/src/api/tests/mod.rs
@@ -1,15 +1,15 @@
 pub(super) use super::{
     ApiError, CatalogAuditOptions, CatalogCombineInput, CatalogCombineSelection,
-    CatalogConflictStrategy, CatalogMessageKey, CatalogOrigin, CatalogSemantics,
-    CatalogStorageFormat, CatalogUpdateInput, CombineCatalogOptions, CompileCatalogArtifactOptions,
+    CatalogConflictStrategy, CatalogMessageKey, CatalogMode, CatalogOrigin, CatalogSemantics,
+    CatalogUpdateInput, CombineCatalogOptions, CompileCatalogArtifactOptions,
     CompileCatalogOptions, CompileSelectedCatalogArtifactOptions, CompiledCatalogIdIndex,
     CompiledCatalogTranslationKind, CompiledKeyStrategy, CompiledTranslation, DiagnosticSeverity,
     EffectiveTranslation, EffectiveTranslationRef, ExtractedMessage, ExtractedPluralMessage,
     ExtractedSingularMessage, ObsoleteStrategy, OrderBy, ParseCatalogOptions,
-    PlaceholderCommentMode, PluralEncoding, PluralSource, SourceExtractedMessage, TranslationShape,
-    UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs, combine_catalogs,
-    compile::compiled_key_for, compile_catalog_artifact, compile_catalog_artifact_selected,
-    compiled_key, machine_translation_hash, parse_catalog,
+    PlaceholderCommentMode, PluralEncoding, PluralSource, RenderOptions, SourceExtractedMessage,
+    TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs,
+    combine_catalogs, compile::compiled_key_for, compile_catalog_artifact,
+    compile_catalog_artifact_selected, compiled_key, machine_translation_hash, parse_catalog,
     plural::cached_icu_plural_categories_for, update_catalog, update_catalog_file,
 };
 pub(super) use crate::parse_po;
@@ -35,18 +35,14 @@ pub(super) fn normalized_catalog(
     locale: Option<&str>,
     plural_encoding: PluralEncoding,
 ) -> super::NormalizedParsedCatalog {
-    let semantics = match plural_encoding {
-        PluralEncoding::Icu => CatalogSemantics::IcuNative,
-        PluralEncoding::Gettext => CatalogSemantics::GettextCompat,
+    let mode = match plural_encoding {
+        PluralEncoding::Icu => CatalogMode::IcuPo,
+        PluralEncoding::Gettext => CatalogMode::GettextPo,
     };
     parse_catalog(ParseCatalogOptions {
-        content,
-        source_locale: "en",
         locale,
-        storage_format: CatalogStorageFormat::Po,
-        semantics,
-        plural_encoding,
-        ..ParseCatalogOptions::default()
+        mode,
+        ..ParseCatalogOptions::new(content, "en")
     })
     .expect("parse catalog")
     .into_normalized_view()
@@ -58,13 +54,9 @@ pub(super) fn normalized_ndjson_catalog(
     locale: Option<&str>,
 ) -> super::NormalizedParsedCatalog {
     parse_catalog(ParseCatalogOptions {
-        content,
-        source_locale: "en",
         locale,
-        storage_format: CatalogStorageFormat::Ndjson,
-        semantics: CatalogSemantics::IcuNative,
-        plural_encoding: PluralEncoding::Icu,
-        ..ParseCatalogOptions::default()
+        mode: CatalogMode::IcuNdjson,
+        ..ParseCatalogOptions::new(content, "en")
     })
     .expect("parse ndjson catalog")
     .into_normalized_view()

--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -663,6 +663,76 @@ pub enum CatalogSemantics {
     GettextCompat,
 }
 
+/// Valid high-level catalog mode combinations.
+///
+/// This type groups the storage format, semantic model, and plural encoding
+/// choices that must be kept in sync for catalog parse, update, and combine
+/// operations. It is non-exhaustive so future supported catalog modes can be
+/// added without breaking downstream matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum CatalogMode {
+    /// Gettext PO storage with ICU-native message semantics.
+    #[default]
+    IcuPo,
+    /// NDJSON storage with ICU-native message semantics.
+    IcuNdjson,
+    /// Gettext PO storage with classic gettext plural semantics.
+    GettextPo,
+}
+
+impl CatalogMode {
+    /// Returns the storage format implied by this mode.
+    #[must_use]
+    pub const fn storage_format(self) -> CatalogStorageFormat {
+        match self {
+            Self::IcuPo | Self::GettextPo => CatalogStorageFormat::Po,
+            Self::IcuNdjson => CatalogStorageFormat::Ndjson,
+        }
+    }
+
+    /// Returns the catalog semantics implied by this mode.
+    #[must_use]
+    pub const fn semantics(self) -> CatalogSemantics {
+        match self {
+            Self::IcuPo | Self::IcuNdjson => CatalogSemantics::IcuNative,
+            Self::GettextPo => CatalogSemantics::GettextCompat,
+        }
+    }
+
+    /// Returns the plural encoding implied by this mode.
+    #[must_use]
+    pub const fn plural_encoding(self) -> PluralEncoding {
+        match self {
+            Self::IcuPo | Self::IcuNdjson => PluralEncoding::Icu,
+            Self::GettextPo => PluralEncoding::Gettext,
+        }
+    }
+
+    /// Returns the matching catalog mode for explicit parts.
+    #[must_use]
+    pub const fn from_parts(
+        storage_format: CatalogStorageFormat,
+        semantics: CatalogSemantics,
+        plural_encoding: PluralEncoding,
+    ) -> Option<Self> {
+        match (storage_format, semantics, plural_encoding) {
+            (CatalogStorageFormat::Po, CatalogSemantics::IcuNative, PluralEncoding::Icu) => {
+                Some(Self::IcuPo)
+            }
+            (CatalogStorageFormat::Ndjson, CatalogSemantics::IcuNative, PluralEncoding::Icu) => {
+                Some(Self::IcuNdjson)
+            }
+            (
+                CatalogStorageFormat::Po,
+                CatalogSemantics::GettextCompat,
+                PluralEncoding::Gettext,
+            ) => Some(Self::GettextPo),
+            _ => None,
+        }
+    }
+}
+
 /// Strategy used for messages that disappear from the extracted input.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ObsoleteStrategy {
@@ -703,6 +773,36 @@ impl Default for PlaceholderCommentMode {
     }
 }
 
+/// Shared rendering options for catalog serialization.
+///
+/// These fields control how a catalog is sorted and which optional reference and
+/// placeholder details are written, independent of storage format or semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderOptions<'a> {
+    /// Sort order for the final rendered catalog.
+    pub order_by: OrderBy,
+    /// Whether source origins should be rendered as references.
+    pub include_origins: bool,
+    /// Whether rendered references should include line numbers.
+    pub include_line_numbers: bool,
+    /// Controls emission of placeholder comments.
+    pub print_placeholders_in_comments: PlaceholderCommentMode,
+    /// Optional additional header attributes to inject or override.
+    pub custom_header_attributes: Option<&'a BTreeMap<String, String>>,
+}
+
+impl Default for RenderOptions<'_> {
+    fn default() -> Self {
+        Self {
+            order_by: OrderBy::Msgid,
+            include_origins: true,
+            include_line_numbers: true,
+            print_placeholders_in_comments: PlaceholderCommentMode::Enabled { limit: 3 },
+            custom_header_attributes: None,
+        }
+    }
+}
+
 /// Options for in-memory catalog updates.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdateCatalogOptions<'a> {
@@ -714,59 +814,32 @@ pub struct UpdateCatalogOptions<'a> {
     pub input: CatalogUpdateInput,
     /// Existing catalog content, when updating an in-memory catalog.
     pub existing: Option<&'a str>,
-    /// Storage format used when reading existing content and rendering the result.
-    pub storage_format: CatalogStorageFormat,
-    /// High-level semantics used when parsing, merging, and rendering the catalog.
-    pub semantics: CatalogSemantics,
-    /// Target plural representation for the rendered PO file.
-    pub plural_encoding: PluralEncoding,
+    /// High-level catalog mode used when parsing, merging, and rendering the catalog.
+    pub mode: CatalogMode,
     /// Strategy for messages absent from the extracted input.
     pub obsolete_strategy: ObsoleteStrategy,
     /// Whether source-locale translations should be refreshed from the extracted source strings.
     pub overwrite_source_translations: bool,
-    /// Sort order for the final rendered catalog.
-    pub order_by: OrderBy,
-    /// Whether source origins should be rendered as references.
-    pub include_origins: bool,
-    /// Whether rendered references should include line numbers.
-    pub include_line_numbers: bool,
-    /// Controls emission of placeholder comments.
-    pub print_placeholders_in_comments: PlaceholderCommentMode,
-    /// Optional additional header attributes to inject or override.
-    pub custom_header_attributes: Option<&'a BTreeMap<String, String>>,
-}
-
-impl Default for UpdateCatalogOptions<'_> {
-    fn default() -> Self {
-        Self {
-            locale: None,
-            source_locale: "",
-            input: CatalogUpdateInput::default(),
-            existing: None,
-            storage_format: CatalogStorageFormat::Po,
-            semantics: CatalogSemantics::IcuNative,
-            plural_encoding: PluralEncoding::Icu,
-            obsolete_strategy: ObsoleteStrategy::Mark,
-            overwrite_source_translations: false,
-            order_by: OrderBy::Msgid,
-            include_origins: true,
-            include_line_numbers: true,
-            print_placeholders_in_comments: PlaceholderCommentMode::Enabled { limit: 3 },
-            custom_header_attributes: None,
-        }
-    }
+    /// Shared serialization options for the rendered catalog.
+    pub render: RenderOptions<'a>,
 }
 
 impl<'a> UpdateCatalogOptions<'a> {
     /// Creates in-memory update options with required fields set.
     ///
-    /// Optional fields use the same defaults as [`UpdateCatalogOptions::default`].
+    /// Optional fields use the same defaults that the previous `Default`
+    /// implementation provided.
     #[must_use]
     pub fn new(source_locale: &'a str, input: impl Into<CatalogUpdateInput>) -> Self {
         Self {
+            locale: None,
             source_locale,
             input: input.into(),
-            ..Self::default()
+            existing: None,
+            mode: CatalogMode::default(),
+            obsolete_strategy: ObsoleteStrategy::Mark,
+            overwrite_source_translations: false,
+            render: RenderOptions::default(),
         }
     }
 }
@@ -776,59 +849,15 @@ impl<'a> UpdateCatalogOptions<'a> {
 pub struct UpdateCatalogFileOptions<'a> {
     /// Path to the catalog file that should be read and conditionally written.
     pub target_path: &'a Path,
-    /// Locale of the catalog being updated. When `None`, Ferrocat infers it from the existing file.
-    pub locale: Option<&'a str>,
-    /// Source locale used for source-side semantics and fallback handling.
-    pub source_locale: &'a str,
-    /// Extracted messages to merge into the catalog.
-    pub input: CatalogUpdateInput,
-    /// Storage format used when reading and writing the file content.
-    pub storage_format: CatalogStorageFormat,
-    /// High-level semantics used when parsing, merging, and rendering the catalog.
-    pub semantics: CatalogSemantics,
-    /// Target plural representation for the rendered PO file.
-    pub plural_encoding: PluralEncoding,
-    /// Strategy for messages absent from the extracted input.
-    pub obsolete_strategy: ObsoleteStrategy,
-    /// Whether source-locale translations should be refreshed from the extracted source strings.
-    pub overwrite_source_translations: bool,
-    /// Sort order for the final rendered catalog.
-    pub order_by: OrderBy,
-    /// Whether source origins should be rendered as references.
-    pub include_origins: bool,
-    /// Whether rendered references should include line numbers.
-    pub include_line_numbers: bool,
-    /// Controls emission of placeholder comments.
-    pub print_placeholders_in_comments: PlaceholderCommentMode,
-    /// Optional additional header attributes to inject or override.
-    pub custom_header_attributes: Option<&'a BTreeMap<String, String>>,
-}
-
-impl Default for UpdateCatalogFileOptions<'_> {
-    fn default() -> Self {
-        Self {
-            target_path: Path::new(""),
-            locale: None,
-            source_locale: "",
-            input: CatalogUpdateInput::default(),
-            storage_format: CatalogStorageFormat::Po,
-            semantics: CatalogSemantics::IcuNative,
-            plural_encoding: PluralEncoding::Icu,
-            obsolete_strategy: ObsoleteStrategy::Mark,
-            overwrite_source_translations: false,
-            order_by: OrderBy::Msgid,
-            include_origins: true,
-            include_line_numbers: true,
-            print_placeholders_in_comments: PlaceholderCommentMode::Enabled { limit: 3 },
-            custom_header_attributes: None,
-        }
-    }
+    /// In-memory update options applied to the file content.
+    pub options: UpdateCatalogOptions<'a>,
 }
 
 impl<'a> UpdateCatalogFileOptions<'a> {
     /// Creates file update options with required fields set.
     ///
-    /// Optional fields use the same defaults as [`UpdateCatalogFileOptions::default`].
+    /// Optional fields use the same defaults that the previous `Default`
+    /// implementation provided.
     #[must_use]
     pub fn new(
         target_path: &'a Path,
@@ -837,9 +866,7 @@ impl<'a> UpdateCatalogFileOptions<'a> {
     ) -> Self {
         Self {
             target_path,
-            source_locale,
-            input: input.into(),
-            ..Self::default()
+            options: UpdateCatalogOptions::new(source_locale, input),
         }
     }
 }
@@ -853,12 +880,8 @@ pub struct CombineCatalogOptions<'a> {
     pub locale: Option<&'a str>,
     /// Source locale used for source-side semantics and validation.
     pub source_locale: &'a str,
-    /// Storage format used when reading inputs and rendering the result.
-    pub storage_format: CatalogStorageFormat,
-    /// High-level semantics used when parsing, combining, and rendering catalogs.
-    pub semantics: CatalogSemantics,
-    /// Target plural representation for the rendered PO file.
-    pub plural_encoding: PluralEncoding,
+    /// High-level catalog mode used when reading inputs and rendering the result.
+    pub mode: CatalogMode,
     /// Strategy for resolving conflicting non-empty translations.
     pub conflict_strategy: CatalogConflictStrategy,
     /// Message identity selection rule applied after all inputs are read.
@@ -873,35 +896,24 @@ pub struct CombineCatalogOptions<'a> {
     pub include_obsolete: bool,
 }
 
-impl Default for CombineCatalogOptions<'_> {
-    fn default() -> Self {
+impl<'a> CombineCatalogOptions<'a> {
+    /// Creates combine options with required fields set.
+    ///
+    /// Optional fields use the same defaults that the previous `Default`
+    /// implementation provided.
+    #[must_use]
+    pub fn new(inputs: &'a [CatalogCombineInput<'a>], source_locale: &'a str) -> Self {
         Self {
-            inputs: &[],
+            inputs,
             locale: None,
-            source_locale: "",
-            storage_format: CatalogStorageFormat::Po,
-            semantics: CatalogSemantics::IcuNative,
-            plural_encoding: PluralEncoding::Icu,
+            source_locale,
+            mode: CatalogMode::default(),
             conflict_strategy: CatalogConflictStrategy::UseFirst,
             selection: CatalogCombineSelection::All,
             order_by: OrderBy::Msgid,
             include_origins: true,
             include_line_numbers: true,
             include_obsolete: false,
-        }
-    }
-}
-
-impl<'a> CombineCatalogOptions<'a> {
-    /// Creates combine options with required fields set.
-    ///
-    /// Optional fields use the same defaults as [`CombineCatalogOptions::default`].
-    #[must_use]
-    pub fn new(inputs: &'a [CatalogCombineInput<'a>], source_locale: &'a str) -> Self {
-        Self {
-            inputs,
-            source_locale,
-            ..Self::default()
         }
     }
 }
@@ -915,40 +927,25 @@ pub struct ParseCatalogOptions<'a> {
     pub locale: Option<&'a str>,
     /// Source locale used for source-side semantics and validation.
     pub source_locale: &'a str,
-    /// Storage format used when parsing the content.
-    pub storage_format: CatalogStorageFormat,
-    /// High-level semantics used when interpreting catalog content.
-    pub semantics: CatalogSemantics,
-    /// Target plural interpretation for the resulting catalog view.
-    pub plural_encoding: PluralEncoding,
+    /// High-level catalog mode used when interpreting catalog content.
+    pub mode: CatalogMode,
     /// Whether unsupported ICU plural projection cases should become hard errors.
     pub strict: bool,
-}
-
-impl Default for ParseCatalogOptions<'_> {
-    fn default() -> Self {
-        Self {
-            content: "",
-            locale: None,
-            source_locale: "",
-            storage_format: CatalogStorageFormat::Po,
-            semantics: CatalogSemantics::IcuNative,
-            plural_encoding: PluralEncoding::Icu,
-            strict: false,
-        }
-    }
 }
 
 impl<'a> ParseCatalogOptions<'a> {
     /// Creates parse options with required fields set.
     ///
-    /// Optional fields use the same defaults as [`ParseCatalogOptions::default`].
+    /// Optional fields use the same defaults that the previous `Default`
+    /// implementation provided.
     #[must_use]
     pub fn new(content: &'a str, source_locale: &'a str) -> Self {
         Self {
             content,
+            locale: None,
             source_locale,
-            ..Self::default()
+            mode: CatalogMode::default(),
+            strict: false,
         }
     }
 }
@@ -1068,7 +1065,7 @@ mod tests {
 
     use super::{
         ApiError, CatalogCombineInput, CatalogCombineSelection, CatalogConflictStrategy,
-        CatalogMessage, CatalogMessageExtra, CatalogMessageKey, CatalogSemantics,
+        CatalogMessage, CatalogMessageExtra, CatalogMessageKey, CatalogMode, CatalogSemantics,
         CatalogStorageFormat, CatalogUpdateInput, CombineCatalogOptions, Diagnostic,
         DiagnosticSeverity, EffectiveTranslation, EffectiveTranslationRef, NormalizedParsedCatalog,
         ObsoleteStrategy, OrderBy, ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode,
@@ -1235,51 +1232,40 @@ mod tests {
 
     #[test]
     fn option_defaults_reflect_native_po_defaults() {
-        let update = UpdateCatalogOptions::default();
-        assert_eq!(update.storage_format, CatalogStorageFormat::Po);
-        assert_eq!(update.semantics, CatalogSemantics::IcuNative);
-        assert_eq!(update.plural_encoding, PluralEncoding::Icu);
+        let update = UpdateCatalogOptions::new("en", Vec::<super::ExtractedMessage>::new());
+        assert_eq!(update.mode, CatalogMode::IcuPo);
         assert_eq!(update.obsolete_strategy, ObsoleteStrategy::Mark);
-        assert_eq!(update.order_by, OrderBy::Msgid);
-        assert!(update.include_origins);
-        assert!(update.include_line_numbers);
+        assert_eq!(update.render.order_by, OrderBy::Msgid);
+        assert!(update.render.include_origins);
+        assert!(update.render.include_line_numbers);
         assert_eq!(
-            update.print_placeholders_in_comments,
+            update.render.print_placeholders_in_comments,
             PlaceholderCommentMode::Enabled { limit: 3 }
         );
-        let update_new = UpdateCatalogOptions::new("en", Vec::<super::ExtractedMessage>::new());
-        assert_eq!(update_new.source_locale, "en");
+        assert_eq!(update.source_locale, "en");
         assert!(matches!(
-            update_new.input,
+            update.input,
             CatalogUpdateInput::Structured(messages) if messages.is_empty()
         ));
 
-        let update_file = UpdateCatalogFileOptions::default();
-        assert_eq!(update_file.target_path, Path::new(""));
-        assert_eq!(update_file.storage_format, CatalogStorageFormat::Po);
-        assert_eq!(update_file.semantics, CatalogSemantics::IcuNative);
-        assert_eq!(update_file.plural_encoding, PluralEncoding::Icu);
-        let update_file_new = UpdateCatalogFileOptions::new(
+        let update_file = UpdateCatalogFileOptions::new(
             Path::new("locale/de.po"),
             "en",
             Vec::<super::SourceExtractedMessage>::new(),
         );
-        assert_eq!(update_file_new.target_path, Path::new("locale/de.po"));
-        assert_eq!(update_file_new.source_locale, "en");
+        assert_eq!(update_file.target_path, Path::new("locale/de.po"));
+        assert_eq!(update_file.options.mode, CatalogMode::IcuPo);
+        assert_eq!(update_file.options.source_locale, "en");
         assert!(matches!(
-            update_file_new.input,
+            update_file.options.input,
             CatalogUpdateInput::SourceFirst(messages) if messages.is_empty()
         ));
 
-        let parse = ParseCatalogOptions::default();
-        assert_eq!(parse.storage_format, CatalogStorageFormat::Po);
-        assert_eq!(parse.semantics, CatalogSemantics::IcuNative);
-        assert_eq!(parse.plural_encoding, PluralEncoding::Icu);
+        let parse = ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en");
+        assert_eq!(parse.content, "msgid \"Hello\"\nmsgstr \"Hallo\"\n");
+        assert_eq!(parse.source_locale, "en");
+        assert_eq!(parse.mode, CatalogMode::IcuPo);
         assert!(!parse.strict);
-        let parse_new = ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en");
-        assert_eq!(parse_new.content, "msgid \"Hello\"\nmsgstr \"Hallo\"\n");
-        assert_eq!(parse_new.source_locale, "en");
-        assert_eq!(parse_new.storage_format, CatalogStorageFormat::Po);
 
         let inputs = [CatalogCombineInput::labeled(
             "msgid \"Hello\"\nmsgstr \"Hallo\"\n",
@@ -1288,11 +1274,61 @@ mod tests {
         let combine = CombineCatalogOptions::new(&inputs, "en");
         assert_eq!(combine.inputs, &inputs);
         assert_eq!(combine.source_locale, "en");
+        assert_eq!(combine.mode, CatalogMode::IcuPo);
         assert_eq!(combine.conflict_strategy, CatalogConflictStrategy::UseFirst);
         assert_eq!(combine.selection, CatalogCombineSelection::All);
         assert!(combine.include_origins);
         assert!(combine.include_line_numbers);
         assert!(!combine.include_obsolete);
+    }
+
+    #[test]
+    fn catalog_mode_maps_only_supported_catalog_combinations() {
+        assert_eq!(CatalogMode::default(), CatalogMode::IcuPo);
+        assert_eq!(
+            CatalogMode::IcuPo.storage_format(),
+            CatalogStorageFormat::Po
+        );
+        assert_eq!(CatalogMode::IcuPo.semantics(), CatalogSemantics::IcuNative);
+        assert_eq!(CatalogMode::IcuPo.plural_encoding(), PluralEncoding::Icu);
+
+        assert_eq!(
+            CatalogMode::from_parts(
+                CatalogStorageFormat::Ndjson,
+                CatalogSemantics::IcuNative,
+                PluralEncoding::Icu
+            ),
+            Some(CatalogMode::IcuNdjson)
+        );
+        assert_eq!(
+            CatalogMode::from_parts(
+                CatalogStorageFormat::Po,
+                CatalogSemantics::GettextCompat,
+                PluralEncoding::Gettext
+            ),
+            Some(CatalogMode::GettextPo)
+        );
+        assert_eq!(
+            CatalogMode::from_parts(
+                CatalogStorageFormat::Ndjson,
+                CatalogSemantics::GettextCompat,
+                PluralEncoding::Gettext
+            ),
+            None
+        );
+        assert_eq!(
+            CatalogMode::from_parts(
+                CatalogStorageFormat::Po,
+                CatalogSemantics::IcuNative,
+                PluralEncoding::Icu
+            ),
+            Some(CatalogMode::IcuPo)
+        );
+        let update = UpdateCatalogOptions {
+            mode: CatalogMode::GettextPo,
+            ..UpdateCatalogOptions::new("en", Vec::<super::SourceExtractedMessage>::new())
+        };
+        assert_eq!(update.mode, CatalogMode::GettextPo);
     }
 
     #[test]

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -26,17 +26,13 @@
 //! };
 //!
 //! let source = parse_catalog(ParseCatalogOptions {
-//!     content: "msgid \"Hello\"\nmsgstr \"Hello\"\n",
-//!     source_locale: "en",
 //!     locale: Some("en"),
-//!     ..ParseCatalogOptions::default()
+//!     ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en")
 //! })?
 //! .into_normalized_view()?;
 //! let requested = parse_catalog(ParseCatalogOptions {
-//!     content: "msgid \"Hello\"\nmsgstr \"Hallo\"\n",
-//!     source_locale: "en",
 //!     locale: Some("de"),
-//!     ..ParseCatalogOptions::default()
+//!     ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
 //! })?
 //! .into_normalized_view()?;
 //! let index = CompiledCatalogIdIndex::new(&[&requested, &source], ferrocat_po::CompiledKeyStrategy::FerrocatV1)?;
@@ -44,12 +40,7 @@
 //! let compiled = compile_catalog_artifact_selected(
 //!     &[&requested, &source],
 //!     &index,
-//!     &CompileSelectedCatalogArtifactOptions {
-//!         requested_locale: "de",
-//!         source_locale: "en",
-//!         compiled_ids: &compiled_ids,
-//!         ..CompileSelectedCatalogArtifactOptions::default()
-//!     },
+//!     &CompileSelectedCatalogArtifactOptions::new("de", "en", &compiled_ids),
 //! )?;
 //!
 //! assert_eq!(compiled.messages.len(), 1);
@@ -60,17 +51,13 @@
 //! use ferrocat_po::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog};
 //!
 //! let source = parse_catalog(ParseCatalogOptions {
-//!     content: "msgid \"Hello {name}\"\nmsgstr \"Hello {name}\"\n",
-//!     source_locale: "en",
 //!     locale: Some("en"),
-//!     ..ParseCatalogOptions::default()
+//!     ..ParseCatalogOptions::new("msgid \"Hello {name}\"\nmsgstr \"Hello {name}\"\n", "en")
 //! })?
 //! .into_normalized_view()?;
 //! let target = parse_catalog(ParseCatalogOptions {
-//!     content: "msgid \"Hello {name}\"\nmsgstr \"Hallo\"\n",
-//!     source_locale: "en",
 //!     locale: Some("de"),
-//!     ..ParseCatalogOptions::default()
+//!     ..ParseCatalogOptions::new("msgid \"Hello {name}\"\nmsgstr \"Hallo\"\n", "en")
 //! })?
 //! .into_normalized_view()?;
 //! let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
@@ -95,21 +82,22 @@ pub use api::{
     ApiError, COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION, CatalogAuditChecks, CatalogAuditDiagnostic,
     CatalogAuditMessageRef, CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary,
     CatalogCombineInput, CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats,
-    CatalogConflictStrategy, CatalogMessage, CatalogMessageExtra, CatalogMessageKey, CatalogOrigin,
-    CatalogSemantics, CatalogStats, CatalogStorageFormat, CatalogUpdateInput, CatalogUpdateResult,
-    CombineCatalogOptions, CompileCatalogArtifactOptions, CompileCatalogOptions,
-    CompileSelectedCatalogArtifactOptions, CompiledCatalog, CompiledCatalogArtifact,
-    CompiledCatalogDiagnostic, CompiledCatalogIdDescription, CompiledCatalogIdIndex,
-    CompiledCatalogMissingMessage, CompiledCatalogTranslationKind, CompiledCatalogUnavailableId,
-    CompiledKeyStrategy, CompiledMessage, CompiledTranslation, DescribeCompiledIdsReport,
-    Diagnostic, DiagnosticSeverity, EffectiveTranslation, EffectiveTranslationRef,
-    ExtractedMessage, ExtractedPluralMessage, ExtractedSingularMessage, MachineTranslationMetadata,
-    NdjsonCatalogReader, NdjsonCatalogReaderOptions, NdjsonCatalogWriter,
-    NdjsonCatalogWriterOptions, NormalizedParsedCatalog, ObsoleteStrategy, OrderBy,
-    ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode, PluralEncoding, PluralSource,
-    SourceExtractedMessage, TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions,
-    audit_catalogs, combine_catalogs, compile_catalog_artifact, compile_catalog_artifact_selected,
-    compiled_key, machine_translation_hash, parse_catalog, update_catalog, update_catalog_file,
+    CatalogConflictStrategy, CatalogMessage, CatalogMessageExtra, CatalogMessageKey, CatalogMode,
+    CatalogOrigin, CatalogSemantics, CatalogStats, CatalogStorageFormat, CatalogUpdateInput,
+    CatalogUpdateResult, CombineCatalogOptions, CompileCatalogArtifactOptions,
+    CompileCatalogOptions, CompileSelectedCatalogArtifactOptions, CompiledCatalog,
+    CompiledCatalogArtifact, CompiledCatalogDiagnostic, CompiledCatalogIdDescription,
+    CompiledCatalogIdIndex, CompiledCatalogMissingMessage, CompiledCatalogTranslationKind,
+    CompiledCatalogUnavailableId, CompiledKeyStrategy, CompiledMessage, CompiledTranslation,
+    DescribeCompiledIdsReport, Diagnostic, DiagnosticSeverity, EffectiveTranslation,
+    EffectiveTranslationRef, ExtractedMessage, ExtractedPluralMessage, ExtractedSingularMessage,
+    MachineTranslationMetadata, NdjsonCatalogReader, NdjsonCatalogReaderOptions,
+    NdjsonCatalogWriter, NdjsonCatalogWriterOptions, NormalizedParsedCatalog, ObsoleteStrategy,
+    OrderBy, ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode, PluralEncoding,
+    PluralSource, RenderOptions, SourceExtractedMessage, TranslationShape,
+    UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs, combine_catalogs,
+    compile_catalog_artifact, compile_catalog_artifact_selected, compiled_key,
+    machine_translation_hash, parse_catalog, update_catalog, update_catalog_file,
 };
 pub use borrowed::{
     BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, parse_po_borrowed,

--- a/crates/ferrocat-po/tests/property_po.rs
+++ b/crates/ferrocat-po/tests/property_po.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use ferrocat_po::{
-    CatalogSemantics, CatalogStorageFormat, ParseCatalogOptions, PluralEncoding, SerializeOptions,
-    parse_catalog, parse_po, parse_po_borrowed, stringify_po,
+    CatalogMode, ParseCatalogOptions, SerializeOptions, parse_catalog, parse_po, parse_po_borrowed,
+    stringify_po,
 };
 use proptest::prelude::*;
 
@@ -79,20 +79,14 @@ proptest! {
         let po = parse_catalog(ParseCatalogOptions {
             content: &render_po(&entries),
             locale: Some("de"),
-            source_locale: "en",
-            storage_format: CatalogStorageFormat::Po,
-            semantics: CatalogSemantics::IcuNative,
-            plural_encoding: PluralEncoding::Icu,
-            ..ParseCatalogOptions::default()
+            mode: CatalogMode::IcuPo,
+            ..ParseCatalogOptions::new("", "en")
         })
         .expect("generated PO catalog should parse");
         let ndjson = parse_catalog(ParseCatalogOptions {
             content: &render_ndjson(&entries),
-            source_locale: "en",
-            storage_format: CatalogStorageFormat::Ndjson,
-            semantics: CatalogSemantics::IcuNative,
-            plural_encoding: PluralEncoding::Icu,
-            ..ParseCatalogOptions::default()
+            mode: CatalogMode::IcuNdjson,
+            ..ParseCatalogOptions::new("", "en")
         })
         .expect("generated NDJSON catalog should parse");
 

--- a/crates/ferrocat/examples/ndjson_with_mt_metadata.rs
+++ b/crates/ferrocat/examples/ndjson_with_mt_metadata.rs
@@ -1,5 +1,5 @@
 use ferrocat::{
-    CatalogStorageFormat, CatalogUpdateInput, EffectiveTranslationRef, SourceExtractedMessage,
+    CatalogMode, CatalogUpdateInput, EffectiveTranslationRef, SourceExtractedMessage,
     UpdateCatalogOptions, machine_translation_hash, update_catalog,
 };
 
@@ -19,14 +19,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let result = update_catalog(UpdateCatalogOptions {
         locale: Some("de"),
-        source_locale: "en",
-        storage_format: CatalogStorageFormat::Ndjson,
+        mode: CatalogMode::IcuNdjson,
         existing: Some(&existing),
         input: CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
             msgid: "Hello".to_owned(),
             ..SourceExtractedMessage::default()
         }]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })?;
 
     assert!(result.content.contains("format: ferrocat.ndjson.v1"));

--- a/crates/ferrocat/examples/release_audit.rs
+++ b/crates/ferrocat/examples/release_audit.rs
@@ -8,7 +8,7 @@ fn catalog(
         content,
         locale: Some(locale),
         source_locale: "en",
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("", "en")
     })?
     .into_normalized_view()?)
 }

--- a/crates/ferrocat/examples/runtime_compile.rs
+++ b/crates/ferrocat/examples/runtime_compile.rs
@@ -11,7 +11,7 @@ fn catalog(
         content,
         locale: Some(locale),
         source_locale: "en",
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("", "en")
     })?
     .into_normalized_view()?)
 }

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -25,17 +25,13 @@
 //! };
 //!
 //! let source = parse_catalog(ParseCatalogOptions {
-//!     content: "msgid \"Hello\"\nmsgstr \"Hello\"\n",
-//!     source_locale: "en",
 //!     locale: Some("en"),
-//!     ..ParseCatalogOptions::default()
+//!     ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en")
 //! })?
 //! .into_normalized_view()?;
 //! let requested = parse_catalog(ParseCatalogOptions {
-//!     content: "msgid \"Hello\"\nmsgstr \"Hallo\"\n",
-//!     source_locale: "en",
 //!     locale: Some("de"),
-//!     ..ParseCatalogOptions::default()
+//!     ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
 //! })?
 //! .into_normalized_view()?;
 //! let index = CompiledCatalogIdIndex::new(&[&requested, &source], CompiledKeyStrategy::FerrocatV1)?;
@@ -43,12 +39,7 @@
 //! let compiled = compile_catalog_artifact_selected(
 //!     &[&requested, &source],
 //!     &index,
-//!     &CompileSelectedCatalogArtifactOptions {
-//!         requested_locale: "de",
-//!         source_locale: "en",
-//!         compiled_ids: &compiled_ids,
-//!         ..CompileSelectedCatalogArtifactOptions::default()
-//!     },
+//!     &CompileSelectedCatalogArtifactOptions::new("de", "en", &compiled_ids),
 //! )?;
 //!
 //! assert_eq!(compiled.messages.len(), 1);
@@ -61,17 +52,13 @@
 //! };
 //!
 //! let source = parse_catalog(ParseCatalogOptions {
-//!     content: "msgid \"Checkout\"\nmsgstr \"Checkout\"\n",
-//!     source_locale: "en",
 //!     locale: Some("en"),
-//!     ..ParseCatalogOptions::default()
+//!     ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
 //! })?
 //! .into_normalized_view()?;
 //! let target = parse_catalog(ParseCatalogOptions {
-//!     content: "",
-//!     source_locale: "en",
 //!     locale: Some("de"),
-//!     ..ParseCatalogOptions::default()
+//!     ..ParseCatalogOptions::new("", "en")
 //! })?
 //! .into_normalized_view()?;
 //! let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
@@ -87,17 +74,18 @@ pub mod catalog {
         CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary, CatalogCombineInput,
         CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats,
         CatalogConflictStrategy, CatalogMessage, CatalogMessageExtra, CatalogMessageKey,
-        CatalogOrigin, CatalogSemantics, CatalogStats, CatalogStorageFormat, CatalogUpdateInput,
-        CatalogUpdateResult, CombineCatalogOptions, CompileCatalogArtifactOptions,
-        CompileCatalogOptions, CompileSelectedCatalogArtifactOptions, CompiledCatalog,
-        CompiledCatalogArtifact, CompiledCatalogDiagnostic, CompiledCatalogIdDescription,
-        CompiledCatalogIdIndex, CompiledCatalogMissingMessage, CompiledCatalogTranslationKind,
+        CatalogMode, CatalogOrigin, CatalogSemantics, CatalogStats, CatalogStorageFormat,
+        CatalogUpdateInput, CatalogUpdateResult, CombineCatalogOptions,
+        CompileCatalogArtifactOptions, CompileCatalogOptions,
+        CompileSelectedCatalogArtifactOptions, CompiledCatalog, CompiledCatalogArtifact,
+        CompiledCatalogDiagnostic, CompiledCatalogIdDescription, CompiledCatalogIdIndex,
+        CompiledCatalogMissingMessage, CompiledCatalogTranslationKind,
         CompiledCatalogUnavailableId, CompiledKeyStrategy, CompiledMessage, CompiledTranslation,
         DescribeCompiledIdsReport, Diagnostic, DiagnosticSeverity, EffectiveTranslation,
         EffectiveTranslationRef, ExtractedMessage, ExtractedPluralMessage,
         ExtractedSingularMessage, MachineTranslationMetadata, NormalizedParsedCatalog,
         ObsoleteStrategy, OrderBy, ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode,
-        PluralEncoding, PluralSource, SourceExtractedMessage, TranslationShape,
+        PluralEncoding, PluralSource, RenderOptions, SourceExtractedMessage, TranslationShape,
         UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs, combine_catalogs,
         compile_catalog_artifact, compile_catalog_artifact_selected, compiled_key,
         machine_translation_hash, parse_catalog, update_catalog, update_catalog_file,
@@ -169,8 +157,8 @@ pub use ferrocat_po::{
     ApiError, CatalogAuditChecks, CatalogAuditDiagnostic, CatalogAuditMessageRef,
     CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary, CatalogCombineInput,
     CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats, CatalogConflictStrategy,
-    CatalogMessage, CatalogMessageExtra, CatalogMessageKey, CatalogOrigin, CatalogSemantics,
-    CatalogStats, CatalogStorageFormat, CatalogUpdateInput, CatalogUpdateResult,
+    CatalogMessage, CatalogMessageExtra, CatalogMessageKey, CatalogMode, CatalogOrigin,
+    CatalogSemantics, CatalogStats, CatalogStorageFormat, CatalogUpdateInput, CatalogUpdateResult,
     CombineCatalogOptions, CompileCatalogArtifactOptions, CompileCatalogOptions,
     CompileSelectedCatalogArtifactOptions, CompiledCatalog, CompiledCatalogArtifact,
     CompiledCatalogDiagnostic, CompiledCatalogIdDescription, CompiledCatalogIdIndex,
@@ -179,9 +167,9 @@ pub use ferrocat_po::{
     Diagnostic, DiagnosticSeverity, EffectiveTranslation, EffectiveTranslationRef,
     ExtractedMessage, ExtractedPluralMessage, ExtractedSingularMessage, MachineTranslationMetadata,
     NormalizedParsedCatalog, ObsoleteStrategy, OrderBy, ParseCatalogOptions, ParsedCatalog,
-    PlaceholderCommentMode, PluralEncoding, PluralSource, SourceExtractedMessage, TranslationShape,
-    UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs, combine_catalogs,
-    compile_catalog_artifact, compile_catalog_artifact_selected, compiled_key,
+    PlaceholderCommentMode, PluralEncoding, PluralSource, RenderOptions, SourceExtractedMessage,
+    TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs,
+    combine_catalogs, compile_catalog_artifact, compile_catalog_artifact_selected, compiled_key,
     machine_translation_hash, parse_catalog, update_catalog, update_catalog_file,
 };
 pub use ferrocat_po::{

--- a/crates/ferrocat/tests/smoke.rs
+++ b/crates/ferrocat/tests/smoke.rs
@@ -1,11 +1,11 @@
 use ferrocat::{
     catalog::{
-        CatalogCombineInput, CatalogMessageKey, CatalogSemantics, CatalogUpdateInput,
+        CatalogCombineInput, CatalogMessageKey, CatalogMode, CatalogUpdateInput,
         CombineCatalogOptions, CompileCatalogArtifactOptions,
         CompileSelectedCatalogArtifactOptions, CompiledCatalogIdIndex, CompiledKeyStrategy,
-        EffectiveTranslation, EffectiveTranslationRef, ParseCatalogOptions, PluralEncoding,
-        SourceExtractedMessage, combine_catalogs, compile_catalog_artifact,
-        compile_catalog_artifact_selected, parse_catalog,
+        EffectiveTranslation, EffectiveTranslationRef, ParseCatalogOptions, SourceExtractedMessage,
+        combine_catalogs, compile_catalog_artifact, compile_catalog_artifact_selected,
+        parse_catalog,
     },
     icu, po,
 };
@@ -57,9 +57,8 @@ msgstr "world"
         content: "msgid \"hello\"\nmsgstr \"world\"\n",
         locale: Some("de"),
         source_locale: "en",
-        semantics: CatalogSemantics::GettextCompat,
-        plural_encoding: PluralEncoding::Gettext,
-        ..ParseCatalogOptions::default()
+        mode: CatalogMode::GettextPo,
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect("parse gettext-compat catalog");
 
@@ -67,7 +66,7 @@ msgstr "world"
         content: "msgid \"hello\"\nmsgstr \"world\"\n",
         locale: Some("de"),
         source_locale: "en",
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect("parse catalog");
     let normalized = parsed_catalog
@@ -87,18 +86,14 @@ msgstr "world"
         content: "msgid \"hello\"\nmsgstr \"hello\"\n",
         locale: Some("en"),
         source_locale: "en",
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("", "en")
     })
     .expect("parse source catalog")
     .into_normalized_view()
     .expect("normalized source catalog");
     let artifact = compile_catalog_artifact(
         &[&normalized, &source],
-        &CompileCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            ..CompileCatalogArtifactOptions::default()
-        },
+        &CompileCatalogArtifactOptions::new("de", "en"),
     )
     .expect("compile artifact");
     assert_eq!(artifact.messages.len(), 1);
@@ -113,12 +108,7 @@ msgstr "world"
     let selected_artifact = compile_catalog_artifact_selected(
         &[&normalized, &source],
         &index,
-        &CompileSelectedCatalogArtifactOptions {
-            requested_locale: "de",
-            source_locale: "en",
-            compiled_ids: &compiled_ids,
-            ..CompileSelectedCatalogArtifactOptions::default()
-        },
+        &CompileSelectedCatalogArtifactOptions::new("de", "en", &compiled_ids),
     )
     .expect("compile selected artifact");
     assert_eq!(selected_artifact.messages.len(), 1);

--- a/docs/app/routes/guide/runtime-compilation.mdx
+++ b/docs/app/routes/guide/runtime-compilation.mdx
@@ -18,10 +18,8 @@ Use `NormalizedParsedCatalog::compile` when you want a runtime-facing lookup str
 use ferrocat::{CompileCatalogOptions, ParseCatalogOptions, parse_catalog};
 
 let parsed = parse_catalog(ParseCatalogOptions {
-    content: "msgid \"Hello\"\nmsgstr \"Hallo\"\n",
-    source_locale: "en",
     locale: Some("de"),
-    ..ParseCatalogOptions::default()
+    ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
 })?;
 let normalized = parsed.into_normalized_view()?;
 let compiled = normalized.compile(&CompileCatalogOptions::default())?;
@@ -46,27 +44,19 @@ use ferrocat::{
 };
 
 let source = parse_catalog(ParseCatalogOptions {
-    content: "msgid \"Hello\"\nmsgstr \"Hello\"\n",
-    source_locale: "en",
     locale: Some("en"),
-    ..ParseCatalogOptions::default()
+    ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en")
 })?
 .into_normalized_view()?;
 let requested = parse_catalog(ParseCatalogOptions {
-    content: "msgid \"Hello\"\nmsgstr \"Hallo\"\n",
-    source_locale: "en",
     locale: Some("de"),
-    ..ParseCatalogOptions::default()
+    ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
 })?
 .into_normalized_view()?;
 
 let artifact = compile_catalog_artifact(
     &[&requested, &source],
-    &CompileCatalogArtifactOptions {
-        requested_locale: "de",
-        source_locale: "en",
-        ..CompileCatalogArtifactOptions::default()
-    },
+    &CompileCatalogArtifactOptions::new("de", "en"),
 )?;
 
 assert_eq!(artifact.messages.len(), 1);

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -98,9 +98,9 @@ At the high-level catalog layer, `ferrocat` supports three explicit combinations
 
 | Mode | Storage format | Message model |
 |---|---|---|
-| Classic Gettext catalog mode | Gettext PO | Gettext-compatible plurals |
-| ICU-native Gettext PO mode | Gettext PO | ICU MessageFormat |
-| ICU-native NDJSON catalog mode | NDJSON catalog storage | ICU MessageFormat |
+| `CatalogMode::GettextPo` | Gettext PO | Gettext-compatible plurals |
+| `CatalogMode::IcuPo` | Gettext PO | ICU MessageFormat |
+| `CatalogMode::IcuNdjson` | NDJSON catalog storage | ICU MessageFormat |
 
 `NDJSON + Gettext-compatible plurals` is intentionally unsupported. In API terms, that means `CatalogStorageFormat::Ndjson` is only available with `CatalogSemantics::IcuNative`.
 
@@ -263,15 +263,13 @@ Choose this when your application wants semantic catalog data rather than just P
 
 `ParseCatalogOptions` borrows the source text and locale strings, so you can parse directly from existing buffers without first building owned request strings.
 
-High-level catalog parsing now also takes an explicit `storage_format`:
+High-level catalog parsing should normally choose one `CatalogMode` instead of setting storage, semantics, and plural encoding separately:
 
-- `CatalogStorageFormat::Po` for classic Gettext PO catalogs
-- `CatalogStorageFormat::Ndjson` for Ferrocat's frontmatter + one-message-per-line NDJSON catalog storage
+- `CatalogMode::IcuPo` for ICU-native messages stored in PO
+- `CatalogMode::IcuNdjson` for ICU-native messages stored as frontmatter + one-message-per-line NDJSON
+- `CatalogMode::GettextPo` for classic Gettext-compatible plurals stored in PO
 
-High-level parsing also takes an explicit `CatalogSemantics`:
-
-- `CatalogSemantics::IcuNative` is the default and keeps ICU/text messages raw
-- `CatalogSemantics::GettextCompat` is the explicit classic gettext plural mode
+The lower-level `storage_format`, `semantics`, and `plural_encoding` fields remain available for compatibility, but `CatalogMode` keeps the three choices synchronized.
 
 Important boundaries:
 
@@ -295,10 +293,8 @@ use ferrocat::{ParseCatalogOptions, parse_catalog};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let catalog = parse_catalog(ParseCatalogOptions {
-        content: "msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n",
         locale: Some("de"),
-        source_locale: "en",
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
     })?;
 
     let view = catalog.into_normalized_view()?;
@@ -353,17 +349,13 @@ use ferrocat::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_c
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let source = parse_catalog(ParseCatalogOptions {
-        content: "msgid \"Checkout\"\nmsgstr \"Checkout\"\n",
         locale: Some("en"),
-        source_locale: "en",
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
     })?
     .into_normalized_view()?;
     let target = parse_catalog(ParseCatalogOptions {
-        content: "msgid \"Checkout\"\nmsgstr \"\"\n",
         locale: Some("de"),
-        source_locale: "en",
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"\"\n", "en")
     })?
     .into_normalized_view()?;
 
@@ -466,17 +458,16 @@ use ferrocat::{
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let source = parse_catalog(ParseCatalogOptions {
-        content: "msgid \"Checkout\"\nmsgstr \"Checkout\"\n\nmsgid \"Cart\"\nmsgstr \"Cart\"\n",
         locale: Some("en"),
-        source_locale: "en",
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new(
+            "msgid \"Checkout\"\nmsgstr \"Checkout\"\n\nmsgid \"Cart\"\nmsgstr \"Cart\"\n",
+            "en",
+        )
     })?
     .into_normalized_view()?;
     let german = parse_catalog(ParseCatalogOptions {
-        content: "msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n",
         locale: Some("de"),
-        source_locale: "en",
-        ..ParseCatalogOptions::default()
+        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
     })?
     .into_normalized_view()?;
 
@@ -551,14 +542,11 @@ Compared with `merge_catalog`, this is the "full semantics" path. It is the bett
 
 `UpdateCatalogOptions` borrows locale strings, optional existing content, and optional custom-header maps. The extracted message payload itself stays owned, because that is usually the natural shape for upstream extractor output.
 
-Like parsing, updates now use an explicit `storage_format`. PO remains the default. NDJSON storage uses a small frontmatter header plus one JSON message record per line.
+Like parsing, updates should normally choose one `CatalogMode`. PO with ICU-native semantics remains the default. NDJSON storage uses a small frontmatter header plus one JSON message record per line.
 
 Choose NDJSON when collaboration and automation matter more than maximum PO fidelity. The one-record-per-line shape keeps large catalog diffs readable and makes ordinary Git conflict handling more practical, including hosted review flows where custom `.gitattributes` merge drivers may not be part of the web merge path.
 
-Updates also use an explicit `CatalogSemantics`:
-
-- `IcuNative` is the default and writes raw ICU/text messages
-- `GettextCompat` is the explicit PO-interop mode and writes classic gettext plurals
+Use `CatalogMode::GettextPo` for explicit PO-interop mode that writes classic gettext plurals.
 
 In `GettextCompat` mode, Ferrocat synthesizes `Plural-Forms` only for safe
 locale defaults that it knows, including common one-form, Germanic/Romance
@@ -571,21 +559,19 @@ In native mode, `CatalogUpdateInput::SourceFirst` stays source-text-first; it no
 In `NDJSON` storage, arbitrary gettext-style custom headers are intentionally out of scope for `v1`; only the explicit frontmatter metadata and per-record fields are persisted. Machine-translation metadata uses the optional `mt` record field and remains part of `ferrocat.ndjson.v1`.
 
 ```rust
-use ferrocat::{
-    CatalogStorageFormat, CatalogUpdateInput, SourceExtractedMessage, UpdateCatalogOptions,
-    update_catalog,
+use ferrocat_po::{
+    CatalogMode, CatalogUpdateInput, SourceExtractedMessage, UpdateCatalogOptions, update_catalog,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = update_catalog(UpdateCatalogOptions {
         locale: Some("de"),
-        source_locale: "en",
-        storage_format: CatalogStorageFormat::Ndjson,
+        mode: CatalogMode::IcuNdjson,
         input: CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
             msgid: "Checkout".to_owned(),
             ..SourceExtractedMessage::default()
         }]),
-        ..UpdateCatalogOptions::default()
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
     })?;
 
     assert!(result.content.starts_with("---\nformat: ferrocat.ndjson.v1\n"));


### PR DESCRIPTION
## Summary

- Refs #54.
- Adds `CatalogMode` in `ferrocat-po` for the three valid high-level catalog combinations: ICU PO, ICU NDJSON, and Gettext PO.
- Adds `mode()` and `with_mode(...)` helpers to `UpdateCatalogOptions`, `UpdateCatalogFileOptions`, `CombineCatalogOptions`, and `ParseCatalogOptions` so callers can keep storage format, semantics, and plural encoding synchronized.
- Updates API docs to prefer `CatalogMode` for normal construction while keeping the existing explicit fields available.

## Verification

- [x] cargo fmt --all --check
- [x] cargo check --workspace --all-targets --all-features --locked
- [x] cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- [x] cargo test --workspace --all-features --locked
- [x] RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- [x] cargo +1.93.0 check --workspace --all-targets --all-features --locked
- [x] cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked
- [x] pnpm build from docs/
- [x] git diff --check

## Notes

- This is a first API-design step, not the full option-struct refactor.
- It intentionally does not close #54; remaining work is removing or composing duplicated option fields once the safe construction path has landed.
- `CatalogMode` is exported from `ferrocat-po` in this PR. The umbrella `ferrocat` reexport is left out so the existing package verification continues to work against the currently published lower-level crate during same-version release checks.