### PR TITLE
feat(api): add diagnostic codes and io path context

### DIFF
--- a/crates/ferrocat-icu/src/analysis.rs
+++ b/crates/ferrocat-icu/src/analysis.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::ast::{IcuMessage, IcuNode, IcuOption, IcuPluralKind};
+use crate::diagnostic_codes;
 
 /// Severity level attached to ICU authoring diagnostics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -288,7 +289,7 @@ pub fn validate_icu_formatter_support_from_analysis(
             IcuFormatterSupport::UnsupportedKind { severity } => {
                 report.diagnostics.push(IcuDiagnostic::new(
                     severity,
-                    "icu.unsupported_formatter_kind",
+                    diagnostic_codes::icu::UNSUPPORTED_FORMATTER_KIND,
                     format!(
                         "ICU formatter `{}` uses unsupported formatter kind `{}`.",
                         formatter.name, formatter.kind
@@ -299,7 +300,7 @@ pub fn validate_icu_formatter_support_from_analysis(
             IcuFormatterSupport::UnsupportedStyle { severity } => {
                 report.diagnostics.push(IcuDiagnostic::new(
                     severity,
-                    "icu.unsupported_formatter_style",
+                    diagnostic_codes::icu::UNSUPPORTED_FORMATTER_STYLE,
                     format!(
                         "ICU formatter `{}` uses unsupported `{}` formatter style `{}`.",
                         formatter.name,
@@ -517,7 +518,7 @@ fn compare_arguments(
         let Some(translation_kind) = translation_arguments.get(name) else {
             report.diagnostics.push(IcuDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "icu.missing_argument",
+                diagnostic_codes::icu::MISSING_ARGUMENT,
                 format!("Translation is missing ICU argument `{name}`."),
                 Some(name.clone()),
             ));
@@ -526,7 +527,7 @@ fn compare_arguments(
         if source_kind != translation_kind {
             report.diagnostics.push(IcuDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "icu.argument_kind_changed",
+                diagnostic_codes::icu::ARGUMENT_KIND_CHANGED,
                 format!(
                     "Translation changes ICU argument `{name}` from {source_kind:?} to {translation_kind:?}."
                 ),
@@ -540,7 +541,7 @@ fn compare_arguments(
             if !source_arguments.contains_key(name) {
                 report.diagnostics.push(IcuDiagnostic::new(
                     IcuDiagnosticSeverity::Error,
-                    "icu.extra_argument",
+                    diagnostic_codes::icu::EXTRA_ARGUMENT,
                     format!(
                         "Translation adds ICU argument `{name}` that is not present in source."
                     ),
@@ -566,7 +567,7 @@ fn compare_formatter_styles(
         if source_style != *translation_style {
             report.diagnostics.push(IcuDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "icu.formatter_style_changed",
+                diagnostic_codes::icu::FORMATTER_STYLE_CHANGED,
                 format!(
                     "Translation changes ICU formatter style for `{name}` from {source_style:?} to {translation_style:?}."
                 ),
@@ -597,7 +598,7 @@ fn compare_tags(
         if translation_count < *source_count {
             report.diagnostics.push(IcuDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "icu.missing_tag",
+                diagnostic_codes::icu::MISSING_TAG,
                 format!("Translation is missing ICU tag `{name}`."),
                 Some(name.clone()),
             ));
@@ -609,7 +610,7 @@ fn compare_tags(
             if *translation_count > source_count {
                 report.diagnostics.push(IcuDiagnostic::new(
                     IcuDiagnosticSeverity::Error,
-                    "icu.extra_tag",
+                    diagnostic_codes::icu::EXTRA_TAG,
                     format!("Translation adds ICU tag `{name}` that is not present in source."),
                     Some(name.clone()),
                 ));
@@ -644,7 +645,7 @@ fn compare_selects(
             if !translation_selectors.contains(selector) {
                 report.diagnostics.push(IcuDiagnostic::new(
                     IcuDiagnosticSeverity::Error,
-                    "icu.missing_select_selector",
+                    diagnostic_codes::icu::MISSING_SELECT_SELECTOR,
                     format!(
                         "Translation is missing ICU select selector `{selector}` for `{name}`."
                     ),
@@ -657,7 +658,7 @@ fn compare_selects(
                 if !source_selectors.contains(selector) {
                     report.diagnostics.push(IcuDiagnostic::new(
                         IcuDiagnosticSeverity::Warning,
-                        "icu.extra_select_selector",
+                        diagnostic_codes::icu::EXTRA_SELECT_SELECTOR,
                         format!("Translation adds ICU select selector `{selector}` for `{name}`."),
                         Some(format!("{name}:{selector}")),
                     ));
@@ -694,7 +695,7 @@ fn compare_plurals(
         if source_plural.offset != translation_plural.offset {
             report.diagnostics.push(IcuDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "icu.plural_offset_changed",
+                diagnostic_codes::icu::PLURAL_OFFSET_CHANGED,
                 format!(
                     "Translation changes ICU plural offset for `{}` from {} to {}.",
                     source_plural.name, source_plural.offset, translation_plural.offset
@@ -708,7 +709,7 @@ fn compare_plurals(
             if !translation_selectors.contains(selector) {
                 report.diagnostics.push(IcuDiagnostic::new(
                     IcuDiagnosticSeverity::Error,
-                    "icu.missing_plural_selector",
+                    diagnostic_codes::icu::MISSING_PLURAL_SELECTOR,
                     format!(
                         "Translation is missing ICU plural selector `{selector}` for `{}`.",
                         source_plural.name
@@ -731,7 +732,7 @@ fn report_pattern_styles(analysis: &IcuAnalysis, label: &str, report: &mut IcuCo
         }
         report.diagnostics.push(IcuDiagnostic::new(
             IcuDiagnosticSeverity::Warning,
-            "icu.pattern_style_discouraged",
+            diagnostic_codes::icu::PATTERN_STYLE_DISCOURAGED,
             format!(
                 "{label} ICU formatter `{}` uses an opaque pattern style; prefer a predefined style or `::` skeleton.",
                 formatter.name

--- a/crates/ferrocat-icu/src/diagnostic_codes.rs
+++ b/crates/ferrocat-icu/src/diagnostic_codes.rs
@@ -1,0 +1,97 @@
+//! Stable machine-readable diagnostic codes emitted by `ferrocat-icu`.
+//!
+//! The constants in this module are the canonical spellings used in
+//! [`crate::IcuDiagnostic::code`] and [`crate::MessageMetadataDiagnostic::code`].
+//! CI, editor integrations, and build tooling can match these constants instead
+//! of parsing human-readable diagnostic messages.
+
+/// ICU compatibility diagnostic codes.
+pub mod icu {
+    /// Formatter kind is not supported by the target runtime.
+    pub const UNSUPPORTED_FORMATTER_KIND: &str = "icu.unsupported_formatter_kind";
+    /// Formatter style is not supported by the target runtime.
+    pub const UNSUPPORTED_FORMATTER_STYLE: &str = "icu.unsupported_formatter_style";
+    /// Translation omits an argument used by the source message.
+    pub const MISSING_ARGUMENT: &str = "icu.missing_argument";
+    /// Translation changes an argument kind used by the source message.
+    pub const ARGUMENT_KIND_CHANGED: &str = "icu.argument_kind_changed";
+    /// Translation adds an argument that is not present in the source message.
+    pub const EXTRA_ARGUMENT: &str = "icu.extra_argument";
+    /// Translation changes a formatter style used by the source message.
+    pub const FORMATTER_STYLE_CHANGED: &str = "icu.formatter_style_changed";
+    /// Translation omits a rich-text tag used by the source message.
+    pub const MISSING_TAG: &str = "icu.missing_tag";
+    /// Translation adds a rich-text tag that is not present in the source message.
+    pub const EXTRA_TAG: &str = "icu.extra_tag";
+    /// Translation omits a selector from a source `select` argument.
+    pub const MISSING_SELECT_SELECTOR: &str = "icu.missing_select_selector";
+    /// Translation adds a selector to a source `select` argument.
+    pub const EXTRA_SELECT_SELECTOR: &str = "icu.extra_select_selector";
+    /// Translation changes a source plural offset.
+    pub const PLURAL_OFFSET_CHANGED: &str = "icu.plural_offset_changed";
+    /// Translation omits a selector from a source plural argument.
+    pub const MISSING_PLURAL_SELECTOR: &str = "icu.missing_plural_selector";
+    /// ICU formatter uses an opaque pattern style.
+    pub const PATTERN_STYLE_DISCOURAGED: &str = "icu.pattern_style_discouraged";
+
+    /// All ICU compatibility diagnostic codes emitted by this crate.
+    pub const ALL: &[&str] = &[
+        UNSUPPORTED_FORMATTER_KIND,
+        UNSUPPORTED_FORMATTER_STYLE,
+        MISSING_ARGUMENT,
+        ARGUMENT_KIND_CHANGED,
+        EXTRA_ARGUMENT,
+        FORMATTER_STYLE_CHANGED,
+        MISSING_TAG,
+        EXTRA_TAG,
+        MISSING_SELECT_SELECTOR,
+        EXTRA_SELECT_SELECTOR,
+        PLURAL_OFFSET_CHANGED,
+        MISSING_PLURAL_SELECTOR,
+        PATTERN_STYLE_DISCOURAGED,
+    ];
+}
+
+/// Semantic message metadata diagnostic codes.
+pub mod metadata {
+    /// Metadata `msgid` is not valid ICU MessageFormat v1.
+    pub const INVALID_MSGID: &str = "metadata.invalid_msgid";
+    /// Metadata omits an argument parsed from `msgid`.
+    pub const MISSING_ARGUMENT: &str = "metadata.missing_argument";
+    /// Metadata declares an argument that is not used by `msgid`.
+    pub const EXTRA_ARGUMENT: &str = "metadata.extra_argument";
+    /// Metadata declares an argument kind that does not match `msgid`.
+    pub const ARGUMENT_KIND_MISMATCH: &str = "metadata.argument_kind_mismatch";
+    /// Metadata omits a rich-text tag parsed from `msgid`.
+    pub const MISSING_TAG: &str = "metadata.missing_tag";
+    /// Metadata declares a rich-text tag that is not used by `msgid`.
+    pub const EXTRA_TAG: &str = "metadata.extra_tag";
+    /// Metadata omits a selector parsed from `msgid`.
+    pub const MISSING_SELECTOR: &str = "metadata.missing_selector";
+    /// Metadata declares a selector that is not used by `msgid`.
+    pub const EXTRA_SELECTOR: &str = "metadata.extra_selector";
+    /// Metadata declares a selector kind that does not match `msgid`.
+    pub const SELECTOR_KIND_MISMATCH: &str = "metadata.selector_kind_mismatch";
+    /// Metadata omits a selector case parsed from `msgid`.
+    pub const MISSING_SELECTOR_CASE: &str = "metadata.missing_selector_case";
+    /// Metadata declares a selector case that is not used by `msgid`.
+    pub const EXTRA_SELECTOR_CASE: &str = "metadata.extra_selector_case";
+    /// Metadata declares a selector offset that does not match `msgid`.
+    pub const SELECTOR_OFFSET_MISMATCH: &str = "metadata.selector_offset_mismatch";
+
+    /// All semantic metadata diagnostic codes emitted by this crate.
+    pub const ALL: &[&str] = &[
+        INVALID_MSGID,
+        MISSING_ARGUMENT,
+        EXTRA_ARGUMENT,
+        ARGUMENT_KIND_MISMATCH,
+        MISSING_TAG,
+        EXTRA_TAG,
+        MISSING_SELECTOR,
+        EXTRA_SELECTOR,
+        SELECTOR_KIND_MISMATCH,
+        MISSING_SELECTOR_CASE,
+        EXTRA_SELECTOR_CASE,
+        SELECTOR_OFFSET_MISMATCH,
+    ];
+}

--- a/crates/ferrocat-icu/src/lib.rs
+++ b/crates/ferrocat-icu/src/lib.rs
@@ -58,6 +58,7 @@
 
 mod analysis;
 mod ast;
+pub mod diagnostic_codes;
 mod error;
 mod metadata;
 mod parser;

--- a/crates/ferrocat-icu/src/metadata.rs
+++ b/crates/ferrocat-icu/src/metadata.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     IcuAnalysis, IcuArgumentKind, IcuDiagnosticSeverity, IcuParseError, IcuPluralKind,
-    IcuStyleKind, analyze_icu, parse_icu,
+    IcuStyleKind, analyze_icu, diagnostic_codes, parse_icu,
 };
 
 /// Authoring input for semantic message metadata.
@@ -451,7 +451,7 @@ pub fn validate_message_metadata(input: &MessageMetadataInput) -> MessageMetadat
         return MessageMetadataValidationReport {
             diagnostics: vec![MessageMetadataDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "metadata.invalid_msgid",
+                diagnostic_codes::metadata::INVALID_MSGID,
                 "Message metadata `msgid` is not valid ICU MessageFormat v1.",
                 Some("msgid".to_owned()),
             )],
@@ -608,7 +608,7 @@ fn validate_args(
         if !normalized.contains_key(name) {
             report.diagnostics.push(MessageMetadataDiagnostic::new(
                 IcuDiagnosticSeverity::Warning,
-                "metadata.missing_argument",
+                diagnostic_codes::metadata::MISSING_ARGUMENT,
                 format!("Message metadata is missing parsed ICU argument `{name}`."),
                 Some(name.clone()),
             ));
@@ -618,7 +618,7 @@ fn validate_args(
         let Some(derived_argument) = derived.get(*name) else {
             report.diagnostics.push(MessageMetadataDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "metadata.extra_argument",
+                diagnostic_codes::metadata::EXTRA_ARGUMENT,
                 format!("Message metadata declares argument `{name}` that is not used by `msgid`."),
                 Some((*name).clone()),
             ));
@@ -630,7 +630,7 @@ fn validate_args(
         {
             report.diagnostics.push(MessageMetadataDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "metadata.argument_kind_mismatch",
+                diagnostic_codes::metadata::ARGUMENT_KIND_MISMATCH,
                 format!(
                     "Message metadata declares argument `{name}` as {:?}, but `msgid` uses {:?}.",
                     argument.kind, derived_argument.kind
@@ -652,7 +652,7 @@ fn validate_tags(
         if !input.contains(tag) {
             report.diagnostics.push(MessageMetadataDiagnostic::new(
                 IcuDiagnosticSeverity::Warning,
-                "metadata.missing_tag",
+                diagnostic_codes::metadata::MISSING_TAG,
                 format!("Message metadata is missing parsed ICU tag `{tag}`."),
                 Some(tag.clone()),
             ));
@@ -662,7 +662,7 @@ fn validate_tags(
         if !derived.contains(tag) {
             report.diagnostics.push(MessageMetadataDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "metadata.extra_tag",
+                diagnostic_codes::metadata::EXTRA_TAG,
                 format!("Message metadata declares tag `{tag}` that is not used by `msgid`."),
                 Some(tag.clone()),
             ));
@@ -679,7 +679,7 @@ fn validate_selectors(
         if !input.contains_key(name) {
             report.diagnostics.push(MessageMetadataDiagnostic::new(
                 IcuDiagnosticSeverity::Warning,
-                "metadata.missing_selector",
+                diagnostic_codes::metadata::MISSING_SELECTOR,
                 format!("Message metadata is missing parsed ICU selector `{name}`."),
                 Some(name.clone()),
             ));
@@ -689,7 +689,7 @@ fn validate_selectors(
         let Some(derived_selector) = derived.get(name) else {
             report.diagnostics.push(MessageMetadataDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "metadata.extra_selector",
+                diagnostic_codes::metadata::EXTRA_SELECTOR,
                 format!("Message metadata declares selector `{name}` that is not used by `msgid`."),
                 Some(name.clone()),
             ));
@@ -698,7 +698,7 @@ fn validate_selectors(
         if selector.kind != derived_selector.kind {
             report.diagnostics.push(MessageMetadataDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "metadata.selector_kind_mismatch",
+                diagnostic_codes::metadata::SELECTOR_KIND_MISMATCH,
                 format!(
                     "Message metadata declares selector `{name}` as {:?}, but `msgid` uses {:?}.",
                     selector.kind, derived_selector.kind
@@ -716,7 +716,7 @@ fn validate_selectors(
             if !input_cases.contains(case) {
                 report.diagnostics.push(MessageMetadataDiagnostic::new(
                     IcuDiagnosticSeverity::Warning,
-                    "metadata.missing_selector_case",
+                    diagnostic_codes::metadata::MISSING_SELECTOR_CASE,
                     format!(
                         "Message metadata is missing parsed ICU selector case `{case}` for `{name}`."
                     ),
@@ -728,7 +728,7 @@ fn validate_selectors(
             if !derived_cases.contains(case) {
                 report.diagnostics.push(MessageMetadataDiagnostic::new(
                     IcuDiagnosticSeverity::Error,
-                    "metadata.extra_selector_case",
+                    diagnostic_codes::metadata::EXTRA_SELECTOR_CASE,
                     format!(
                         "Message metadata declares selector case `{case}` for `{name}` that is not used by `msgid`."
                     ),
@@ -739,7 +739,7 @@ fn validate_selectors(
         if selector.offset != derived_selector.offset {
             report.diagnostics.push(MessageMetadataDiagnostic::new(
                 IcuDiagnosticSeverity::Error,
-                "metadata.selector_offset_mismatch",
+                diagnostic_codes::metadata::SELECTOR_OFFSET_MISMATCH,
                 format!(
                     "Message metadata declares selector `{name}` offset {:?}, but `msgid` uses {:?}.",
                     selector.offset, derived_selector.offset

--- a/crates/ferrocat-po/src/api/audit.rs
+++ b/crates/ferrocat-po/src/api/audit.rs
@@ -7,6 +7,8 @@ use ferrocat_icu::{
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::diagnostic_codes;
+
 use super::{
     ApiError, CatalogMessage, CatalogMessageKey, DiagnosticSeverity, EffectiveTranslationRef,
     NormalizedParsedCatalog, validate_source_locale,
@@ -213,7 +215,7 @@ pub fn audit_catalogs(
     let Some(source_catalog) = catalog_index.get(options.source_locale).copied() else {
         report.diagnostics.push(CatalogAuditDiagnostic::new(
             DiagnosticSeverity::Error,
-            "catalog.missing_source_locale",
+            diagnostic_codes::catalog::MISSING_SOURCE_LOCALE,
             format!(
                 "Catalog audit did not receive source locale `{}`.",
                 options.source_locale
@@ -310,7 +312,7 @@ fn select_target_locales(
         } else {
             report.diagnostics.push(CatalogAuditDiagnostic::new(
                 DiagnosticSeverity::Error,
-                "catalog.missing_locale",
+                diagnostic_codes::catalog::MISSING_LOCALE,
                 format!("Catalog audit did not receive requested locale `{locale}`."),
                 None,
                 Some((*locale).to_owned()),
@@ -339,7 +341,7 @@ fn audit_catalog_entries(
         if options.checks.obsolete_entries && message.obsolete {
             report.diagnostics.push(CatalogAuditDiagnostic::new(
                 DiagnosticSeverity::Info,
-                "catalog.obsolete_entry",
+                diagnostic_codes::catalog::OBSOLETE_ENTRY,
                 "Catalog contains an obsolete entry.",
                 Some(message_ref.clone()),
                 None,
@@ -348,7 +350,7 @@ fn audit_catalog_entries(
         if options.checks.fuzzy_flags && message_has_fuzzy_flag(message) {
             report.diagnostics.push(CatalogAuditDiagnostic::new(
                 DiagnosticSeverity::Info,
-                "catalog.fuzzy_flag",
+                diagnostic_codes::catalog::FUZZY_FLAG,
                 "Catalog entry carries a fuzzy flag.",
                 Some(message_ref.clone()),
                 Some("fuzzy".to_owned()),
@@ -374,7 +376,7 @@ fn audit_target_catalog(
             else {
                 report.diagnostics.push(CatalogAuditDiagnostic::new(
                     DiagnosticSeverity::Error,
-                    "catalog.missing_translation",
+                    diagnostic_codes::catalog::MISSING_TRANSLATION,
                     format!("Locale `{target_locale}` is missing translation for source message."),
                     Some(message_ref),
                     Some(target_locale.to_owned()),
@@ -384,7 +386,7 @@ fn audit_target_catalog(
             if translation_is_empty(target_message) {
                 report.diagnostics.push(CatalogAuditDiagnostic::new(
                     DiagnosticSeverity::Error,
-                    "catalog.empty_translation",
+                    diagnostic_codes::catalog::EMPTY_TRANSLATION,
                     format!("Locale `{target_locale}` has an empty translation."),
                     Some(message_ref),
                     Some(target_locale.to_owned()),
@@ -398,7 +400,7 @@ fn audit_target_catalog(
             if !message.obsolete && !source_keys.contains(key) {
                 report.diagnostics.push(CatalogAuditDiagnostic::new(
                     DiagnosticSeverity::Warning,
-                    "catalog.extra_translation",
+                    diagnostic_codes::catalog::EXTRA_TRANSLATION,
                     format!(
                         "Locale `{target_locale}` contains an active message that is not present in the source catalog."
                     ),
@@ -427,7 +429,7 @@ fn audit_icu_syntax_for_message(
         if let Err(error) = parse_icu(value) {
             report.diagnostics.push(CatalogAuditDiagnostic::new(
                 DiagnosticSeverity::Error,
-                "icu.invalid_syntax",
+                diagnostic_codes::icu::INVALID_SYNTAX,
                 format!("Catalog message is not valid ICU MessageFormat v1: {error}"),
                 Some(message_ref.clone()),
                 None,
@@ -485,7 +487,7 @@ fn audit_metadata(
         if !seen.insert(key.clone()) {
             report.diagnostics.push(CatalogAuditDiagnostic::new(
                 DiagnosticSeverity::Error,
-                "catalog.duplicate_metadata",
+                diagnostic_codes::catalog::DUPLICATE_METADATA,
                 "Semantic metadata contains a duplicate message identity.",
                 Some(source_ref.clone()),
                 None,
@@ -494,7 +496,7 @@ fn audit_metadata(
         if !source_keys.contains(&key) {
             report.diagnostics.push(CatalogAuditDiagnostic::new(
                 DiagnosticSeverity::Warning,
-                "catalog.metadata_unknown_message",
+                diagnostic_codes::catalog::METADATA_UNKNOWN_MESSAGE,
                 "Semantic metadata refers to a message that is not active in the source catalog.",
                 Some(source_ref.clone()),
                 None,
@@ -503,7 +505,7 @@ fn audit_metadata(
         if let Err(error) = normalize_message_metadata(input.clone()) {
             report.diagnostics.push(CatalogAuditDiagnostic::new(
                 DiagnosticSeverity::Error,
-                "metadata.invalid_msgid",
+                diagnostic_codes::metadata::INVALID_MSGID,
                 format!("Semantic metadata `msgid` is not valid ICU MessageFormat v1: {error}"),
                 Some(source_ref.clone()),
                 Some("msgid".to_owned()),

--- a/crates/ferrocat-po/src/api/catalog.rs
+++ b/crates/ferrocat-po/src/api/catalog.rs
@@ -8,6 +8,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 
+use crate::diagnostic_codes;
+
 use super::file_io::atomic_write;
 use super::helpers::{
     dedupe_origins, dedupe_placeholders, dedupe_strings, merge_placeholders, merge_unique_origins,
@@ -223,7 +225,7 @@ pub fn update_catalog_file(
     let existing = match fs::read_to_string(options.target_path) {
         Ok(content) => Some(content),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-        Err(error) => return Err(ApiError::Io(error)),
+        Err(error) => return Err(ApiError::io_with_path(options.target_path, error)),
     };
 
     let result = update_catalog(UpdateCatalogOptions {
@@ -447,7 +449,7 @@ fn merge_combine_message(
                 diagnostics.push(
                     Diagnostic::new(
                         DiagnosticSeverity::Warning,
-                        "combine.conflict_resolved",
+                        diagnostic_codes::combine::CONFLICT_RESOLVED,
                         format!(
                             "Resolved conflicting translations for definitions from {} using {:?}.",
                             entry.labels.join(", "),
@@ -886,7 +888,7 @@ fn merge_message(
                             diagnostics.push(
                                 Diagnostic::new(
                                     DiagnosticSeverity::Warning,
-                                    "plural.assumed_variable",
+                                    diagnostic_codes::plural::ASSUMED_VARIABLE,
                                     "Unable to determine plural placeholder name, assuming \"count\".",
                                 )
                                 .with_identity(&next.msgid, next.msgctxt.as_deref()),
@@ -974,7 +976,7 @@ fn apply_header_defaults(
             }
             (None, None) => diagnostics.push(Diagnostic::new(
                 DiagnosticSeverity::Info,
-                "plural.missing_plural_forms_header",
+                diagnostic_codes::plural::MISSING_PLURAL_FORMS_HEADER,
                 "No safe default Plural-Forms header is known for this locale; keeping the header unset.",
             )),
             (Some(_), Some(header))
@@ -984,7 +986,7 @@ fn apply_header_defaults(
                 headers.insert("Plural-Forms".to_owned(), header);
                 diagnostics.push(Diagnostic::new(
                     DiagnosticSeverity::Info,
-                    "plural.completed_plural_forms_header",
+                    diagnostic_codes::plural::COMPLETED_PLURAL_FORMS_HEADER,
                     "Plural-Forms header was missing the plural expression and has been completed using a safe locale default.",
                 ));
             }
@@ -1147,7 +1149,7 @@ fn export_message_to_po(
                 diagnostics.push(
                     Diagnostic::new(
                         DiagnosticSeverity::Error,
-                        "plural.unsupported_gettext_export",
+                        diagnostic_codes::plural::UNSUPPORTED_GETTEXT_EXPORT,
                         "Plural translation is missing the required \"other\" category.",
                     )
                     .with_identity(&message.msgid, message.msgctxt.as_deref()),
@@ -1530,7 +1532,7 @@ fn validate_plural_forms_header(
         match expected_gettext_nplurals_for_locale(locale) {
             Some(expected) if nplurals != expected => diagnostics.push(Diagnostic::new(
                 DiagnosticSeverity::Warning,
-                "plural.nplurals_locale_mismatch",
+                diagnostic_codes::plural::NPLURALS_LOCALE_MISMATCH,
                 format!(
                     "Plural-Forms declares nplurals={nplurals}, but locale-derived categories expect {expected}."
                 ),
@@ -1540,7 +1542,7 @@ fn validate_plural_forms_header(
     } else if plural_forms.plural.is_some() {
         diagnostics.push(Diagnostic::new(
             DiagnosticSeverity::Warning,
-            "parse.invalid_plural_forms_header",
+            diagnostic_codes::parse::INVALID_PLURAL_FORMS_HEADER,
             "Plural-Forms header contains a plural expression but no parseable nplurals value.",
         ));
     }
@@ -1548,7 +1550,7 @@ fn validate_plural_forms_header(
     if plural_forms.nplurals.is_some() && plural_forms.plural.is_none() {
         diagnostics.push(Diagnostic::new(
             DiagnosticSeverity::Info,
-            "plural.missing_plural_expression",
+            diagnostic_codes::plural::MISSING_PLURAL_EXPRESSION,
             "Plural-Forms header declares nplurals but omits the plural expression.",
         ));
     }

--- a/crates/ferrocat-po/src/api/compile.rs
+++ b/crates/ferrocat-po/src/api/compile.rs
@@ -11,6 +11,8 @@ use ferrocat_icu::{
 };
 use sha2::{Digest, Sha256};
 
+use crate::diagnostic_codes;
+
 use super::plural::synthesize_icu_plural;
 use super::{
     ApiError, CatalogMessage, CatalogMessageKey, CatalogSemantics, CompileCatalogArtifactOptions,
@@ -525,7 +527,7 @@ where
                 }
                 artifact.diagnostics.push(CompiledCatalogDiagnostic {
                     severity: DiagnosticSeverity::Error,
-                    code: "compile.invalid_icu_message".to_owned(),
+                    code: diagnostic_codes::compile::INVALID_ICU_MESSAGE.to_owned(),
                     message: format!("Final runtime message failed ICU validation: {error}"),
                     key: compiled_key.clone(),
                     msgid: source_key.msgid.clone(),

--- a/crates/ferrocat-po/src/api/file_io.rs
+++ b/crates/ferrocat-po/src/api/file_io.rs
@@ -6,24 +6,34 @@ use super::ApiError;
 
 pub(super) fn atomic_write(path: &Path, content: &str) -> Result<(), ApiError> {
     let directory = path.parent().unwrap_or_else(|| Path::new("."));
-    fs::create_dir_all(directory)?;
+    fs::create_dir_all(directory).map_err(|error| ApiError::io_with_path(directory, error))?;
 
     if path.file_name().is_none() {
         return Err(ApiError::InvalidArguments(
             "target_path must have a file name".to_owned(),
         ));
     }
-    let mut temp_file = tempfile::NamedTempFile::new_in(directory)?;
-    temp_file.write_all(content.as_bytes())?;
-    temp_file.as_file().sync_all()?;
-    temp_file.persist(path).map_err(|error| error.error)?;
+    let mut temp_file = tempfile::NamedTempFile::new_in(directory)
+        .map_err(|error| ApiError::io_with_path(directory, error))?;
+    temp_file
+        .write_all(content.as_bytes())
+        .map_err(|error| ApiError::io_with_path(path, error))?;
+    temp_file
+        .as_file()
+        .sync_all()
+        .map_err(|error| ApiError::io_with_path(path, error))?;
+    temp_file
+        .persist(path)
+        .map_err(|error| ApiError::io_with_path(path, error.error))?;
     sync_directory(directory)?;
     Ok(())
 }
 
 #[cfg(unix)]
 fn sync_directory(directory: &Path) -> Result<(), ApiError> {
-    fs::File::open(directory)?.sync_all()?;
+    fs::File::open(directory)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| ApiError::io_with_path(directory, error))?;
     Ok(())
 }
 

--- a/crates/ferrocat-po/src/api/tests/catalog.rs
+++ b/crates/ferrocat-po/src/api/tests/catalog.rs
@@ -868,6 +868,30 @@ fn update_catalog_file_writes_only_when_changed() {
 }
 
 #[test]
+fn update_catalog_file_read_error_includes_path_context() {
+    let temp_dir = std::env::temp_dir().join("ferrocat-po-update-file-read-error-test");
+    let _ = fs::remove_dir_all(&temp_dir);
+    fs::create_dir_all(&temp_dir).expect("create temp dir");
+
+    let error = update_catalog_file(UpdateCatalogFileOptions {
+        target_path: &temp_dir,
+        source_locale: "en",
+        locale: Some("en"),
+        input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
+            msgid: "Hello".to_owned(),
+            ..ExtractedSingularMessage::default()
+        })]),
+        ..UpdateCatalogFileOptions::default()
+    })
+    .expect_err("directory read should fail");
+
+    assert_eq!(error.path(), Some(temp_dir.as_path()));
+    assert!(matches!(error, ApiError::Io(_)));
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
 fn update_catalog_ndjson_renders_frontmatter_and_roundtrips() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",

--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::ParseError;
 
@@ -994,6 +994,59 @@ impl std::error::Error for ApiError {
     }
 }
 
+impl ApiError {
+    /// Creates a filesystem error with path context.
+    #[must_use]
+    pub fn io_with_path(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        let kind = source.kind();
+        Self::Io(std::io::Error::new(
+            kind,
+            PathIoError {
+                path: path.into(),
+                source,
+            },
+        ))
+    }
+
+    /// Returns the filesystem path associated with this error, when available.
+    #[must_use]
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Self::Io(error) => error
+                .get_ref()
+                .and_then(|source| source.downcast_ref::<PathIoError>())
+                .map(|error| error.path.as_path()),
+            Self::Parse(_)
+            | Self::InvalidArguments(_)
+            | Self::Conflict(_)
+            | Self::Unsupported(_) => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PathIoError {
+    path: PathBuf,
+    source: std::io::Error,
+}
+
+impl fmt::Display for PathIoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "I/O error for `{}`: {}",
+            self.path.display(),
+            self.source
+        )
+    }
+}
+
+impl std::error::Error for PathIoError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
 impl From<ParseError> for ApiError {
     fn from(value: ParseError) -> Self {
         Self::Parse(value)
@@ -1258,6 +1311,20 @@ mod tests {
             io_error.source().map(ToString::to_string).as_deref(),
             Some("disk")
         );
+        assert_eq!(io_error.path(), None);
+
+        let io_path_error = ApiError::io_with_path(
+            Path::new("locale/de.po"),
+            io::Error::other("permission denied"),
+        );
+        assert_eq!(io_path_error.path(), Some(Path::new("locale/de.po")));
+        let source = io_path_error.source().expect("io source");
+        assert!(source.to_string().contains("locale/de.po"));
+        assert_eq!(
+            source.source().map(ToString::to_string).as_deref(),
+            Some("permission denied")
+        );
+        assert!(io_path_error.to_string().contains("locale/de.po"));
 
         let parse_error = ApiError::from(ParseError::new("bad syntax"));
         assert_eq!(

--- a/crates/ferrocat-po/src/diagnostic_codes.rs
+++ b/crates/ferrocat-po/src/diagnostic_codes.rs
@@ -1,0 +1,189 @@
+//! Stable machine-readable diagnostic codes emitted by `ferrocat-po`.
+//!
+//! The constants in this module are the canonical spellings used in
+//! [`crate::Diagnostic::code`], [`crate::CatalogAuditDiagnostic::code`], and
+//! [`crate::CompiledCatalogDiagnostic::code`]. CI, editor integrations, and
+//! build tooling can match these constants instead of parsing human-readable
+//! diagnostic messages.
+
+/// Catalog audit diagnostic codes.
+pub mod catalog {
+    /// Audit did not receive the configured source locale catalog.
+    pub const MISSING_SOURCE_LOCALE: &str = "catalog.missing_source_locale";
+    /// Audit did not receive a requested target locale catalog.
+    pub const MISSING_LOCALE: &str = "catalog.missing_locale";
+    /// Catalog contains an obsolete entry.
+    pub const OBSOLETE_ENTRY: &str = "catalog.obsolete_entry";
+    /// Catalog entry carries a fuzzy flag.
+    pub const FUZZY_FLAG: &str = "catalog.fuzzy_flag";
+    /// Target locale is missing an active source message.
+    pub const MISSING_TRANSLATION: &str = "catalog.missing_translation";
+    /// Target locale has an empty translation for an active source message.
+    pub const EMPTY_TRANSLATION: &str = "catalog.empty_translation";
+    /// Target locale contains an active message missing from the source catalog.
+    pub const EXTRA_TRANSLATION: &str = "catalog.extra_translation";
+    /// Semantic metadata contains a duplicate message identity.
+    pub const DUPLICATE_METADATA: &str = "catalog.duplicate_metadata";
+    /// Semantic metadata refers to a message outside the active source catalog.
+    pub const METADATA_UNKNOWN_MESSAGE: &str = "catalog.metadata_unknown_message";
+
+    /// All catalog audit diagnostic codes emitted by this crate.
+    pub const ALL: &[&str] = &[
+        MISSING_SOURCE_LOCALE,
+        MISSING_LOCALE,
+        OBSOLETE_ENTRY,
+        FUZZY_FLAG,
+        MISSING_TRANSLATION,
+        EMPTY_TRANSLATION,
+        EXTRA_TRANSLATION,
+        DUPLICATE_METADATA,
+        METADATA_UNKNOWN_MESSAGE,
+    ];
+}
+
+/// Catalog combine diagnostic codes.
+pub mod combine {
+    /// Combine resolved a conflicting translation according to the chosen strategy.
+    pub const CONFLICT_RESOLVED: &str = "combine.conflict_resolved";
+
+    /// All catalog combine diagnostic codes emitted by this crate.
+    pub const ALL: &[&str] = &[CONFLICT_RESOLVED];
+}
+
+/// Runtime compilation diagnostic codes.
+pub mod compile {
+    /// Final runtime message failed ICU validation.
+    pub const INVALID_ICU_MESSAGE: &str = "compile.invalid_icu_message";
+
+    /// All runtime compilation diagnostic codes emitted by this crate.
+    pub const ALL: &[&str] = &[INVALID_ICU_MESSAGE];
+}
+
+/// PO parse diagnostic codes emitted by high-level catalog helpers.
+pub mod parse {
+    /// `Plural-Forms` header has a plural expression but no parseable `nplurals`.
+    pub const INVALID_PLURAL_FORMS_HEADER: &str = "parse.invalid_plural_forms_header";
+
+    /// All PO parse diagnostic codes emitted by this crate.
+    pub const ALL: &[&str] = &[INVALID_PLURAL_FORMS_HEADER];
+}
+
+/// Plural import/export diagnostic codes.
+pub mod plural {
+    /// Plural placeholder name could not be inferred and `count` was assumed.
+    pub const ASSUMED_VARIABLE: &str = "plural.assumed_variable";
+    /// No safe default `Plural-Forms` header is known for the locale.
+    pub const MISSING_PLURAL_FORMS_HEADER: &str = "plural.missing_plural_forms_header";
+    /// `Plural-Forms` header was completed from a safe locale default.
+    pub const COMPLETED_PLURAL_FORMS_HEADER: &str = "plural.completed_plural_forms_header";
+    /// ICU plural cannot be exported to gettext plural form safely.
+    pub const UNSUPPORTED_GETTEXT_EXPORT: &str = "plural.unsupported_gettext_export";
+    /// `nplurals` does not match the locale-derived plural category count.
+    pub const NPLURALS_LOCALE_MISMATCH: &str = "plural.nplurals_locale_mismatch";
+    /// `Plural-Forms` header declares `nplurals` but omits the expression.
+    pub const MISSING_PLURAL_EXPRESSION: &str = "plural.missing_plural_expression";
+
+    /// All plural diagnostic codes emitted by this crate.
+    pub const ALL: &[&str] = &[
+        ASSUMED_VARIABLE,
+        MISSING_PLURAL_FORMS_HEADER,
+        COMPLETED_PLURAL_FORMS_HEADER,
+        UNSUPPORTED_GETTEXT_EXPORT,
+        NPLURALS_LOCALE_MISMATCH,
+        MISSING_PLURAL_EXPRESSION,
+    ];
+}
+
+/// ICU syntax and compatibility diagnostic codes surfaced by catalog APIs.
+pub mod icu {
+    /// Catalog message is not valid ICU MessageFormat v1.
+    pub const INVALID_SYNTAX: &str = "icu.invalid_syntax";
+    /// Formatter kind is not supported by the target runtime.
+    pub const UNSUPPORTED_FORMATTER_KIND: &str = "icu.unsupported_formatter_kind";
+    /// Formatter style is not supported by the target runtime.
+    pub const UNSUPPORTED_FORMATTER_STYLE: &str = "icu.unsupported_formatter_style";
+    /// Translation omits an argument used by the source message.
+    pub const MISSING_ARGUMENT: &str = "icu.missing_argument";
+    /// Translation changes an argument kind used by the source message.
+    pub const ARGUMENT_KIND_CHANGED: &str = "icu.argument_kind_changed";
+    /// Translation adds an argument that is not present in the source message.
+    pub const EXTRA_ARGUMENT: &str = "icu.extra_argument";
+    /// Translation changes a formatter style used by the source message.
+    pub const FORMATTER_STYLE_CHANGED: &str = "icu.formatter_style_changed";
+    /// Translation omits a rich-text tag used by the source message.
+    pub const MISSING_TAG: &str = "icu.missing_tag";
+    /// Translation adds a rich-text tag that is not present in the source message.
+    pub const EXTRA_TAG: &str = "icu.extra_tag";
+    /// Translation omits a selector from a source `select` argument.
+    pub const MISSING_SELECT_SELECTOR: &str = "icu.missing_select_selector";
+    /// Translation adds a selector to a source `select` argument.
+    pub const EXTRA_SELECT_SELECTOR: &str = "icu.extra_select_selector";
+    /// Translation changes a source plural offset.
+    pub const PLURAL_OFFSET_CHANGED: &str = "icu.plural_offset_changed";
+    /// Translation omits a selector from a source plural argument.
+    pub const MISSING_PLURAL_SELECTOR: &str = "icu.missing_plural_selector";
+    /// ICU formatter uses an opaque pattern style.
+    pub const PATTERN_STYLE_DISCOURAGED: &str = "icu.pattern_style_discouraged";
+
+    /// All ICU diagnostic codes emitted or surfaced by this crate.
+    pub const ALL: &[&str] = &[
+        INVALID_SYNTAX,
+        UNSUPPORTED_FORMATTER_KIND,
+        UNSUPPORTED_FORMATTER_STYLE,
+        MISSING_ARGUMENT,
+        ARGUMENT_KIND_CHANGED,
+        EXTRA_ARGUMENT,
+        FORMATTER_STYLE_CHANGED,
+        MISSING_TAG,
+        EXTRA_TAG,
+        MISSING_SELECT_SELECTOR,
+        EXTRA_SELECT_SELECTOR,
+        PLURAL_OFFSET_CHANGED,
+        MISSING_PLURAL_SELECTOR,
+        PATTERN_STYLE_DISCOURAGED,
+    ];
+}
+
+/// Semantic message metadata diagnostic codes surfaced by catalog APIs.
+pub mod metadata {
+    /// Metadata `msgid` is not valid ICU MessageFormat v1.
+    pub const INVALID_MSGID: &str = "metadata.invalid_msgid";
+    /// Metadata omits an argument parsed from `msgid`.
+    pub const MISSING_ARGUMENT: &str = "metadata.missing_argument";
+    /// Metadata declares an argument that is not used by `msgid`.
+    pub const EXTRA_ARGUMENT: &str = "metadata.extra_argument";
+    /// Metadata declares an argument kind that does not match `msgid`.
+    pub const ARGUMENT_KIND_MISMATCH: &str = "metadata.argument_kind_mismatch";
+    /// Metadata omits a rich-text tag parsed from `msgid`.
+    pub const MISSING_TAG: &str = "metadata.missing_tag";
+    /// Metadata declares a rich-text tag that is not used by `msgid`.
+    pub const EXTRA_TAG: &str = "metadata.extra_tag";
+    /// Metadata omits a selector parsed from `msgid`.
+    pub const MISSING_SELECTOR: &str = "metadata.missing_selector";
+    /// Metadata declares a selector that is not used by `msgid`.
+    pub const EXTRA_SELECTOR: &str = "metadata.extra_selector";
+    /// Metadata declares a selector kind that does not match `msgid`.
+    pub const SELECTOR_KIND_MISMATCH: &str = "metadata.selector_kind_mismatch";
+    /// Metadata omits a selector case parsed from `msgid`.
+    pub const MISSING_SELECTOR_CASE: &str = "metadata.missing_selector_case";
+    /// Metadata declares a selector case that is not used by `msgid`.
+    pub const EXTRA_SELECTOR_CASE: &str = "metadata.extra_selector_case";
+    /// Metadata declares a selector offset that does not match `msgid`.
+    pub const SELECTOR_OFFSET_MISMATCH: &str = "metadata.selector_offset_mismatch";
+
+    /// All semantic metadata diagnostic codes surfaced by this crate.
+    pub const ALL: &[&str] = &[
+        INVALID_MSGID,
+        MISSING_ARGUMENT,
+        EXTRA_ARGUMENT,
+        ARGUMENT_KIND_MISMATCH,
+        MISSING_TAG,
+        EXTRA_TAG,
+        MISSING_SELECTOR,
+        EXTRA_SELECTOR,
+        SELECTOR_KIND_MISMATCH,
+        MISSING_SELECTOR_CASE,
+        EXTRA_SELECTOR_CASE,
+        SELECTOR_OFFSET_MISMATCH,
+    ];
+}

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -82,6 +82,7 @@
 #[cfg(feature = "catalog")]
 mod api;
 mod borrowed;
+pub mod diagnostic_codes;
 mod merge;
 mod parse;
 mod scan;

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -418,6 +418,19 @@ when the audit completes with at least one error diagnostic, and `2` for usage,
 I/O, parse, or serialization failures. Use `--format json` to write the
 structured `CatalogAuditReport`.
 
+Use `ferrocat_po::diagnostic_codes` when CI, editor integrations, or release
+gates need canonical code strings without hard-coding literals:
+
+```rust
+use ferrocat_po::{CatalogAuditOptions, audit_catalogs, diagnostic_codes};
+
+let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
+let has_missing = report
+    .diagnostics
+    .iter()
+    .any(|diagnostic| diagnostic.code == diagnostic_codes::catalog::MISSING_TRANSLATION);
+```
+
 ### `compiled_key`
 
 Use this when a host adapter, source transform, or manifest builder needs the
@@ -729,6 +742,9 @@ formatters.
 At the catalog artifact layer, set `icu_compatibility: true` on
 `CompileCatalogArtifactOptions` or `CompileSelectedCatalogArtifactOptions` to
 collect the same diagnostics while compiling the final locale artifact.
+The `ferrocat_icu::diagnostic_codes::icu` constants expose the canonical code
+strings for direct ICU checks, while `ferrocat_po::diagnostic_codes::icu`
+contains the same compatibility strings plus catalog-level ICU syntax codes.
 
 ### `validate_icu_formatter_support`
 
@@ -785,7 +801,7 @@ part of this source-side metadata format.
 
 ## Error Surface
 
-`ApiError` and the lower-level `ParseError` are intentionally small today. `ApiError` distinguishes parse, I/O, invalid-argument, conflict, and unsupported-operation failures, and its `std::error::Error::source()` implementation preserves underlying parse and I/O causes. PO `ParseError` keeps the existing human-readable display message and exposes `message()` plus optional `position()` metadata for tooling. Position metadata reports a zero-based byte offset plus one-based line and column when the parser can attach source context.
+`ApiError` and the lower-level `ParseError` are intentionally small today. `ApiError` distinguishes parse, I/O, invalid-argument, conflict, and unsupported-operation failures, and its `std::error::Error::source()` implementation preserves underlying parse and I/O causes. Disk helpers that know the affected path attach path context to `ApiError::Io`; call `ApiError::path()` to read that context without parsing the display string. PO `ParseError` keeps the existing human-readable display message and exposes `message()` plus optional `position()` metadata for tooling. Position metadata reports a zero-based byte offset plus one-based line and column when the parser can attach source context.
 
 ## Practical Rule Of Thumb
 


### PR DESCRIPTION
## Summary
- add public `diagnostic_codes` modules for `ferrocat-icu` and `ferrocat-po`
- route existing diagnostic emitters through the published constants
- attach path context to `ApiError::Io` for disk helpers and expose it via `ApiError::path()`
- document diagnostic-code constants and IO path context

Closes #53

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo +1.93.0 check --workspace --all-targets --all-features --locked`
- `pnpm build` from `docs/`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked`