### PR TITLE
feat(api): add umbrella namespace modules

### DIFF
--- a/crates/ferrocat/examples/merge_extracted_messages.rs
+++ b/crates/ferrocat/examples/merge_extracted_messages.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use ferrocat::{MergeExtractedMessage, merge_catalog};
+use ferrocat::po::{MergeMessageInput, merge_catalog};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let existing = r#"
@@ -12,16 +12,16 @@ msgstr "Alter CTA"
 "#;
 
     let extracted = [
-        MergeExtractedMessage {
+        MergeMessageInput {
             msgid: Cow::Borrowed("Hello"),
             references: vec![Cow::Borrowed("src/app.rs:10")],
-            ..MergeExtractedMessage::default()
+            ..MergeMessageInput::default()
         },
-        MergeExtractedMessage {
+        MergeMessageInput {
             msgid: Cow::Borrowed("Checkout"),
             references: vec![Cow::Borrowed("src/checkout.rs:42")],
             extracted_comments: vec![Cow::Borrowed("Primary checkout button")],
-            ..MergeExtractedMessage::default()
+            ..MergeMessageInput::default()
         },
     ];
 

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -159,6 +159,11 @@ pub use ferrocat_icu::{
 /// JSON schema version emitted by [`CompiledCatalogArtifact`] serialization.
 pub const COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION: u16 = 1;
 
+#[deprecated(
+    since = "0.14.0",
+    note = "use ferrocat::po::MergeMessageInput for the PO merge helper input"
+)]
+pub use ferrocat_po::MergeExtractedMessage;
 #[cfg(feature = "catalog")]
 pub use ferrocat_po::{
     ApiError, CatalogAuditChecks, CatalogAuditDiagnostic, CatalogAuditMessageRef,
@@ -179,14 +184,9 @@ pub use ferrocat_po::{
     compile_catalog_artifact, compile_catalog_artifact_selected, compiled_key,
     machine_translation_hash, parse_catalog, update_catalog, update_catalog_file,
 };
-#[deprecated(
-    since = "0.14.0",
-    note = "use ferrocat::po::MergeMessageInput for the PO merge helper input"
-)]
-pub use ferrocat_po::MergeExtractedMessage;
 pub use ferrocat_po::{
     BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, Header, MsgStr, MsgStrIter,
-    ParseError, PoFile, PoItem, SerializeOptions, escape_string, extract_quoted, extract_quoted_cow,
-    merge_catalog, parse_po, parse_po_borrowed, stringify_po, unescape_string,
+    ParseError, PoFile, PoItem, SerializeOptions, escape_string, extract_quoted,
+    extract_quoted_cow, merge_catalog, parse_po, parse_po_borrowed, stringify_po, unescape_string,
 };
 pub use icu::has_select_ordinal;

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -8,10 +8,10 @@
 //! # Examples
 //!
 //! ```rust
-//! use ferrocat::{parse_icu, parse_po};
+//! use ferrocat::{icu, po};
 //!
-//! let po = parse_po("msgid \"Hello\"\nmsgstr \"Hallo\"\n")?;
-//! let icu = parse_icu("Hello {name}")?;
+//! let po = po::parse_po("msgid \"Hello\"\nmsgstr \"Hallo\"\n")?;
+//! let icu = icu::parse_icu("Hello {name}")?;
 //!
 //! assert_eq!(po.items[0].msgid, "Hello");
 //! assert_eq!(icu.nodes.len(), 2);
@@ -19,7 +19,7 @@
 //! ```
 //!
 //! ```rust
-//! use ferrocat::{
+//! use ferrocat::catalog::{
 //!     CompileSelectedCatalogArtifactOptions, CompiledCatalogIdIndex, CompiledKeyStrategy,
 //!     ParseCatalogOptions, compile_catalog_artifact_selected, parse_catalog,
 //! };
@@ -56,7 +56,9 @@
 //! ```
 //!
 //! ```rust
-//! use ferrocat::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog};
+//! use ferrocat::catalog::{
+//!     CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog,
+//! };
 //!
 //! let source = parse_catalog(ParseCatalogOptions {
 //!     content: "msgid \"Checkout\"\nmsgstr \"Checkout\"\n",
@@ -78,7 +80,66 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
-pub use ferrocat_icu::has_selectordinal as has_select_ordinal;
+/// High-level catalog maintenance, audit, and runtime artifact APIs.
+pub mod catalog {
+    pub use ferrocat_po::{
+        ApiError, CatalogAuditChecks, CatalogAuditDiagnostic, CatalogAuditMessageRef,
+        CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary, CatalogCombineInput,
+        CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats,
+        CatalogConflictStrategy, CatalogMessage, CatalogMessageExtra, CatalogMessageKey,
+        CatalogOrigin, CatalogSemantics, CatalogStats, CatalogStorageFormat, CatalogUpdateInput,
+        CatalogUpdateResult, CombineCatalogOptions, CompileCatalogArtifactOptions,
+        CompileCatalogOptions, CompileSelectedCatalogArtifactOptions, CompiledCatalog,
+        CompiledCatalogArtifact, CompiledCatalogDiagnostic, CompiledCatalogIdDescription,
+        CompiledCatalogIdIndex, CompiledCatalogMissingMessage, CompiledCatalogTranslationKind,
+        CompiledCatalogUnavailableId, CompiledKeyStrategy, CompiledMessage, CompiledTranslation,
+        DescribeCompiledIdsReport, Diagnostic, DiagnosticSeverity, EffectiveTranslation,
+        EffectiveTranslationRef, ExtractedMessage, ExtractedPluralMessage,
+        ExtractedSingularMessage, MachineTranslationMetadata, NormalizedParsedCatalog,
+        ObsoleteStrategy, OrderBy, ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode,
+        PluralEncoding, PluralSource, SourceExtractedMessage, TranslationShape,
+        UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs, combine_catalogs,
+        compile_catalog_artifact, compile_catalog_artifact_selected, compiled_key,
+        machine_translation_hash, parse_catalog, update_catalog, update_catalog_file,
+    };
+}
+
+/// ICU MessageFormat parsing, analysis, compatibility, and metadata APIs.
+pub mod icu {
+    pub use ferrocat_icu::has_selectordinal as has_select_ordinal;
+    pub use ferrocat_icu::{
+        IcuAnalysis, IcuArgument, IcuArgumentKind, IcuCompatibilityOptions, IcuCompatibilityReport,
+        IcuDiagnostic, IcuDiagnosticSeverity, IcuErrorKind, IcuFormatter, IcuFormatterSupport,
+        IcuMessage, IcuNode, IcuOption, IcuParseError, IcuParserOptions, IcuPluralKind,
+        IcuPluralSummary, IcuPosition, IcuSelectSummary, IcuStyleKind, IcuTagSummary,
+        MessageArgumentFormatMetadata, MessageArgumentKind, MessageArgumentMetadata,
+        MessageArgumentMetadataInput, MessageFormatStyleKind, MessageMetadata,
+        MessageMetadataDiagnostic, MessageMetadataInput, MessageMetadataValidationReport,
+        MessageOriginMetadata, MessageSelectorKind, MessageSelectorMetadata, analyze_icu,
+        compare_icu_messages, derive_message_metadata_from_icu, extract_argument_names,
+        extract_tag_names, extract_variables, has_plural, has_select, has_tag,
+        normalize_message_metadata, parse_icu, parse_icu_with_options, stringify_icu, validate_icu,
+        validate_icu_formatter_support, validate_icu_formatter_support_from_analysis,
+        validate_message_metadata,
+    };
+}
+
+/// Low-level PO parsing, serialization, and text merge APIs.
+pub mod po {
+    pub use ferrocat_po::MergeExtractedMessage as MergeMessageInput;
+    pub use ferrocat_po::{
+        BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, Header, MsgStr, MsgStrIter,
+        ParseError, PoFile, PoItem, SerializeOptions, escape_string, extract_quoted,
+        extract_quoted_cow, merge_catalog, parse_po, parse_po_borrowed, stringify_po,
+        unescape_string,
+    };
+}
+
+#[deprecated(
+    since = "0.14.0",
+    note = "use ferrocat::has_select_ordinal or ferrocat::icu::has_select_ordinal"
+)]
+pub use ferrocat_icu::has_selectordinal;
 pub use ferrocat_icu::{
     IcuAnalysis, IcuArgument, IcuArgumentKind, IcuCompatibilityOptions, IcuCompatibilityReport,
     IcuDiagnostic, IcuDiagnosticSeverity, IcuErrorKind, IcuFormatter, IcuFormatterSupport,
@@ -89,7 +150,7 @@ pub use ferrocat_icu::{
     MessageMetadataDiagnostic, MessageMetadataInput, MessageMetadataValidationReport,
     MessageOriginMetadata, MessageSelectorKind, MessageSelectorMetadata, analyze_icu,
     compare_icu_messages, derive_message_metadata_from_icu, extract_argument_names,
-    extract_tag_names, extract_variables, has_plural, has_select, has_selectordinal, has_tag,
+    extract_tag_names, extract_variables, has_plural, has_select, has_tag,
     normalize_message_metadata, parse_icu, parse_icu_with_options, stringify_icu, validate_icu,
     validate_icu_formatter_support, validate_icu_formatter_support_from_analysis,
     validate_message_metadata,
@@ -118,9 +179,14 @@ pub use ferrocat_po::{
     compile_catalog_artifact, compile_catalog_artifact_selected, compiled_key,
     machine_translation_hash, parse_catalog, update_catalog, update_catalog_file,
 };
+#[deprecated(
+    since = "0.14.0",
+    note = "use ferrocat::po::MergeMessageInput for the PO merge helper input"
+)]
+pub use ferrocat_po::MergeExtractedMessage;
 pub use ferrocat_po::{
-    BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, Header, MergeExtractedMessage,
-    MsgStr, MsgStrIter, ParseError, PoFile, PoItem, SerializeOptions, escape_string,
-    extract_quoted, extract_quoted_cow, merge_catalog, parse_po, parse_po_borrowed, stringify_po,
-    unescape_string,
+    BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, Header, MsgStr, MsgStrIter,
+    ParseError, PoFile, PoItem, SerializeOptions, escape_string, extract_quoted, extract_quoted_cow,
+    merge_catalog, parse_po, parse_po_borrowed, stringify_po, unescape_string,
 };
+pub use icu::has_select_ordinal;

--- a/crates/ferrocat/tests/smoke.rs
+++ b/crates/ferrocat/tests/smoke.rs
@@ -1,16 +1,18 @@
 use ferrocat::{
-    CatalogCombineInput, CatalogMessageKey, CatalogSemantics, CatalogUpdateInput,
-    CombineCatalogOptions, CompileCatalogArtifactOptions, CompileSelectedCatalogArtifactOptions,
-    CompiledCatalogIdIndex, CompiledKeyStrategy, EffectiveTranslation, EffectiveTranslationRef,
-    MergeExtractedMessage, ParseCatalogOptions, PluralEncoding, SerializeOptions,
-    SourceExtractedMessage, combine_catalogs, compile_catalog_artifact,
-    compile_catalog_artifact_selected, has_select_ordinal, merge_catalog, parse_catalog, parse_icu,
-    parse_po, stringify_po,
+    catalog::{
+        CatalogCombineInput, CatalogMessageKey, CatalogSemantics, CatalogUpdateInput,
+        CombineCatalogOptions, CompileCatalogArtifactOptions,
+        CompileSelectedCatalogArtifactOptions, CompiledCatalogIdIndex, CompiledKeyStrategy,
+        EffectiveTranslation, EffectiveTranslationRef, ParseCatalogOptions, PluralEncoding,
+        SourceExtractedMessage, combine_catalogs, compile_catalog_artifact,
+        compile_catalog_artifact_selected, parse_catalog,
+    },
+    icu, po,
 };
 
 #[test]
 fn umbrella_crate_reexports_po_and_icu_surfaces() {
-    let mut file = parse_po(
+    let mut file = po::parse_po(
         r#"
 msgid "hello"
 msgstr "world"
@@ -20,14 +22,14 @@ msgstr "world"
 
     file.items[0].msgstr = "Welt".to_owned().into();
 
-    let rendered = stringify_po(&file, &SerializeOptions::default());
+    let rendered = po::stringify_po(&file, &po::SerializeOptions::default());
     assert!(rendered.contains(r#"msgstr "Welt""#));
 
-    let merged = merge_catalog(
+    let merged = po::merge_catalog(
         rendered.as_str(),
-        &[MergeExtractedMessage {
+        &[po::MergeMessageInput {
             msgid: "hello".into(),
-            ..MergeExtractedMessage::default()
+            ..po::MergeMessageInput::default()
         }],
     )
     .expect("merge catalog");
@@ -41,8 +43,9 @@ msgstr "world"
         .expect("combine catalogs");
     assert!(combined.content.contains(r#"msgid "bye""#));
 
-    let message = parse_icu("{count, selectordinal, one {#st} other {#th}}").expect("parse icu");
-    assert!(has_select_ordinal(&message));
+    let message =
+        icu::parse_icu("{count, selectordinal, one {#st} other {#th}}").expect("parse icu");
+    assert!(icu::has_select_ordinal(&message));
 
     let _source_input = CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
         msgid: "hello".into(),

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -75,6 +75,22 @@ compatibility rules around the compiled artifact JSON contract.
 Ferrocat is still pre-1.0, but growth-prone public enums are deliberately marked as non-exhaustive where new variants are realistic. Downstream code should keep fallback match arms for ICU AST nodes, catalog storage formats, compiled key strategies, and API-level error categories.
 
 Semantically closed option enums such as `CatalogSemantics` and `PluralEncoding` remain exhaustive so callers can continue to match every documented mode directly.
+## Umbrella Crate Namespaces
+
+When depending on the umbrella `ferrocat` crate, prefer the namespaced modules
+for new code:
+
+- `ferrocat::po` for low-level PO parsing, serialization, and text merge APIs
+- `ferrocat::catalog` for high-level catalog update, audit, combine, and runtime artifact APIs
+- `ferrocat::icu` for ICU MessageFormat parsing, analysis, compatibility, and metadata APIs
+
+The historical top-level re-exports remain for compatibility. New examples use
+the modules because they avoid collisions such as source extraction inputs for
+catalog updates versus inputs for the PO merge helper. The legacy top-level
+`has_selectordinal` export is deprecated; use `has_select_ordinal` or
+`ferrocat::icu::has_select_ordinal`. The legacy top-level
+`MergeExtractedMessage` export is also deprecated; use
+`ferrocat::po::MergeMessageInput`.
 
 ## Supported Catalog Modes
 
@@ -189,14 +205,14 @@ Ferrocat assumes exact catalog identity here: `msgid` plus optional `msgctxt`. T
 ```rust
 use std::borrow::Cow;
 
-use ferrocat::{MergeExtractedMessage, merge_catalog};
+use ferrocat::po::{MergeMessageInput, merge_catalog};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let existing = "msgid \"Hello\"\nmsgstr \"Hallo\"\n";
-    let extracted = [MergeExtractedMessage {
+    let extracted = [MergeMessageInput {
         msgid: Cow::Borrowed("Hello"),
         references: vec![Cow::Borrowed("src/app.rs:10")],
-        ..MergeExtractedMessage::default()
+        ..MergeMessageInput::default()
     }];
 
     let merged = merge_catalog(existing, &extracted)?;


### PR DESCRIPTION
## Summary
- add `ferrocat::po`, `ferrocat::catalog`, and `ferrocat::icu` modules to the umbrella crate
- keep existing top-level re-exports compatible while deprecating the confusing top-level `has_selectordinal` and `MergeExtractedMessage` names
- expose `ferrocat::po::MergeMessageInput` as the clearer merge-helper input name
- update umbrella examples, smoke coverage, and API docs to use the namespaces

Closes #56

## Notes
- This intentionally does not rename every low-level function or add file-helper companions. Those are separate API-design decisions and should be handled as focused follow-ups if still desired.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo +1.93.0 check --workspace --all-targets --all-features --locked`
- `pnpm build` from `docs/`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked`