### PR TITLE
feat(po): add safe gettext plural forms table

### DIFF
--- a/crates/ferrocat-po/src/api/catalog.rs
+++ b/crates/ferrocat-po/src/api/catalog.rs
@@ -19,7 +19,10 @@ use super::mt::{
     validate_machine_translation_metadata,
 };
 use super::ndjson::{parse_catalog_to_internal_ndjson, stringify_catalog_ndjson};
-use super::plural::{PluralProfile, derive_plural_variable, synthesize_icu_plural};
+use super::plural::{
+    PluralProfile, derive_plural_variable, expected_gettext_nplurals_for_locale,
+    synthesize_icu_plural,
+};
 use super::{
     ApiError, CatalogCombineResult, CatalogCombineStats, CatalogConflictStrategy, CatalogMessage,
     CatalogMessageExtra, CatalogOrigin, CatalogSemantics, CatalogStats, CatalogStorageFormat,
@@ -99,6 +102,15 @@ struct CombineEntry {
     labels: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MergeCatalogContext<'a> {
+    locale: Option<&'a str>,
+    source_locale: &'a str,
+    semantics: CatalogSemantics,
+    overwrite_source_translations: bool,
+    obsolete_strategy: ObsoleteStrategy,
+}
+
 /// Merges extracted messages into an existing catalog and returns updated catalog content.
 ///
 /// # Errors
@@ -168,15 +180,15 @@ pub fn update_catalog(options: UpdateCatalogOptions<'_>) -> Result<CatalogUpdate
         .or_else(|| existing.headers.get("Language").cloned());
     let mut diagnostics = existing.diagnostics.clone();
     let normalized = normalize_update_input(&options.input)?;
-    let (mut merged, stats) = merge_catalogs(
-        existing,
-        &normalized,
-        locale.as_deref(),
-        options.source_locale,
-        options.overwrite_source_translations,
-        options.obsolete_strategy,
-        &mut diagnostics,
-    );
+    let merge_context = MergeCatalogContext {
+        locale: locale.as_deref(),
+        source_locale: options.source_locale,
+        semantics: options.semantics,
+        overwrite_source_translations: options.overwrite_source_translations,
+        obsolete_strategy: options.obsolete_strategy,
+    };
+    let (mut merged, stats) =
+        merge_catalogs(existing, &normalized, merge_context, &mut diagnostics);
     merged.locale.clone_from(&locale);
     apply_storage_defaults(&mut merged, &options, locale.as_deref(), &mut diagnostics)?;
     sort_messages(&mut merged.messages, options.order_by);
@@ -731,13 +743,12 @@ fn push_normalized_message(
 fn merge_catalogs(
     existing: Catalog,
     normalized: &[NormalizedMessage],
-    locale: Option<&str>,
-    source_locale: &str,
-    overwrite_source_translations: bool,
-    obsolete_strategy: ObsoleteStrategy,
+    context: MergeCatalogContext<'_>,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> (Catalog, CatalogStats) {
-    let is_source_locale = locale.is_none_or(|value| value == source_locale);
+    let is_source_locale = context
+        .locale
+        .is_none_or(|value| value == context.source_locale);
     let mut stats = CatalogStats::default();
 
     let mut existing_index = BTreeMap::<(String, Option<String>), usize>::new();
@@ -758,8 +769,9 @@ fn merge_catalogs(
             previous.as_ref(),
             next,
             is_source_locale,
-            locale,
-            overwrite_source_translations,
+            context.locale,
+            context.semantics,
+            context.overwrite_source_translations,
             diagnostics,
         );
         if previous.is_none() {
@@ -776,7 +788,7 @@ fn merge_catalogs(
         if matched[index] {
             continue;
         }
-        match obsolete_strategy {
+        match context.obsolete_strategy {
             ObsoleteStrategy::Delete => {
                 stats.obsolete_removed += 1;
             }
@@ -819,6 +831,7 @@ fn merge_message(
     next: &NormalizedMessage,
     is_source_locale: bool,
     locale: Option<&str>,
+    semantics: CatalogSemantics,
     overwrite_source_translations: bool,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> CanonicalMessage {
@@ -837,7 +850,11 @@ fn merge_message(
             },
         },
         (NormalizedKind::Plural { source, variable }, previous) => {
-            let plural_profile = PluralProfile::for_locale(locale);
+            let plural_profile = if semantics == CatalogSemantics::GettextCompat {
+                PluralProfile::for_gettext_locale(locale)
+            } else {
+                PluralProfile::for_locale(locale)
+            };
 
             match previous {
                 Some(previous)
@@ -949,7 +966,7 @@ fn apply_header_defaults(
         headers.insert("Language".to_owned(), locale.to_owned());
     }
     if semantics == CatalogSemantics::GettextCompat && !custom.contains_key("Plural-Forms") {
-        let profile = PluralProfile::for_locale(locale);
+        let profile = PluralProfile::for_gettext_locale(locale);
         let parsed_header = parse_plural_forms_from_headers(headers);
         match (parsed_header.raw.as_deref(), profile.gettext_header()) {
             (None, Some(header)) => {
@@ -1119,7 +1136,8 @@ fn export_message_to_po(
                 return Ok(item);
             }
 
-            let plural_profile = PluralProfile::for_translation(locale, translation_by_category);
+            let plural_profile =
+                PluralProfile::for_gettext_translation(locale, translation_by_category);
             let nplurals = plural_profile
                 .nplurals()
                 .max(translation_by_category.len().max(1));
@@ -1509,16 +1527,15 @@ fn validate_plural_forms_header(
     }
 
     if let Some(nplurals) = plural_forms.nplurals {
-        let profile = PluralProfile::for_locale(locale);
-        let expected = profile.nplurals();
-        if locale.is_some() && nplurals != expected {
-            diagnostics.push(Diagnostic::new(
+        match expected_gettext_nplurals_for_locale(locale) {
+            Some(expected) if nplurals != expected => diagnostics.push(Diagnostic::new(
                 DiagnosticSeverity::Warning,
                 "plural.nplurals_locale_mismatch",
                 format!(
                     "Plural-Forms declares nplurals={nplurals}, but locale-derived categories expect {expected}."
                 ),
-            ));
+            )),
+            _ => {}
         }
     } else if plural_forms.plural.is_some() {
         diagnostics.push(Diagnostic::new(

--- a/crates/ferrocat-po/src/api/plural.rs
+++ b/crates/ferrocat-po/src/api/plural.rs
@@ -40,7 +40,219 @@ pub(super) type PluralCategoryCache = Mutex<HashMap<String, Option<Vec<String>>>
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct PluralProfile {
     categories: Vec<String>,
+    gettext_header: Option<&'static str>,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GettextPluralRule {
+    locale: &'static str,
+    categories: &'static [&'static str],
+    header: &'static str,
+}
+
+impl GettextPluralRule {
+    const fn nplurals(self) -> usize {
+        self.categories.len()
+    }
+}
+
+const ONE_FORM_CATEGORIES: &[&str] = &["other"];
+const TWO_FORM_CATEGORIES: &[&str] = &["one", "other"];
+const THREE_FORM_CATEGORIES: &[&str] = &["one", "few", "other"];
+const SIX_FORM_CATEGORIES: &[&str] = &["zero", "one", "two", "few", "many", "other"];
+
+const GETTEXT_ONE_FORM_HEADER: &str = "nplurals=1; plural=0;";
+const GETTEXT_ONE_ONLY_HEADER: &str = "nplurals=2; plural=(n != 1);";
+const GETTEXT_ZERO_ONE_HEADER: &str = "nplurals=2; plural=(n > 1);";
+const GETTEXT_POLISH_HEADER: &str = "nplurals=3; plural=(n == 1 ? 0 : (n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)) ? 1 : 2);";
+const GETTEXT_SLAVIC_THREE_FORM_HEADER: &str = "nplurals=3; plural=(n % 10 == 1 && n % 100 != 11 ? 0 : (n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)) ? 1 : 2);";
+const GETTEXT_CZECH_SLOVAK_HEADER: &str =
+    "nplurals=3; plural=(n == 1 ? 0 : (n >= 2 && n <= 4) ? 1 : 2);";
+const GETTEXT_ARABIC_HEADER: &str = "nplurals=6; plural=(n == 0 ? 0 : n == 1 ? 1 : n == 2 ? 2 : (n % 100 >= 3 && n % 100 <= 10) ? 3 : (n % 100 >= 11) ? 4 : 5);";
+
+// Seeded from GNU gettext's documented plural-form families for common locales.
+const GETTEXT_PLURAL_RULES: &[GettextPluralRule] = &[
+    GettextPluralRule {
+        locale: "ar",
+        categories: SIX_FORM_CATEGORIES,
+        header: GETTEXT_ARABIC_HEADER,
+    },
+    GettextPluralRule {
+        locale: "be",
+        categories: THREE_FORM_CATEGORIES,
+        header: GETTEXT_SLAVIC_THREE_FORM_HEADER,
+    },
+    GettextPluralRule {
+        locale: "bg",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "cs",
+        categories: THREE_FORM_CATEGORIES,
+        header: GETTEXT_CZECH_SLOVAK_HEADER,
+    },
+    GettextPluralRule {
+        locale: "da",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "de",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "el",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "en",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "eo",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "es",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "et",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "fi",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "fr",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ZERO_ONE_HEADER,
+    },
+    GettextPluralRule {
+        locale: "he",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "hr",
+        categories: THREE_FORM_CATEGORIES,
+        header: GETTEXT_SLAVIC_THREE_FORM_HEADER,
+    },
+    GettextPluralRule {
+        locale: "hu",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "id",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "it",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "ja",
+        categories: ONE_FORM_CATEGORIES,
+        header: GETTEXT_ONE_FORM_HEADER,
+    },
+    GettextPluralRule {
+        locale: "ko",
+        categories: ONE_FORM_CATEGORIES,
+        header: GETTEXT_ONE_FORM_HEADER,
+    },
+    GettextPluralRule {
+        locale: "nb",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "nl",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "nn",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "no",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "pl",
+        categories: THREE_FORM_CATEGORIES,
+        header: GETTEXT_POLISH_HEADER,
+    },
+    GettextPluralRule {
+        locale: "pt",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "pt-br",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ZERO_ONE_HEADER,
+    },
+    GettextPluralRule {
+        locale: "ru",
+        categories: THREE_FORM_CATEGORIES,
+        header: GETTEXT_SLAVIC_THREE_FORM_HEADER,
+    },
+    GettextPluralRule {
+        locale: "sk",
+        categories: THREE_FORM_CATEGORIES,
+        header: GETTEXT_CZECH_SLOVAK_HEADER,
+    },
+    GettextPluralRule {
+        locale: "sr",
+        categories: THREE_FORM_CATEGORIES,
+        header: GETTEXT_SLAVIC_THREE_FORM_HEADER,
+    },
+    GettextPluralRule {
+        locale: "sv",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "th",
+        categories: ONE_FORM_CATEGORIES,
+        header: GETTEXT_ONE_FORM_HEADER,
+    },
+    GettextPluralRule {
+        locale: "tr",
+        categories: TWO_FORM_CATEGORIES,
+        header: GETTEXT_ONE_ONLY_HEADER,
+    },
+    GettextPluralRule {
+        locale: "uk",
+        categories: THREE_FORM_CATEGORIES,
+        header: GETTEXT_SLAVIC_THREE_FORM_HEADER,
+    },
+    GettextPluralRule {
+        locale: "vi",
+        categories: ONE_FORM_CATEGORIES,
+        header: GETTEXT_ONE_FORM_HEADER,
+    },
+    GettextPluralRule {
+        locale: "zh",
+        categories: ONE_FORM_CATEGORIES,
+        header: GETTEXT_ONE_FORM_HEADER,
+    },
+];
 
 impl PluralProfile {
     /// Builds the plural-category profile used for one import/export operation.
@@ -49,18 +261,27 @@ impl PluralProfile {
     /// gettext slot count; otherwise we fall back to a synthetic category list
     /// so we do not silently mislabel translator-provided slots.
     fn new(locale: Option<&str>, nplurals: Option<usize>) -> Self {
-        let categories = locale.and_then(icu_plural_categories_for).map_or_else(
-            || fallback_plural_categories(nplurals),
-            |locale_categories| {
-                if nplurals.is_none() || nplurals == Some(locale_categories.len()) {
-                    locale_categories
-                } else {
-                    fallback_plural_categories(nplurals)
-                }
-            },
-        );
+        let normalized_locale = normalized_locale(locale);
+        let categories = normalized_locale
+            .as_deref()
+            .and_then(icu_plural_categories_for)
+            .map_or_else(
+                || fallback_plural_categories(nplurals),
+                |locale_categories| {
+                    if nplurals.is_none() || nplurals == Some(locale_categories.len()) {
+                        locale_categories
+                    } else {
+                        fallback_plural_categories(nplurals)
+                    }
+                },
+            );
+        let gettext_header =
+            gettext_header_for_categories(normalized_locale.as_deref(), categories.len());
 
-        Self { categories }
+        Self {
+            categories,
+            gettext_header,
+        }
     }
 
     pub(super) fn for_locale(locale: Option<&str>) -> Self {
@@ -68,14 +289,56 @@ impl PluralProfile {
     }
 
     pub(super) fn for_gettext_slots(locale: Option<&str>, nplurals: Option<usize>) -> Self {
-        Self::new(locale, nplurals)
+        Self::new_gettext(locale, nplurals)
     }
 
-    pub(super) fn for_translation(
+    pub(super) fn for_gettext_locale(locale: Option<&str>) -> Self {
+        Self::new_gettext(locale, None)
+    }
+
+    pub(super) fn for_gettext_translation(
         locale: Option<&str>,
         translation_by_category: &BTreeMap<String, String>,
     ) -> Self {
-        Self::new(locale, Some(translation_by_category.len()))
+        Self::new_gettext(locale, Some(translation_by_category.len()))
+    }
+
+    fn new_gettext(locale: Option<&str>, nplurals: Option<usize>) -> Self {
+        let normalized_locale = normalized_locale(locale);
+        if let Some(rule) = normalized_locale
+            .as_deref()
+            .and_then(gettext_plural_rule_for_normalized)
+            .filter(|rule| nplurals.is_none() || nplurals == Some(rule.nplurals()))
+        {
+            return Self {
+                categories: static_categories(rule.categories),
+                gettext_header: Some(rule.header),
+            };
+        }
+
+        let categories = normalized_locale
+            .as_deref()
+            .and_then(icu_plural_categories_for)
+            .map_or_else(
+                || fallback_plural_categories(nplurals),
+                |locale_categories| {
+                    if nplurals.is_none() || nplurals == Some(locale_categories.len()) {
+                        locale_categories
+                    } else {
+                        fallback_plural_categories(nplurals)
+                    }
+                },
+            );
+        let gettext_header = if normalized_locale.is_none() {
+            generic_gettext_header_for_nplurals(categories.len())
+        } else {
+            None
+        };
+
+        Self {
+            categories,
+            gettext_header,
+        }
     }
 
     pub(super) fn categories(&self) -> &[String] {
@@ -134,11 +397,7 @@ impl PluralProfile {
     }
 
     pub(super) fn gettext_header(&self) -> Option<String> {
-        match self.nplurals() {
-            1 => Some("nplurals=1; plural=0;".to_owned()),
-            2 => Some("nplurals=2; plural=(n != 1);".to_owned()),
-            _ => None,
-        }
+        self.gettext_header.map(str::to_owned)
     }
 }
 
@@ -219,6 +478,59 @@ pub(super) fn cached_icu_plural_categories_for(
 
 fn normalize_plural_locale(locale: &str) -> String {
     locale.trim().replace('_', "-")
+}
+
+fn normalized_locale(locale: Option<&str>) -> Option<String> {
+    let normalized = normalize_plural_locale(locale?);
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn static_categories(categories: &[&str]) -> Vec<String> {
+    categories.iter().copied().map(str::to_owned).collect()
+}
+
+fn gettext_plural_rule_for_normalized(locale: &str) -> Option<GettextPluralRule> {
+    let normalized = locale.to_ascii_lowercase();
+    gettext_plural_rule_for_key(&normalized).or_else(|| {
+        normalized
+            .split_once('-')
+            .and_then(|(language, _)| gettext_plural_rule_for_key(language))
+    })
+}
+
+fn gettext_plural_rule_for_key(locale: &str) -> Option<GettextPluralRule> {
+    GETTEXT_PLURAL_RULES
+        .iter()
+        .copied()
+        .find(|rule| rule.locale == locale)
+}
+
+fn gettext_header_for_categories(locale: Option<&str>, nplurals: usize) -> Option<&'static str> {
+    locale
+        .and_then(gettext_plural_rule_for_normalized)
+        .filter(|rule| rule.nplurals() == nplurals)
+        .map(|rule| rule.header)
+        .or_else(|| {
+            locale
+                .is_none()
+                .then(|| generic_gettext_header_for_nplurals(nplurals))
+                .flatten()
+        })
+}
+
+fn generic_gettext_header_for_nplurals(nplurals: usize) -> Option<&'static str> {
+    match nplurals {
+        1 => Some(GETTEXT_ONE_FORM_HEADER),
+        2 => Some(GETTEXT_ONE_ONLY_HEADER),
+        _ => None,
+    }
+}
+
+pub(super) fn expected_gettext_nplurals_for_locale(locale: Option<&str>) -> Option<usize> {
+    let normalized = normalized_locale(locale)?;
+    gettext_plural_rule_for_normalized(&normalized)
+        .map(GettextPluralRule::nplurals)
+        .or_else(|| icu_plural_categories_for(&normalized).map(|categories| categories.len()))
 }
 
 const fn plural_category_name(category: PluralCategory) -> &'static str {
@@ -589,10 +901,12 @@ mod tests {
     use std::sync::Mutex;
 
     use super::{
-        IcuPluralProjection, PluralProfile, cached_icu_plural_categories_for,
-        derive_plural_variable, fallback_plural_categories, looks_like_projectable_icu_plural,
-        materialize_plural_categories, normalize_plural_locale, project_icu_plural,
-        sorted_plural_keys, split_icu_kind, synthesize_icu_plural,
+        GETTEXT_ARABIC_HEADER, GETTEXT_ONE_FORM_HEADER, GETTEXT_POLISH_HEADER,
+        GETTEXT_SLAVIC_THREE_FORM_HEADER, GETTEXT_ZERO_ONE_HEADER, IcuPluralProjection,
+        PluralProfile, cached_icu_plural_categories_for, derive_plural_variable,
+        expected_gettext_nplurals_for_locale, fallback_plural_categories,
+        looks_like_projectable_icu_plural, materialize_plural_categories, normalize_plural_locale,
+        project_icu_plural, sorted_plural_keys, split_icu_kind, synthesize_icu_plural,
     };
 
     #[test]
@@ -641,7 +955,7 @@ mod tests {
 
     #[test]
     fn plural_profiles_and_category_helpers_fill_expected_shapes() {
-        let profile = PluralProfile::for_translation(
+        let profile = PluralProfile::for_gettext_translation(
             Some("fr"),
             &BTreeMap::from([
                 ("one".to_owned(), "un".to_owned()),
@@ -689,7 +1003,7 @@ mod tests {
         );
         assert_eq!(
             profile.gettext_header().as_deref(),
-            Some("nplurals=2; plural=(n != 1);")
+            Some(GETTEXT_ZERO_ONE_HEADER)
         );
         assert_eq!(
             materialize_plural_categories(
@@ -701,6 +1015,44 @@ mod tests {
                 ("other".to_owned(), String::new()),
             ])
         );
+    }
+
+    #[test]
+    fn gettext_plural_profiles_use_safe_locale_table() {
+        let cases = [
+            ("fr", GETTEXT_ZERO_ONE_HEADER, &["one", "other"][..]),
+            ("pt_BR", GETTEXT_ZERO_ONE_HEADER, &["one", "other"]),
+            ("pl", GETTEXT_POLISH_HEADER, &["one", "few", "other"]),
+            (
+                "ru",
+                GETTEXT_SLAVIC_THREE_FORM_HEADER,
+                &["one", "few", "other"],
+            ),
+            (
+                "ar",
+                GETTEXT_ARABIC_HEADER,
+                &["zero", "one", "two", "few", "many", "other"],
+            ),
+            ("ja", GETTEXT_ONE_FORM_HEADER, &["other"]),
+        ];
+
+        for (locale, header, categories) in cases {
+            let profile = PluralProfile::for_gettext_locale(Some(locale));
+            let expected_categories = static_test_categories(categories);
+            assert_eq!(profile.gettext_header().as_deref(), Some(header));
+            assert_eq!(profile.categories(), expected_categories);
+            assert_eq!(
+                expected_gettext_nplurals_for_locale(Some(locale)),
+                Some(categories.len())
+            );
+        }
+    }
+
+    #[test]
+    fn gettext_plural_profiles_do_not_guess_headers_for_unlisted_locales() {
+        let profile = PluralProfile::for_gettext_locale(Some("ga"));
+
+        assert_eq!(profile.gettext_header(), None);
     }
 
     #[test]
@@ -870,5 +1222,9 @@ mod tests {
             PluralProfile::for_gettext_slots(Some("und"), Some(1)).nplurals(),
             1
         );
+    }
+
+    fn static_test_categories(categories: &[&str]) -> Vec<String> {
+        categories.iter().copied().map(str::to_owned).collect()
     }
 }

--- a/crates/ferrocat-po/src/api/tests/catalog.rs
+++ b/crates/ferrocat-po/src/api/tests/catalog.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const POLISH_PLURAL_FORMS: &str = "nplurals=3; plural=(n == 1 ? 0 : (n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)) ? 1 : 2);";
+
 #[test]
 fn update_catalog_creates_new_source_locale_messages() {
     let result = update_catalog(UpdateCatalogOptions {
@@ -630,7 +632,7 @@ fn parse_catalog_reports_plural_forms_locale_mismatch() {
             "msgid \"\"\n",
             "msgstr \"\"\n",
             "\"Language: fr\\n\"\n",
-            "\"Plural-Forms: nplurals=2; plural=(n != 1);\\n\"\n",
+            "\"Plural-Forms: nplurals=3; plural=(n != 1);\\n\"\n",
         ),
         locale: Some("fr"),
         source_locale: "en",
@@ -643,6 +645,32 @@ fn parse_catalog_reports_plural_forms_locale_mismatch() {
 
     assert!(
         parsed
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "plural.nplurals_locale_mismatch")
+    );
+}
+
+#[test]
+fn parse_catalog_accepts_safe_gettext_plural_forms_for_french() {
+    let parsed = parse_catalog(ParseCatalogOptions {
+        content: concat!(
+            "msgid \"\"\n",
+            "msgstr \"\"\n",
+            "\"Language: fr\\n\"\n",
+            "\"Plural-Forms: nplurals=2; plural=(n > 1);\\n\"\n",
+        ),
+        locale: Some("fr"),
+        source_locale: "en",
+        storage_format: CatalogStorageFormat::Po,
+        semantics: CatalogSemantics::GettextCompat,
+        plural_encoding: PluralEncoding::Gettext,
+        strict: false,
+    })
+    .expect("parse");
+
+    assert!(
+        !parsed
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.code == "plural.nplurals_locale_mismatch")
@@ -965,7 +993,7 @@ fn update_catalog_gettext_export_emits_plural_slots() {
 }
 
 #[test]
-fn update_catalog_gettext_export_uses_icu_plural_categories_for_french() {
+fn update_catalog_gettext_export_uses_safe_plural_profile_for_french() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
         locale: Some("fr"),
@@ -985,7 +1013,13 @@ fn update_catalog_gettext_export_uses_icu_plural_categories_for_french() {
     .expect("update");
 
     let parsed = parse_po(&result.content).expect("parse output");
-    assert_eq!(parsed.items[0].msgstr.len(), 3);
+    assert_eq!(parsed.items[0].msgstr.len(), 2);
+    let plural_forms = parsed
+        .headers
+        .iter()
+        .find(|header| header.key == "Plural-Forms")
+        .map(|header| header.value.as_str());
+    assert_eq!(plural_forms, Some("nplurals=2; plural=(n > 1);"));
 }
 
 #[test]
@@ -1013,10 +1047,41 @@ fn update_catalog_gettext_sets_safe_plural_forms_header_for_two_form_locale() {
 }
 
 #[test]
+fn update_catalog_gettext_sets_safe_plural_forms_header_for_multi_form_locale() {
+    let result = update_catalog(UpdateCatalogOptions {
+        source_locale: "en",
+        locale: Some("pl"),
+        semantics: CatalogSemantics::GettextCompat,
+        plural_encoding: PluralEncoding::Gettext,
+        input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {
+            msgid: "Hello".to_owned(),
+            ..ExtractedSingularMessage::default()
+        })]),
+        ..UpdateCatalogOptions::default()
+    })
+    .expect("update");
+
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "plural.missing_plural_forms_header")
+    );
+
+    let parsed = parse_po(&result.content).expect("parse output");
+    let plural_forms = parsed
+        .headers
+        .iter()
+        .find(|header| header.key == "Plural-Forms")
+        .map(|header| header.value.as_str());
+    assert_eq!(plural_forms, Some(POLISH_PLURAL_FORMS));
+}
+
+#[test]
 fn update_catalog_gettext_reports_when_no_safe_plural_forms_header_is_known() {
     let result = update_catalog(UpdateCatalogOptions {
         source_locale: "en",
-        locale: Some("fr"),
+        locale: Some("ga"),
         semantics: CatalogSemantics::GettextCompat,
         plural_encoding: PluralEncoding::Gettext,
         input: structured_input(vec![ExtractedMessage::Singular(ExtractedSingularMessage {

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -455,6 +455,12 @@ Updates also use an explicit `CatalogSemantics`:
 - `IcuNative` is the default and writes raw ICU/text messages
 - `GettextCompat` is the explicit PO-interop mode and writes classic gettext plurals
 
+In `GettextCompat` mode, Ferrocat synthesizes `Plural-Forms` only for safe
+locale defaults that it knows, including common one-form, Germanic/Romance
+two-form, French/Brazilian Portuguese, Slavic three-form, Polish, Czech/Slovak,
+and Arabic rules. Unknown locales keep the header unset and report a diagnostic
+instead of guessing a plural expression.
+
 In native mode, `CatalogUpdateInput::SourceFirst` stays source-text-first; it no longer auto-projects ICU strings into structured plural messages. Use `CatalogUpdateInput::Structured` when you want explicit plural structure.
 
 In `NDJSON` storage, arbitrary gettext-style custom headers are intentionally out of scope for `v1`; only the explicit frontmatter metadata and per-record fields are persisted. Machine-translation metadata uses the optional `mt` record field and remains part of `ferrocat.ndjson.v1`.


### PR DESCRIPTION
Closes #60.

## Summary
- add a private gettext plural-rule table for common safe locale families, including French, Polish, Russian, Arabic, and one-form locales
- route GettextCompat merge, header synthesis, export, and Plural-Forms validation through gettext-specific plural profiles
- keep unknown locales conservative by leaving Plural-Forms unset and reporting the existing diagnostic
- document the safe-header behavior in the API overview

## Validation
- cargo fmt --all --check
- git diff --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- cargo +1.93.0 check --workspace --all-targets --all-features --locked
- pnpm build (from docs/)
- cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked

Reference: GNU gettext plural-form families: https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html