### PR TITLE
feat(api): add serializable schema outputs

### DIFF
--- a/crates/ferrocat-po/Cargo.toml
+++ b/crates/ferrocat-po/Cargo.toml
@@ -22,17 +22,17 @@ catalog = [
     "dep:ferrocat-icu",
     "dep:icu_locale",
     "dep:icu_plurals",
-    "dep:serde",
     "dep:serde_json",
     "dep:sha2",
     "dep:tempfile",
     "ferrocat-icu/serde",
+    "serde",
 ]
 compile = ["catalog"]
 mt = ["catalog"]
 ndjson = ["catalog"]
 plurals = ["catalog"]
-serde = ["catalog"]
+serde = ["dep:serde"]
 
 [dependencies]
 ferrocat-icu = { version = "0.13.0", path = "../ferrocat-icu", default-features = false, optional = true }
@@ -49,6 +49,7 @@ all-features = true
 
 [dev-dependencies]
 ferrocat-conformance = { path = "../ferrocat-conformance" }
+serde_json = "1.0.145"
 
 [lints]
 workspace = true

--- a/crates/ferrocat-po/src/api.rs
+++ b/crates/ferrocat-po/src/api.rs
@@ -18,11 +18,11 @@ pub use self::compile::{
     compile_catalog_artifact, compile_catalog_artifact_selected, compiled_key,
 };
 pub use self::compile_types::{
-    CompileCatalogArtifactOptions, CompileCatalogOptions, CompileSelectedCatalogArtifactOptions,
-    CompiledCatalog, CompiledCatalogArtifact, CompiledCatalogDiagnostic,
-    CompiledCatalogIdDescription, CompiledCatalogIdIndex, CompiledCatalogMissingMessage,
-    CompiledCatalogTranslationKind, CompiledCatalogUnavailableId, CompiledKeyStrategy,
-    CompiledMessage, CompiledTranslation, DescribeCompiledIdsReport,
+    COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION, CompileCatalogArtifactOptions, CompileCatalogOptions,
+    CompileSelectedCatalogArtifactOptions, CompiledCatalog, CompiledCatalogArtifact,
+    CompiledCatalogDiagnostic, CompiledCatalogIdDescription, CompiledCatalogIdIndex,
+    CompiledCatalogMissingMessage, CompiledCatalogTranslationKind, CompiledCatalogUnavailableId,
+    CompiledKeyStrategy, CompiledMessage, CompiledTranslation, DescribeCompiledIdsReport,
 };
 pub use self::mt::{MachineTranslationMetadata, machine_translation_hash};
 pub use self::ndjson::{

--- a/crates/ferrocat-po/src/api/audit.rs
+++ b/crates/ferrocat-po/src/api/audit.rs
@@ -4,6 +4,8 @@ use ferrocat_icu::{
     IcuCompatibilityOptions, IcuDiagnosticSeverity, MessageMetadataInput, compare_icu_messages,
     normalize_message_metadata, parse_icu, validate_message_metadata,
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::{
     ApiError, CatalogMessage, CatalogMessageKey, DiagnosticSeverity, EffectiveTranslationRef,
@@ -69,6 +71,8 @@ impl Default for CatalogAuditChecks {
 
 /// Summary counters for a catalog audit report.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CatalogAuditSummary {
     /// Active source messages considered expected by the audit.
     pub source_messages: usize,
@@ -86,6 +90,8 @@ pub struct CatalogAuditSummary {
 
 /// Catalog message reference attached to audit diagnostics.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CatalogAuditMessageRef {
     /// Locale associated with the diagnostic, when known.
     pub locale: Option<String>,
@@ -107,6 +113,8 @@ impl CatalogAuditMessageRef {
 
 /// One machine-readable catalog audit diagnostic.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CatalogAuditDiagnostic {
     /// Severity for the diagnostic.
     pub severity: DiagnosticSeverity,
@@ -140,6 +148,8 @@ impl CatalogAuditDiagnostic {
 
 /// Report returned by [`audit_catalogs`].
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CatalogAuditReport {
     /// Aggregate audit counters.
     pub summary: CatalogAuditSummary,
@@ -585,4 +595,45 @@ fn finalize_summary(
         }
     }
     report.summary = summary;
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::{
+        CatalogAuditDiagnostic, CatalogAuditMessageRef, CatalogAuditReport, CatalogAuditSummary,
+    };
+    use crate::api::DiagnosticSeverity;
+
+    #[test]
+    fn catalog_audit_report_serde_round_trips_ci_report_shape() {
+        let report = CatalogAuditReport {
+            summary: CatalogAuditSummary {
+                source_messages: 1,
+                target_locales: 1,
+                diagnostics: 1,
+                errors: 1,
+                warnings: 0,
+                infos: 0,
+            },
+            diagnostics: vec![CatalogAuditDiagnostic {
+                severity: DiagnosticSeverity::Error,
+                code: "catalog.missing_translation".to_owned(),
+                message: "missing target translation".to_owned(),
+                source_key: Some(CatalogAuditMessageRef {
+                    locale: Some("de".to_owned()),
+                    msgid: "Checkout".to_owned(),
+                    msgctxt: None,
+                }),
+                name: Some("de".to_owned()),
+            }],
+        };
+
+        let json = serde_json::to_value(&report).expect("audit report serialization must succeed");
+        assert_eq!(json["diagnostics"][0]["severity"], "error");
+        assert_eq!(json["summary"]["errors"], 1);
+
+        let roundtrip: CatalogAuditReport =
+            serde_json::from_value(json).expect("audit report deserialization must succeed");
+        assert_eq!(roundtrip, report);
+    }
 }

--- a/crates/ferrocat-po/src/api/compile_types.rs
+++ b/crates/ferrocat-po/src/api/compile_types.rs
@@ -8,8 +8,19 @@ use super::{
     },
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// JSON schema version emitted by [`CompiledCatalogArtifact`] serialization.
+pub const COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION: u16 = 1;
+
 /// Translation value stored in a compiled runtime catalog.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(tag = "kind", content = "value", rename_all = "snake_case")
+)]
 pub enum CompiledTranslation {
     /// Singular runtime value.
     Singular(String),
@@ -19,6 +30,8 @@ pub enum CompiledTranslation {
 
 /// Built-in key strategy used when compiling runtime catalogs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 pub enum CompiledKeyStrategy {
     /// `ferrocat` v1 key format: SHA-256 over a versioned, length-delimited
     /// `msgctxt`/`msgid` payload, truncated to 64 bits and encoded as unpadded
@@ -182,6 +195,8 @@ impl<'a> CompileSelectedCatalogArtifactOptions<'a> {
 
 /// High-level translation kind associated with a compiled runtime ID.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 pub enum CompiledCatalogTranslationKind {
     /// Translation is a single string value.
     Singular,
@@ -191,6 +206,8 @@ pub enum CompiledCatalogTranslationKind {
 
 /// A compiled runtime message keyed by a derived lookup key.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CompiledMessage {
     /// Stable runtime key derived from the source identity.
     pub key: String,
@@ -202,6 +219,8 @@ pub struct CompiledMessage {
 
 /// Runtime-oriented lookup structure compiled from a normalized catalog.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CompiledCatalog {
     pub(super) entries: BTreeMap<String, CompiledMessage>,
 }
@@ -235,12 +254,16 @@ impl CompiledCatalog {
 
 /// Stable compiled runtime ID index built from one or more normalized catalogs.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CompiledCatalogIdIndex {
     pub(super) ids: BTreeMap<String, CatalogMessageKey>,
 }
 
 /// Metadata describing one compiled runtime ID for a specific catalog set.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CompiledCatalogIdDescription {
     /// Stable runtime ID derived from the source identity.
     pub compiled_id: String,
@@ -254,6 +277,8 @@ pub struct CompiledCatalogIdDescription {
 
 /// Report returned by [`CompiledCatalogIdIndex::describe_compiled_ids`].
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct DescribeCompiledIdsReport {
     /// Metadata for requested IDs that were known to the index and present in the provided catalogs.
     pub described: Vec<CompiledCatalogIdDescription>,
@@ -265,6 +290,8 @@ pub struct DescribeCompiledIdsReport {
 
 /// Known compiled runtime ID that was not present in the provided catalog set.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CompiledCatalogUnavailableId {
     /// Stable runtime ID derived from the source identity.
     pub compiled_id: String,
@@ -434,6 +461,11 @@ impl CompiledCatalogIdIndex {
 }
 
 /// Host-neutral compiled runtime artifact for one requested locale.
+///
+/// When the `serde` feature is enabled, this type serializes with
+/// [`COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION`] as a required
+/// `schema_version` field. Deserialization rejects unknown artifact schema
+/// versions.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CompiledCatalogArtifact {
     /// Final runtime message map keyed by the derived lookup key.
@@ -444,8 +476,70 @@ pub struct CompiledCatalogArtifact {
     pub diagnostics: Vec<CompiledCatalogDiagnostic>,
 }
 
+#[cfg(feature = "serde")]
+#[derive(Serialize)]
+struct CompiledCatalogArtifactWireRef<'a> {
+    schema_version: u16,
+    messages: &'a BTreeMap<String, String>,
+    missing: &'a [CompiledCatalogMissingMessage],
+    diagnostics: &'a [CompiledCatalogDiagnostic],
+}
+
+#[cfg(feature = "serde")]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompiledCatalogArtifactWire {
+    schema_version: u16,
+    #[serde(default)]
+    messages: BTreeMap<String, String>,
+    #[serde(default)]
+    missing: Vec<CompiledCatalogMissingMessage>,
+    #[serde(default)]
+    diagnostics: Vec<CompiledCatalogDiagnostic>,
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for CompiledCatalogArtifact {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        CompiledCatalogArtifactWireRef {
+            schema_version: COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION,
+            messages: &self.messages,
+            missing: &self.missing,
+            diagnostics: &self.diagnostics,
+        }
+        .serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for CompiledCatalogArtifact {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = CompiledCatalogArtifactWire::deserialize(deserializer)?;
+        if wire.schema_version != COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION {
+            return Err(serde::de::Error::custom(format!(
+                "unsupported compiled catalog artifact schema_version {}; expected {}",
+                wire.schema_version, COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION
+            )));
+        }
+
+        Ok(Self {
+            messages: wire.messages,
+            missing: wire.missing,
+            diagnostics: wire.diagnostics,
+        })
+    }
+}
+
 /// Missing-message record emitted by [`super::compile_catalog_artifact`].
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CompiledCatalogMissingMessage {
     /// Stable runtime key derived from the source identity.
     pub key: String,
@@ -459,6 +553,8 @@ pub struct CompiledCatalogMissingMessage {
 
 /// Diagnostic emitted by [`super::compile_catalog_artifact`].
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CompiledCatalogDiagnostic {
     /// Severity for the collected diagnostic.
     pub severity: super::DiagnosticSeverity,
@@ -478,11 +574,14 @@ pub struct CompiledCatalogDiagnostic {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::{
-        CompileCatalogArtifactOptions, CompileCatalogOptions,
-        CompileSelectedCatalogArtifactOptions, CompiledKeyStrategy,
+        COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION, CompileCatalogArtifactOptions,
+        CompileCatalogOptions, CompileSelectedCatalogArtifactOptions, CompiledCatalogArtifact,
+        CompiledCatalogDiagnostic, CompiledCatalogMissingMessage, CompiledKeyStrategy,
     };
-    use crate::api::CatalogSemantics;
+    use crate::api::{CatalogMessageKey, CatalogSemantics, DiagnosticSeverity};
 
     #[test]
     fn compile_option_constructors_set_required_fields_and_keep_defaults() {
@@ -502,5 +601,58 @@ mod tests {
         assert_eq!(selected.source_locale, "en");
         assert_eq!(selected.compiled_ids, selected_ids.as_slice());
         assert_eq!(selected.key_strategy, CompiledKeyStrategy::FerrocatV1);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn compiled_catalog_artifact_serde_uses_versioned_wire_contract() {
+        let artifact = CompiledCatalogArtifact {
+            messages: BTreeMap::from([("runtime-key".to_owned(), "Hallo".to_owned())]),
+            missing: vec![CompiledCatalogMissingMessage {
+                key: "runtime-key".to_owned(),
+                source_key: CatalogMessageKey::new("Hello", None),
+                requested_locale: "de".to_owned(),
+                resolved_locale: Some("en".to_owned()),
+            }],
+            diagnostics: vec![CompiledCatalogDiagnostic {
+                severity: DiagnosticSeverity::Warning,
+                code: "icu.syntax".to_owned(),
+                message: "invalid ICU message".to_owned(),
+                key: "runtime-key".to_owned(),
+                msgid: "Hello".to_owned(),
+                msgctxt: None,
+                locale: "de".to_owned(),
+            }],
+        };
+
+        let json = serde_json::to_value(&artifact).expect("artifact serialization must succeed");
+        assert_eq!(
+            json["schema_version"],
+            COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION
+        );
+        assert_eq!(json["diagnostics"][0]["severity"], "warning");
+
+        let roundtrip: CompiledCatalogArtifact =
+            serde_json::from_value(json).expect("artifact deserialization must succeed");
+        assert_eq!(roundtrip, artifact);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn compiled_catalog_artifact_serde_rejects_unknown_schema_version() {
+        let json = serde_json::json!({
+            "schema_version": COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION + 1,
+            "messages": {},
+            "missing": [],
+            "diagnostics": [],
+        });
+
+        let error = serde_json::from_value::<CompiledCatalogArtifact>(json)
+            .expect_err("unknown artifact schema versions must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported compiled catalog artifact schema_version")
+        );
     }
 }

--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -7,8 +7,13 @@ use crate::ParseError;
 use super::mt::MachineTranslationMetadata;
 use super::plural::PluralProfile;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// File and line information for an extracted message origin.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CatalogOrigin {
     /// Path-like source identifier where the message came from.
     pub file: String,
@@ -33,6 +38,8 @@ pub struct ExtractedSingularMessage {
 
 /// Source-side plural forms for structured catalog messages.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct PluralSource {
     /// Singular source form, when one exists separately from `other`.
     pub one: Option<String>,
@@ -110,6 +117,8 @@ impl From<Vec<SourceExtractedMessage>> for CatalogUpdateInput {
 
 /// Public translation shape returned from parsed catalogs.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "kind", rename_all = "snake_case"))]
 pub enum TranslationShape {
     /// Message represented by a single string value.
     Singular {
@@ -147,6 +156,8 @@ pub enum EffectiveTranslation {
 
 /// Extra translator-facing metadata preserved on a catalog message.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CatalogMessageExtra {
     /// Translator comments that were attached to the original PO item.
     pub translator_comments: Vec<String>,
@@ -156,6 +167,8 @@ pub struct CatalogMessageExtra {
 
 /// Public message representation returned by [`super::parse_catalog`].
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CatalogMessage {
     /// Source message identifier.
     pub msgid: String,
@@ -243,6 +256,8 @@ impl CatalogMessage {
 
 /// Stable lookup key for catalog messages.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CatalogMessageKey {
     /// Source message identifier.
     pub msgid: String,
@@ -263,6 +278,8 @@ impl CatalogMessageKey {
 
 /// Severity level attached to a [`Diagnostic`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum DiagnosticSeverity {
     /// Informational message that does not indicate a problem.
     Info,
@@ -274,6 +291,8 @@ pub enum DiagnosticSeverity {
 
 /// Non-fatal issue collected while parsing or updating catalogs.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct Diagnostic {
     /// Severity level for the diagnostic.
     pub severity: DiagnosticSeverity,
@@ -1254,5 +1273,43 @@ mod tests {
             ApiError::Unsupported("unsupported".to_owned()).to_string(),
             "unsupported"
         );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn catalog_message_and_diagnostic_serde_use_stable_public_shapes() {
+        let message = CatalogMessage {
+            msgid: "Hello".to_owned(),
+            msgctxt: Some("button".to_owned()),
+            translation: TranslationShape::Singular {
+                value: "Hallo".to_owned(),
+            },
+            comments: vec!["Shown in toolbar".to_owned()],
+            origin: Vec::new(),
+            obsolete: false,
+            machine_translation: None,
+            extra: None,
+        };
+        let message_json =
+            serde_json::to_value(&message).expect("catalog message serialization must succeed");
+        assert_eq!(message_json["translation"]["kind"], "singular");
+
+        let roundtrip_message: CatalogMessage = serde_json::from_value(message_json)
+            .expect("catalog message deserialization must succeed");
+        assert_eq!(roundtrip_message, message);
+
+        let diagnostic = Diagnostic::new(
+            DiagnosticSeverity::Error,
+            "catalog.missing",
+            "missing translation",
+        )
+        .with_identity("Hello", Some("button"));
+        let diagnostic_json =
+            serde_json::to_value(&diagnostic).expect("diagnostic serialization must succeed");
+        assert_eq!(diagnostic_json["severity"], "error");
+
+        let roundtrip_diagnostic: Diagnostic = serde_json::from_value(diagnostic_json)
+            .expect("diagnostic deserialization must succeed");
+        assert_eq!(roundtrip_diagnostic, diagnostic);
     }
 }

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -91,11 +91,11 @@ mod utf8;
 
 #[cfg(feature = "catalog")]
 pub use api::{
-    ApiError, CatalogAuditChecks, CatalogAuditDiagnostic, CatalogAuditMessageRef,
-    CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary, CatalogCombineInput,
-    CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats, CatalogConflictStrategy,
-    CatalogMessage, CatalogMessageExtra, CatalogMessageKey, CatalogOrigin, CatalogSemantics,
-    CatalogStats, CatalogStorageFormat, CatalogUpdateInput, CatalogUpdateResult,
+    ApiError, COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION, CatalogAuditChecks, CatalogAuditDiagnostic,
+    CatalogAuditMessageRef, CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary,
+    CatalogCombineInput, CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats,
+    CatalogConflictStrategy, CatalogMessage, CatalogMessageExtra, CatalogMessageKey, CatalogOrigin,
+    CatalogSemantics, CatalogStats, CatalogStorageFormat, CatalogUpdateInput, CatalogUpdateResult,
     CombineCatalogOptions, CompileCatalogArtifactOptions, CompileCatalogOptions,
     CompileSelectedCatalogArtifactOptions, CompiledCatalog, CompiledCatalogArtifact,
     CompiledCatalogDiagnostic, CompiledCatalogIdDescription, CompiledCatalogIdIndex,
@@ -120,8 +120,13 @@ pub use text::{escape_string, extract_quoted, extract_quoted_cow, unescape_strin
 
 use core::{fmt, ops::Index};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// An owned PO document.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct PoFile {
     /// File-level translator comments that appear before the header block.
     pub comments: Vec<String>,
@@ -135,6 +140,8 @@ pub struct PoFile {
 
 /// A single header entry from the PO header block.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct Header {
     /// Header name such as `Language` or `Plural-Forms`.
     pub key: String,
@@ -144,6 +151,8 @@ pub struct Header {
 
 /// A single gettext message entry.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct PoItem {
     /// Source message identifier.
     pub msgid: String,
@@ -196,6 +205,11 @@ impl PoItem {
 
 /// Message translation payload for a PO item.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(tag = "kind", content = "value", rename_all = "snake_case")
+)]
 pub enum MsgStr {
     /// No translation values are present.
     #[default]
@@ -464,7 +478,7 @@ impl std::error::Error for ParseError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{MsgStr, ParseError, ParsePosition};
+    use super::{Header, MsgStr, ParseError, ParsePosition, PoFile, PoItem};
 
     #[test]
     fn parse_error_accessors_preserve_message_and_optional_position() {
@@ -532,5 +546,33 @@ mod tests {
         assert_eq!(plural.iter().collect::<Vec<_>>(), vec!["eins", "viele"]);
         assert_eq!(plural[1], "viele");
         assert_eq!(plural.into_vec(), vec!["eins", "viele"]);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn po_file_serde_round_trips_owned_document_shape() {
+        let file = PoFile {
+            comments: vec!["translator note".to_owned()],
+            headers: vec![Header {
+                key: "Language".to_owned(),
+                value: "de".to_owned(),
+            }],
+            items: vec![PoItem {
+                msgid: "Hello".to_owned(),
+                msgstr: MsgStr::from("Hallo".to_owned()),
+                references: vec!["src/app.rs:10".to_owned()],
+                nplurals: 1,
+                ..PoItem::default()
+            }],
+            ..PoFile::default()
+        };
+
+        let json = serde_json::to_value(&file).expect("PO file serialization must succeed");
+        assert_eq!(json["items"][0]["msgstr"]["kind"], "singular");
+        assert_eq!(json["items"][0]["msgstr"]["value"], "Hallo");
+
+        let roundtrip: PoFile =
+            serde_json::from_value(json).expect("PO file deserialization must succeed");
+        assert_eq!(roundtrip, file);
     }
 }

--- a/crates/ferrocat/Cargo.toml
+++ b/crates/ferrocat/Cargo.toml
@@ -23,7 +23,7 @@ compile = ["catalog", "ferrocat-po/compile"]
 mt = ["catalog", "ferrocat-po/mt"]
 ndjson = ["catalog", "ferrocat-po/ndjson"]
 plurals = ["catalog", "ferrocat-po/plurals"]
-serde = ["catalog", "ferrocat-po/serde", "ferrocat-icu/serde"]
+serde = ["ferrocat-po/serde", "ferrocat-icu/serde"]
 
 [dependencies]
 ferrocat-icu = { version = "0.13.0", path = "../ferrocat-icu", default-features = false }

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -95,6 +95,10 @@ pub use ferrocat_icu::{
     validate_message_metadata,
 };
 #[cfg(feature = "catalog")]
+/// JSON schema version emitted by [`CompiledCatalogArtifact`] serialization.
+pub const COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION: u16 = 1;
+
+#[cfg(feature = "catalog")]
 pub use ferrocat_po::{
     ApiError, CatalogAuditChecks, CatalogAuditDiagnostic, CatalogAuditMessageRef,
     CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary, CatalogCombineInput,

--- a/docs/app/routes/architecture/adr/0019-versioned-artifact-json-contract.mdx
+++ b/docs/app/routes/architecture/adr/0019-versioned-artifact-json-contract.mdx
@@ -1,0 +1,136 @@
+---
+title: "ADR 0019: Version the Compiled Artifact JSON Contract"
+description: "Accepted architecture decision record: versioned compiled artifact JSON contract."
+order: 190
+---
+
+# ADR 0019: Version the Compiled Artifact JSON Contract
+
+- Status: Accepted
+- Date: 2026-06-16
+
+## Context
+
+Ferrocat exposes Rust-native catalog types, but downstream host adapters, CI
+jobs, caches, and editor tooling often need to move selected outputs across a
+process boundary. `serde` support is useful for that, but not every Rust struct
+should automatically become a durable host contract.
+
+The highest-risk boundary is the locale-resolved compiled runtime artifact from
+`compile_catalog_artifact` and `compile_catalog_artifact_selected`. Palamedes
+and other host adapters can treat that payload as the handoff point between
+catalog semantics and host-specific packaging.
+
+Audit reports are also useful as JSON in CI, but their shape follows the Rust
+report API and does not need a separate schema-version field yet.
+
+## Decision
+
+Ferrocat adds opt-in `serde` support for transport-oriented API outputs:
+
+- low-level owned PO documents: `PoFile`, `PoItem`, `Header`, and `MsgStr`
+- high-level catalog messages and message diagnostics
+- catalog audit reports and audit diagnostics
+- compiled catalogs, compiled ID reports, and compiled artifact diagnostics
+- `CompiledCatalogArtifact`
+
+`CompiledCatalogArtifact` uses an explicit JSON wire contract instead of a
+plain derived Rust struct representation. The current contract is schema
+version `1` and serializes as:
+
+```json
+{
+  "schema_version": 1,
+  "messages": {
+    "<compiled-key>": "<runtime ICU message>"
+  },
+  "missing": [
+    {
+      "key": "<compiled-key>",
+      "source_key": {
+        "msgid": "Checkout",
+        "msgctxt": null
+      },
+      "requested_locale": "de",
+      "resolved_locale": "en"
+    }
+  ],
+  "diagnostics": [
+    {
+      "severity": "warning",
+      "code": "icu.syntax",
+      "message": "invalid ICU message",
+      "key": "<compiled-key>",
+      "msgid": "Checkout",
+      "msgctxt": null,
+      "locale": "de"
+    }
+  ]
+}
+```
+
+`schema_version` is required when deserializing a compiled artifact. Ferrocat
+rejects unknown compiled artifact schema versions instead of silently accepting
+payloads with semantics it cannot prove it understands.
+
+Diagnostic severities serialize as lowercase strings: `info`, `warning`, and
+`error`.
+
+## Consequences
+
+Positive:
+
+- host adapters can share one versioned artifact payload without copying
+  Ferrocat's internal Rust structs into JS/TS binding code
+- CI can consume audit reports as stable JSON objects with machine-readable
+  codes and lowercase severities
+- parser-focused users can enable the `serde` feature for low-level PO data
+  without opting into the full catalog feature profile
+
+Negative:
+
+- compiled artifact JSON changes now need compatibility review
+- the artifact deserializer intentionally rejects unknown schema versions, so
+  host adapters must handle version negotiation explicitly
+- most derived serde shapes remain Rust API shapes, not independently versioned
+  wire protocols
+
+## Compatibility Rules
+
+For `CompiledCatalogArtifact` JSON:
+
+- keep `schema_version` present and numeric
+- bump the schema version for removed fields, renamed fields, changed field
+  meanings, or changed severity/code semantics
+- prefer additive changes only when older consumers can safely ignore them; if
+  they cannot, bump the schema version
+- keep `messages` sorted by compiled key through the underlying ordered map
+- keep diagnostic `code` values machine-readable and stable once documented
+
+For audit reports and other derived serde outputs:
+
+- treat the JSON as the serde form of the Rust public API
+- avoid changing field names or enum spelling without a semver-relevant Rust API
+  decision
+- add a separate schema version later if a host adapter needs to consume one of
+  those outputs as a long-lived protocol independent of Rust releases
+
+## Alternatives Considered
+
+### Derive Serde For Everything
+
+Rejected because it would make incidental Rust structure look like a durable
+host protocol. The compiled artifact is a cross-process contract and deserves a
+version field.
+
+### Add Schema Versions To Every Serializable Type
+
+Rejected for now. PO parser output, catalog messages, and audit reports are
+useful through serde, but the strongest compatibility requirement is the
+runtime artifact handoff to host adapters.
+
+### Leave Versioning To Palamedes
+
+Rejected because the artifact semantics are produced by Ferrocat. If Ferrocat
+owns the locale-resolution and fallback rules, it should also version the JSON
+payload that represents those rules.

--- a/docs/app/routes/architecture/adr/index.mdx
+++ b/docs/app/routes/architecture/adr/index.mdx
@@ -27,3 +27,4 @@ Current records:
 - [0016: Add Progressive Semantic Message Metadata Around `msgid`](/architecture/adr/0016-semantic-message-metadata)
 - [0017: Add Catalog Audit Reports Without Reintroducing Fuzzy Matching](/architecture/adr/0017-catalog-audit-reports)
 - [0018: Add Machine-Translation Metadata to Catalog Entries](/architecture/adr/0018-machine-translation-entry-metadata)
+- [0019: Version the Compiled Artifact JSON Contract](/architecture/adr/0019-versioned-artifact-json-contract)

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -27,20 +27,49 @@ The published crates keep the default feature set convenient: `ferrocat`,
 
 Lean parser consumers can opt out with `default-features = false`. For
 `ferrocat-po`, that leaves the PO parser, borrowed parser, serializer, string
-escape helpers, and low-level merge API available without pulling in serde,
-SHA-256 hashing, tempfile, or ICU4X CLDR plural data.
+escape helpers, and low-level merge API available without pulling in SHA-256
+hashing, tempfile, or ICU4X CLDR plural data. Add the `serde` feature when that
+lean parser output should be serialized for caches or tooling.
 
 The named feature profiles are:
 
 - `full`: the default profile with the complete current API surface
 - `catalog`: high-level catalog update, parse, combine, audit, metadata, NDJSON,
   plural, and runtime compile support
-- `serde`: serde implementations used by schema/tooling-oriented consumers
+- `serde`: serde implementations used by schema, cache, and tooling-oriented
+  consumers; it can be enabled without the full catalog profile for low-level PO
+  document types
 - `compile`, `mt`, `ndjson`, and `plurals`: named subsystem profiles reserved for
   callers that want to declare intent explicitly
 
 `docs.rs` builds with all features enabled so the rendered reference shows the
 full API surface.
+
+## Serialized API Shapes
+
+Enable the `serde` feature when Ferrocat output needs to cross a process
+boundary, feed CI, or back a tooling cache.
+
+Serializable public output includes:
+
+- low-level owned PO documents: `PoFile`, `PoItem`, `Header`, and `MsgStr`
+- high-level `CatalogMessage` values and general `Diagnostic` records
+- `CatalogAuditReport` plus its summary and diagnostic records
+- compiled runtime catalog and compiled-ID report records
+- `CompiledCatalogArtifact`
+
+`CompiledCatalogArtifact` is the host-facing runtime payload and has a versioned
+JSON contract. Serialized artifacts include `schema_version: 1`, `messages`,
+`missing`, and `diagnostics`. Deserialization rejects unknown artifact schema
+versions instead of guessing semantics.
+
+Audit reports intentionally use the serde form of the Rust report API rather
+than a separate schema version. They are stable enough for CI consumption today:
+diagnostics carry machine-readable `code` values, and severities serialize as
+`info`, `warning`, or `error`.
+
+See [ADR 0019](/architecture/adr/0019-versioned-artifact-json-contract) for the
+compatibility rules around the compiled artifact JSON contract.
 
 ## Supported Catalog Modes
 


### PR DESCRIPTION
Closes #57.

Stacking:
- This PR is based on PR #106 because the serde and catalog feature structure from #52 is the intended foundation for this change.
- After #106 merges, this branch can be retargeted or rebased onto main.

Summary:
- Adds serde support for transport-oriented public outputs: low-level PO documents, catalog messages, diagnostics, audit reports, compiled catalog records, and compiled artifact diagnostics.
- Keeps ferrocat-po serde usable without the full catalog profile for parser/cache tooling.
- Gives CompiledCatalogArtifact an explicit versioned JSON wire contract with schema_version 1 and rejects unknown artifact schema versions on deserialize.
- Documents the artifact JSON compatibility rules in ADR 0019 and updates the API overview.

Compatibility:
- Default full features remain the documented full API surface.
- ferrocat-po with no default features plus serde only pulls memchr and serde.
- The separately versioned host-facing JSON contract is limited to CompiledCatalogArtifact; other serde shapes follow the Rust public API.

Validation:
- cargo fmt --all --check
- git diff --check
- cargo check -p ferrocat-po --no-default-features --lib --locked
- cargo check -p ferrocat-po --no-default-features --features serde --lib --locked
- cargo check -p ferrocat-po --no-default-features --features catalog --lib --locked
- cargo check -p ferrocat --no-default-features --features serde --lib --locked
- cargo check -p ferrocat --no-default-features --features catalog --lib --locked
- cargo tree -p ferrocat-po --no-default-features --locked -e normal
- cargo tree -p ferrocat-po --no-default-features --features serde --locked -e normal
- cargo test -p ferrocat-po --no-default-features --features serde --lib --locked
- cargo test -p ferrocat-po --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- cargo +1.93.0 check --workspace --all-targets --all-features --locked
- docs/: pnpm build
- cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked