### PR TITLE
ci(bench): add scheduled benchmark reports

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,61 @@
+name: Benchmark Reports
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: Rust-only benchmark profile to run
+        required: true
+        default: rust-scheduled-v1
+        type: choice
+        options:
+          - rust-scheduled-v1
+          - storage-formats-v1
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rust-benchmark-report:
+    name: Rust benchmark report
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      BENCHMARK_PROFILE: ${{ github.event.inputs.profile || 'rust-scheduled-v1' }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run Rust-only benchmark profile
+        run: |
+          mkdir -p target/benchmark
+          cargo run --release -p ferrocat-bench -- compare "$BENCHMARK_PROFILE" --out "target/benchmark/${BENCHMARK_PROFILE}-${GITHUB_RUN_ID}.json"
+
+      - name: Write benchmark summary
+        run: |
+          {
+            echo "## Rust benchmark report"
+            echo ""
+            echo "- Profile: \`$BENCHMARK_PROFILE\`"
+            echo "- Report artifact: \`benchmark-report-${BENCHMARK_PROFILE}-${GITHUB_RUN_ID}\`"
+            echo "- Policy: informational report only; noisy hosted-runner numbers are not a PR gate."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload benchmark report
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-report-${{ env.BENCHMARK_PROFILE }}-${{ github.run_id }}
+          path: target/benchmark/*.json
+          if-no-files-found: error

--- a/benchmark/profiles/rust-scheduled-v1.json
+++ b/benchmark/profiles/rust-scheduled-v1.json
@@ -1,0 +1,17 @@
+{
+  "name": "rust-scheduled-v1",
+  "minimum_sample_millis": 100,
+  "scenarios": [
+    { "id": "po-parse/mixed-10000/ferrocat-owned", "comparison_group": "po-parse/mixed-10000", "workload": "po-parse", "operation": "parse", "fixture": "mixed-10000", "implementation": "ferrocat-parse", "warmup_runs": 1, "measured_runs": 3 },
+    { "id": "po-parse/mixed-10000/ferrocat-borrowed", "comparison_group": "po-parse/mixed-10000", "workload": "po-parse", "operation": "parse", "fixture": "mixed-10000", "implementation": "ferrocat-parse-borrowed", "warmup_runs": 1, "measured_runs": 3 },
+
+    { "id": "po-stringify/mixed-10000/ferrocat", "comparison_group": "po-stringify/mixed-10000", "workload": "po-stringify", "operation": "stringify", "fixture": "mixed-10000", "implementation": "ferrocat-stringify", "warmup_runs": 1, "measured_runs": 3 },
+    { "id": "po-merge/mixed-10000/ferrocat", "comparison_group": "po-merge/mixed-10000", "workload": "po-merge-update", "operation": "merge", "fixture": "mixed-10000", "implementation": "ferrocat-merge", "warmup_runs": 1, "measured_runs": 3 },
+    { "id": "po-update/catalog-icu-heavy/ferrocat", "comparison_group": "po-update/catalog-icu-heavy", "workload": "po-merge-update", "operation": "update-catalog", "fixture": "catalog-icu-heavy", "implementation": "ferrocat-update-catalog", "warmup_runs": 1, "measured_runs": 3 },
+
+    { "id": "catalog-storage-parse/catalog-modern-de-10000/po", "comparison_group": "catalog-storage-parse/catalog-modern-de-10000", "workload": "catalog-storage-parse", "operation": "parse-catalog", "fixture": "catalog-modern-de-10000", "implementation": "ferrocat-parse-catalog-po", "warmup_runs": 1, "measured_runs": 3 },
+    { "id": "catalog-storage-parse/catalog-modern-de-10000/ndjson", "comparison_group": "catalog-storage-parse/catalog-modern-de-10000", "workload": "catalog-storage-parse", "operation": "parse-catalog", "fixture": "catalog-modern-de-10000", "implementation": "ferrocat-parse-catalog-ndjson", "warmup_runs": 1, "measured_runs": 3 },
+
+    { "id": "icu-parse/icu-nested-1000/ferrocat", "comparison_group": "icu-parse/icu-nested-1000", "workload": "icu-parse", "operation": "parse-icu", "fixture": "icu-nested-1000", "implementation": "ferrocat-parse-icu", "warmup_runs": 1, "measured_runs": 3 }
+  ]
+}

--- a/benchmark/results/README.md
+++ b/benchmark/results/README.md
@@ -1,3 +1,8 @@
-# External Benchmark Reports
+# Benchmark Reports
 
-Store official `ferrocat-bench compare` JSON reports in this directory or a dated subdirectory below it.
+Store official `ferrocat-bench compare` JSON reports in this directory or a
+dated subdirectory below it.
+
+Scheduled GitHub Actions benchmark runs upload JSON reports as workflow
+artifacts instead of committing them here. Copy a report into this directory
+only when it is an intentional release or publication checkpoint.

--- a/crates/ferrocat-bench/src/compare.rs
+++ b/crates/ferrocat-bench/src/compare.rs
@@ -36,7 +36,7 @@ const NOISE_RELATIVE_SPAN_WARNING_THRESHOLD: f64 = 10.0;
 
 pub fn run_verify_benchmark_env() -> Result<(), String> {
     let workspace = workspace_root()?;
-    let detected = BenchmarkEnvironment::detect(&workspace, None)?;
+    let detected = BenchmarkEnvironment::detect(&workspace, None, ToolRequirement::External)?;
 
     println!("benchmark-root: {}", workspace.display());
     println!("system: {}", detected.system_label);
@@ -68,8 +68,8 @@ pub fn run_compare_command(
 ) -> Result<(), String> {
     let workspace = workspace_root()?;
     let options = CompareCliOptions::parse(args)?;
-    let environment = BenchmarkEnvironment::detect(&workspace, None)?;
     let profile = BenchmarkProfile::load(&workspace, profile_name)?;
+    let environment = BenchmarkEnvironment::detect(&workspace, None, profile.tool_requirement())?;
     let report = run_profile(&workspace, &environment, &profile)?;
 
     if let Some(parent) = options.out.parent() {
@@ -406,6 +406,24 @@ impl BenchmarkProfile {
         }
         Ok(profile)
     }
+
+    fn tool_requirement(&self) -> ToolRequirement {
+        if self
+            .scenarios
+            .iter()
+            .any(|scenario| !scenario.implementation.starts_with("ferrocat-"))
+        {
+            ToolRequirement::External
+        } else {
+            ToolRequirement::RustOnly
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ToolRequirement {
+    RustOnly,
+    External,
 }
 
 const fn default_minimum_sample_millis() -> u64 {
@@ -2345,11 +2363,11 @@ struct BenchmarkEnvironment {
 }
 
 impl BenchmarkEnvironment {
-    #[expect(
-        clippy::too_many_lines,
-        reason = "Environment detection keeps all external tool probes together for maintainability."
-    )]
-    fn detect(workspace: &Path, path_override: Option<&OsStr>) -> Result<Self, String> {
+    fn detect(
+        workspace: &Path,
+        path_override: Option<&OsStr>,
+        tool_requirement: ToolRequirement,
+    ) -> Result<Self, String> {
         let mut errors = Vec::new();
         let python_program = preferred_python_program(workspace);
         let os = format!("{}-{}", env::consts::OS, env::consts::ARCH);
@@ -2364,81 +2382,15 @@ impl BenchmarkEnvironment {
                     String::new()
                 }
             };
-        let node_version =
-            match read_command_version_with_path("node", &["--version"], path_override) {
-                Ok(version) => version,
-                Err(error) => {
-                    errors.push(error);
-                    String::new()
-                }
-            };
-        let python_version = match read_command_version_for_program(
-            &python_program,
-            &["--version"],
-            workspace,
-            path_override,
-        ) {
-            Ok(version) => version,
-            Err(error) => {
-                errors.push(error);
-                String::new()
-            }
-        };
-        let msgmerge_version =
-            match read_command_version_with_path("msgmerge", &["--version"], path_override) {
-                Ok(version) => version,
-                Err(error) => {
-                    errors.push(error);
-                    String::new()
-                }
-            };
-        let msgcat_version =
-            match read_command_version_with_path("msgcat", &["--version"], path_override) {
-                Ok(version) => version,
-                Err(error) => {
-                    errors.push(error);
-                    String::new()
-                }
-            };
-        let node_adapter_version = match run_command_capture_with_path(
-            "node",
-            &[
-                OsString::from("--no-warnings"),
-                workspace
-                    .join("benchmark")
-                    .join("node")
-                    .join("adapter.cjs")
-                    .into_os_string(),
-                OsString::from("--check"),
-            ],
-            workspace,
-            path_override,
-        ) {
-            Ok(output) => output.stdout.trim().to_owned(),
-            Err(error) => {
-                errors.push(error);
-                String::new()
-            }
-        };
-        let python_adapter_version = match run_command_capture_with_path(
-            python_program.as_os_str(),
-            &[
-                workspace
-                    .join("benchmark")
-                    .join("python")
-                    .join("adapter.py")
-                    .into_os_string(),
-                OsString::from("--check"),
-            ],
-            workspace,
-            path_override,
-        ) {
-            Ok(output) => output.stdout.trim().to_owned(),
-            Err(error) => {
-                errors.push(error);
-                String::new()
-            }
-        };
+        let mut external = ExternalToolVersions::not_required();
+        if tool_requirement == ToolRequirement::External {
+            external = detect_external_tool_versions(
+                workspace,
+                path_override,
+                &python_program,
+                &mut errors,
+            );
+        }
 
         if !errors.is_empty() {
             return Err(format!(
@@ -2454,12 +2406,12 @@ impl BenchmarkEnvironment {
             cpu_model,
             memory_bytes,
             rustc_version,
-            node_version,
-            python_version,
-            msgmerge_version,
-            msgcat_version,
-            node_adapter_version,
-            python_adapter_version,
+            node_version: external.node_version,
+            python_version: external.python_version,
+            msgmerge_version: external.msgmerge_version,
+            msgcat_version: external.msgcat_version,
+            node_adapter_version: external.node_adapter_version,
+            python_adapter_version: external.python_adapter_version,
             python_program,
         })
     }
@@ -2479,6 +2431,120 @@ impl BenchmarkEnvironment {
             node_adapter_version: self.node_adapter_version.clone(),
             python_adapter_version: self.python_adapter_version.clone(),
         }
+    }
+}
+
+#[derive(Debug)]
+struct ExternalToolVersions {
+    node_version: String,
+    python_version: String,
+    msgmerge_version: String,
+    msgcat_version: String,
+    node_adapter_version: String,
+    python_adapter_version: String,
+}
+
+impl ExternalToolVersions {
+    fn not_required() -> Self {
+        Self {
+            node_version: "not-required".to_owned(),
+            python_version: "not-required".to_owned(),
+            msgmerge_version: "not-required".to_owned(),
+            msgcat_version: "not-required".to_owned(),
+            node_adapter_version: "not-required".to_owned(),
+            python_adapter_version: "not-required".to_owned(),
+        }
+    }
+}
+
+fn detect_external_tool_versions(
+    workspace: &Path,
+    path_override: Option<&OsStr>,
+    python_program: &Path,
+    errors: &mut Vec<String>,
+) -> ExternalToolVersions {
+    let node_version = match read_command_version_with_path("node", &["--version"], path_override) {
+        Ok(version) => version,
+        Err(error) => {
+            errors.push(error);
+            String::new()
+        }
+    };
+    let python_version = match read_command_version_for_program(
+        python_program,
+        &["--version"],
+        workspace,
+        path_override,
+    ) {
+        Ok(version) => version,
+        Err(error) => {
+            errors.push(error);
+            String::new()
+        }
+    };
+    let msgmerge_version =
+        match read_command_version_with_path("msgmerge", &["--version"], path_override) {
+            Ok(version) => version,
+            Err(error) => {
+                errors.push(error);
+                String::new()
+            }
+        };
+    let msgcat_version =
+        match read_command_version_with_path("msgcat", &["--version"], path_override) {
+            Ok(version) => version,
+            Err(error) => {
+                errors.push(error);
+                String::new()
+            }
+        };
+    let node_adapter_version = match run_command_capture_with_path(
+        "node",
+        &[
+            OsString::from("--no-warnings"),
+            workspace
+                .join("benchmark")
+                .join("node")
+                .join("adapter.cjs")
+                .into_os_string(),
+            OsString::from("--check"),
+        ],
+        workspace,
+        path_override,
+    ) {
+        Ok(output) => output.stdout.trim().to_owned(),
+        Err(error) => {
+            errors.push(error);
+            String::new()
+        }
+    };
+    let python_adapter_version = match run_command_capture_with_path(
+        python_program.as_os_str(),
+        &[
+            workspace
+                .join("benchmark")
+                .join("python")
+                .join("adapter.py")
+                .into_os_string(),
+            OsString::from("--check"),
+        ],
+        workspace,
+        path_override,
+    ) {
+        Ok(output) => output.stdout.trim().to_owned(),
+        Err(error) => {
+            errors.push(error);
+            String::new()
+        }
+    };
+
+    ExternalToolVersions {
+        node_version,
+        python_version,
+        msgmerge_version,
+        msgcat_version,
+        node_adapter_version,
+        python_adapter_version,
     }
 }
 
@@ -3407,6 +3473,16 @@ mod tests {
             BenchmarkProfile::load(&workspace, "gettext-official-quick-v1").expect("profile");
         assert_eq!(profile.name, "gettext-official-quick-v1");
         assert!(!profile.scenarios.is_empty());
+        assert_eq!(profile.tool_requirement(), ToolRequirement::External);
+    }
+
+    #[test]
+    fn profile_loads_rust_scheduled_v1_without_external_tools() {
+        let workspace = workspace_root().expect("workspace");
+        let profile = BenchmarkProfile::load(&workspace, "rust-scheduled-v1").expect("profile");
+        assert_eq!(profile.name, "rust-scheduled-v1");
+        assert!(!profile.scenarios.is_empty());
+        assert_eq!(profile.tool_requirement(), ToolRequirement::RustOnly);
     }
 
     #[test]
@@ -3462,9 +3538,12 @@ mod tests {
     #[test]
     fn benchmark_environment_reports_missing_tools() {
         let workspace = workspace_root().expect("workspace");
-        let error =
-            BenchmarkEnvironment::detect(&workspace, Some(OsStr::new("/definitely-missing")))
-                .expect_err("expected failure");
+        let error = BenchmarkEnvironment::detect(
+            &workspace,
+            Some(OsStr::new("/definitely-missing")),
+            ToolRequirement::External,
+        )
+        .expect_err("expected failure");
         assert!(error.contains("benchmark environment verification failed"));
     }
 

--- a/docs/app/routes/operations/release-verification.mdx
+++ b/docs/app/routes/operations/release-verification.mdx
@@ -42,6 +42,9 @@ release gate.
 - Confirm docs.rs builds for `ferrocat` and that the README example still matches the published surface.
 - Confirm the crate READMEs published for `ferrocat`, `ferrocat-po`, and `ferrocat-icu` still describe the current public surface accurately.
 - Confirm the site API overview covers any new public APIs or semver-relevant behavior added in the release.
+- If the release included performance-sensitive changes, run or review the latest
+  `Benchmark Reports` workflow artifact before publishing public benchmark
+  claims.
 - Refresh dated quality snapshots when the release changes conformance counts, coverage thresholds, or the benchmark/coverage commands documented on the site.
 
 ## 5. Confirm repository metadata surface

--- a/docs/app/routes/performance/benchmarking.mdx
+++ b/docs/app/routes/performance/benchmarking.mdx
@@ -10,6 +10,19 @@ order: 10
 
 The internal microbenchmarks remain the fast day-to-day performance loop. The external comparison suite is for serious cross-runtime checkpoints on a documented reference host, especially when comparing Ferrocat against GNU gettext, Node, and Python ecosystem tools.
 
+## Scheduled Rust Reports
+
+The `Benchmark Reports` GitHub Actions workflow runs every Monday and can also
+be started manually. It uses the Rust-only `rust-scheduled-v1` profile by
+default, writes a JSON report under `target/benchmark/`, and uploads that report
+as a workflow artifact.
+
+Treat these hosted-runner reports as trend visibility and noise detection, not
+as a hard PR gate or publication-grade benchmark. Hosted runners are shared and
+variable, so the workflow intentionally reports median timing, coefficient of
+variation, relative span, and noisy scenario flags without failing on benchmark
+movement.
+
 ## Reproduce A Fast Baseline
 
 For a quick local signal before and after hot-path changes, use the quick official profile:
@@ -61,6 +74,13 @@ This checks the required executables and adapter packages and prints the detecte
 
 ## Benchmark Profiles
 
+- `rust-scheduled-v1`
+  - Rust-only scheduled/reporting profile used by the `Benchmark Reports`
+    workflow
+  - covers owned/borrowed PO parse, PO stringify, merge, update, catalog storage
+    parse, and ICU parse scenarios
+  - avoids Node, Python, and GNU gettext adapter setup so the scheduled run stays
+    about Ferrocat internals
 - `gettext-official-v1`
   - the smallest official benchmark profile
   - intentionally benchmark-focused rather than test-focused
@@ -167,6 +187,8 @@ Use this when you want more fixture variety than the slim official profile provi
 
 - Internal microbenchmark history stays in `/performance/performance-history`
 - External comparison reports should be written under `benchmark/results/`
+- Scheduled Rust-only workflow reports stay attached to the `Benchmark Reports`
+  workflow run unless they are promoted into a release or publication checkpoint
 - Do not copy external compare results into the internal performance history tables
 
 ## Current `gettext-official-v1` Shape


### PR DESCRIPTION
## Summary
- add a scheduled/manual `Benchmark Reports` workflow for Rust-only benchmark reporting
- add `rust-scheduled-v1` to cover parser, serializer, merge, update, storage, and ICU internal scenarios
- make `ferrocat-bench compare` require Node, Python, and GNU gettext only for profiles that use external implementations
- document artifact handling and release verification expectations for benchmark reports

Closes #68

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p ferrocat-bench --locked`
- `cargo run -p ferrocat-bench -- compare rust-scheduled-v1 --out target/benchmark/rust-scheduled-v1-smoke.json`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo +1.93.0 check --workspace --all-targets --all-features --locked`
- `pnpm build` from `docs/`

## Packaging note
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked` was retried with network access and still fails on current `main` because package verification resolves the already published `ferrocat-po 0.13.0` without the catalog feature surface expected by the local umbrella crate. That is the existing issue covered by #52 / #106, not a regression from this benchmark-reporting change.