### PR TITLE
fix(po): reject unrecognized parser lines

### DIFF
--- a/crates/ferrocat-po/src/borrowed.rs
+++ b/crates/ferrocat-po/src/borrowed.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::scan::{
     CommentKind, Keyword, LineKind, LineScanner, classify_line, find_quoted_bounds, has_byte,
-    parse_plural_index, split_once_byte, trim_ascii,
+    parse_plural_index, split_once_byte, trim_ascii, unrecognized_po_line,
 };
 use crate::text::{extract_quoted_bytes_cow, split_reference_comment};
 use crate::utf8::input_slice_as_str;
@@ -336,7 +336,7 @@ fn parse_line<'a>(
             file,
             current_nplurals,
         ),
-        LineKind::Other => Ok(()),
+        LineKind::Other => Err(unrecognized_po_line(line.position)),
     }
 }
 
@@ -755,6 +755,17 @@ msgstr "world"
 
         assert_eq!(error.message(), "unescaped quote in string literal");
         assert_eq!(position.offset(), 11);
+        assert_eq!(position.line(), 2);
+        assert_eq!(position.column(), 1);
+    }
+
+    #[test]
+    fn rejects_unrecognized_lines() {
+        let error = parse_po_borrowed("msgid \"ok\"\nmsgstr_ \"typo\"\n")
+            .expect_err("unknown PO line should fail");
+        let position = error.position().expect("position metadata");
+
+        assert_eq!(error.message(), "unrecognized PO syntax");
         assert_eq!(position.line(), 2);
         assert_eq!(position.column(), 1);
     }

--- a/crates/ferrocat-po/src/merge.rs
+++ b/crates/ferrocat-po/src/merge.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::scan::{
     CommentKind, Keyword, LineKind, LineScanner, classify_line, find_byte, find_quoted_bounds,
-    has_byte, parse_plural_index, split_once_byte, trim_ascii,
+    has_byte, parse_plural_index, split_once_byte, trim_ascii, unrecognized_po_line,
 };
 use crate::serialize::{write_keyword, write_prefixed_line};
 use crate::text::{escape_string_into, unescape_string, validate_quoted_content};
@@ -327,7 +327,7 @@ fn parse_line<'a>(
             file,
             current_nplurals,
         ),
-        LineKind::Other => Ok(()),
+        LineKind::Other => Err(unrecognized_po_line(line.position)),
     }
 }
 
@@ -1475,6 +1475,21 @@ mod tests {
         assert_eq!(context_error.message(), "unescaped quote in string literal");
         assert_eq!(context_position.line(), 1);
         assert_eq!(context_position.column(), 1);
+    }
+
+    #[test]
+    fn merge_rejects_unrecognized_existing_lines() {
+        let extracted = [ExtractedMessage {
+            msgid: Cow::Borrowed("ok"),
+            ..ExtractedMessage::default()
+        }];
+        let error = merge_catalog("msgid \"ok\"\nmsgstr_ \"typo\"\n", &extracted)
+            .expect_err("unknown existing PO line should fail");
+        let position = error.position().expect("position metadata");
+
+        assert_eq!(error.message(), "unrecognized PO syntax");
+        assert_eq!(position.line(), 2);
+        assert_eq!(position.column(), 1);
     }
 
     #[test]

--- a/crates/ferrocat-po/src/parse.rs
+++ b/crates/ferrocat-po/src/parse.rs
@@ -4,7 +4,7 @@ use memchr::memchr_iter;
 
 use crate::scan::{
     CommentKind, Keyword, LineKind, LineScanner, classify_line, parse_plural_index,
-    split_once_byte, trim_ascii,
+    split_once_byte, trim_ascii, unrecognized_po_line,
 };
 use crate::text::{extract_quoted_bytes_cow, split_reference_comment};
 use crate::utf8::input_slice_as_str;
@@ -199,7 +199,7 @@ fn parse_line(
             file,
             current_nplurals,
         ),
-        LineKind::Other => Ok(()),
+        LineKind::Other => Err(unrecognized_po_line(line.position)),
     }
 }
 
@@ -579,6 +579,17 @@ msgstr ""
         assert_eq!(position.offset(), 13);
         assert_eq!(position.line(), 2);
         assert_eq!(position.column(), 3);
+    }
+
+    #[test]
+    fn rejects_unrecognized_lines() {
+        let error =
+            parse_po("msgid \"ok\"\nmsgstr_ \"typo\"\n").expect_err("unknown PO line should fail");
+        let position = error.position().expect("position metadata");
+
+        assert_eq!(error.message(), "unrecognized PO syntax");
+        assert_eq!(position.line(), 2);
+        assert_eq!(position.column(), 1);
     }
 
     #[test]

--- a/crates/ferrocat-po/src/scan.rs
+++ b/crates/ferrocat-po/src/scan.rs
@@ -1,6 +1,6 @@
 use memchr::Memchr;
 
-use crate::ParsePosition;
+use crate::{ParseError, ParsePosition};
 
 mod backend {
     use memchr::{memchr, memchr3, memrchr};
@@ -306,48 +306,33 @@ pub fn classify_line(line: &[u8]) -> LineKind {
             _ => LineKind::Comment(CommentKind::Other),
         },
         Some(b'm')
-            if line.len() >= 5
-                && line[1] == b's'
-                && line[2] == b'g'
-                && line[3] == b'i'
-                && line[4] == b'd' =>
+            if line.starts_with(b"msgid_plural") && has_keyword_boundary(line, 12, false) =>
         {
-            if line.len() >= 12
-                && line[5] == b'_'
-                && line[6] == b'p'
-                && line[7] == b'l'
-                && line[8] == b'u'
-                && line[9] == b'r'
-                && line[10] == b'a'
-                && line[11] == b'l'
-            {
-                LineKind::Keyword(Keyword::IdPlural)
-            } else {
-                LineKind::Keyword(Keyword::Id)
-            }
+            LineKind::Keyword(Keyword::IdPlural)
         }
-        Some(b'm')
-            if line.len() >= 6
-                && line[1] == b's'
-                && line[2] == b'g'
-                && line[3] == b's'
-                && line[4] == b't'
-                && line[5] == b'r' =>
-        {
+        Some(b'm') if line.starts_with(b"msgid") && has_keyword_boundary(line, 5, false) => {
+            LineKind::Keyword(Keyword::Id)
+        }
+        Some(b'm') if line.starts_with(b"msgstr") && has_keyword_boundary(line, 6, true) => {
             LineKind::Keyword(Keyword::Str)
         }
-        Some(b'm')
-            if line.len() >= 7
-                && line[1] == b's'
-                && line[2] == b'g'
-                && line[3] == b'c'
-                && line[4] == b't'
-                && line[5] == b'x'
-                && line[6] == b't' =>
-        {
+        Some(b'm') if line.starts_with(b"msgctxt") && has_keyword_boundary(line, 7, false) => {
             LineKind::Keyword(Keyword::Ctxt)
         }
         _ => LineKind::Other,
+    }
+}
+
+pub fn unrecognized_po_line(position: ParsePosition) -> ParseError {
+    ParseError::with_position("unrecognized PO syntax", position)
+}
+
+#[inline]
+fn has_keyword_boundary(line: &[u8], keyword_len: usize, allow_plural_index: bool) -> bool {
+    match line.get(keyword_len).copied() {
+        None | Some(b'"') => true,
+        Some(b'[') if allow_plural_index => true,
+        Some(byte) => byte.is_ascii_whitespace(),
     }
 }
 
@@ -425,6 +410,16 @@ mod tests {
             classify_line(b"msgid \"x\""),
             LineKind::Keyword(Keyword::Id)
         );
+        assert_eq!(
+            classify_line(b"msgid_plural \"xs\""),
+            LineKind::Keyword(Keyword::IdPlural)
+        );
+        assert_eq!(
+            classify_line(b"msgstr[0] \"x\""),
+            LineKind::Keyword(Keyword::Str)
+        );
+        assert_eq!(classify_line(b"msgstr_ \"x\""), LineKind::Other);
+        assert_eq!(classify_line(b"msgid_plurality \"x\""), LineKind::Other);
         assert_eq!(classify_line(br#""continued""#), LineKind::Continuation);
     }
 }

--- a/docs/app/routes/architecture/adr/0003-byte-oriented-scanning-and-structural-separation.mdx
+++ b/docs/app/routes/architecture/adr/0003-byte-oriented-scanning-and-structural-separation.mdx
@@ -29,6 +29,8 @@ This includes:
 - keyword and comment classification on bytes
 - `memchr`-style structural searches
 - delaying string materialization as long as possible
+- rejecting non-empty lines that are not recognized as PO comments, keywords,
+  or continuation strings instead of silently ignoring them
 
 ## Consequences
 
@@ -37,6 +39,8 @@ Positive:
 - materially better parser throughput
 - clearer future extension point for SIMD/NEON backends
 - reduced dependence on general-purpose string search machinery
+- typo-like unknown lines fail with source position metadata before they can
+  drop catalog content silently
 
 Negative:
 

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -96,6 +96,10 @@ Typical use cases:
 - transforms that keep parsed data around beyond the source input lifetime
 - tools where simplicity matters more than minimizing allocations
 
+The parser treats non-empty lines that are neither PO comments, known PO
+keywords, nor valid continuation strings as syntax errors. This avoids silently
+dropping typo-like lines such as `msgstr_ "..."`.
+
 ### `parse_po_borrowed`
 
 Use this when you want to parse without copying more than necessary.


### PR DESCRIPTION
## Summary
- require exact keyword boundaries in the PO line scanner so typo-like forms such as `msgstr_` are not treated as valid `msgstr`
- make owned, borrowed, and merge PO parsers return positioned `ParseError`s for unrecognized non-empty PO lines
- document the parser contract in the API overview and ADR 0003

Part of #59. Charset/bytes handling remains intentionally out of scope for a separate API/design slice.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p ferrocat-po --all-features --locked`
- `cargo test -p ferrocat-po --no-default-features --lib --locked`
- `cargo check -p ferrocat-po --no-default-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo +1.93.0 check --workspace --all-targets --all-features --locked`
- `pnpm build` from `docs/`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked`

## Stack
Base is `codex/issue-52-feature-profiles` so this branch includes the feature-profile/package fix from #106 before changing parser behavior.