### PR TITLE
feat(ndjson): add streaming catalog reader writer

### DIFF
--- a/crates/ferrocat-po/src/api.rs
+++ b/crates/ferrocat-po/src/api.rs
@@ -25,6 +25,10 @@ pub use self::compile_types::{
     CompiledMessage, CompiledTranslation, DescribeCompiledIdsReport,
 };
 pub use self::mt::{MachineTranslationMetadata, machine_translation_hash};
+pub use self::ndjson::{
+    NdjsonCatalogReader, NdjsonCatalogReaderOptions, NdjsonCatalogWriter,
+    NdjsonCatalogWriterOptions,
+};
 pub use self::types::{
     ApiError, CatalogCombineInput, CatalogCombineResult, CatalogCombineSelection,
     CatalogCombineStats, CatalogConflictStrategy, CatalogMessage, CatalogMessageExtra,

--- a/crates/ferrocat-po/src/api/catalog.rs
+++ b/crates/ferrocat-po/src/api/catalog.rs
@@ -1555,7 +1555,7 @@ fn validate_plural_forms_header(
 }
 
 /// Rebuilds the public `CatalogMessage` shape from the canonical internal form.
-fn public_message_from_canonical(message: CanonicalMessage) -> CatalogMessage {
+pub(super) fn public_message_from_canonical(message: CanonicalMessage) -> CatalogMessage {
     let translation = match message.translation {
         CanonicalTranslation::Singular { value } => TranslationShape::Singular { value },
         CanonicalTranslation::Plural {

--- a/crates/ferrocat-po/src/api/ndjson.rs
+++ b/crates/ferrocat-po/src/api/ndjson.rs
@@ -1,26 +1,274 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::{BufRead, Write};
 
 use serde::{Deserialize, Serialize};
 
 use super::catalog::{
     CanonicalMessage, CanonicalTranslation, Catalog, append_placeholder_comments,
-    plural_source_branches, split_placeholder_comments,
+    plural_source_branches, public_message_from_canonical, split_placeholder_comments,
 };
 use super::mt::{
     MachineTranslationMetadata, machine_translation_hash, validate_machine_translation_metadata,
 };
 use super::plural::synthesize_icu_plural;
 use super::{
-    ApiError, CatalogOrigin, CatalogSemantics, EffectiveTranslationRef, PlaceholderCommentMode,
+    ApiError, CatalogMessage, CatalogMessageExtra, CatalogOrigin, CatalogSemantics,
+    EffectiveTranslationRef, PlaceholderCommentMode, TranslationShape,
 };
 
 const FRONTMATTER_DELIMITER: &str = "---";
 const NDJSON_FORMAT_V1: &str = "ferrocat.ndjson.v1";
 
+/// Options for constructing an [`NdjsonCatalogReader`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct NdjsonCatalogReaderOptions<'a> {
+    /// Optional explicit locale override. When `None`, the reader uses the
+    /// locale declared in NDJSON frontmatter.
+    pub locale: Option<&'a str>,
+    /// Source locale expected by the caller.
+    pub source_locale: &'a str,
+}
+
+impl<'a> NdjsonCatalogReaderOptions<'a> {
+    /// Creates reader options with the required source locale set.
+    #[must_use]
+    pub const fn new(source_locale: &'a str) -> Self {
+        Self {
+            locale: None,
+            source_locale,
+        }
+    }
+}
+
+/// Streaming reader for Ferrocat NDJSON catalog records.
+///
+/// The reader consumes and validates frontmatter during construction, then
+/// yields one [`CatalogMessage`] per non-empty NDJSON body line.
+pub struct NdjsonCatalogReader<R> {
+    inner: NdjsonCanonicalReader<R>,
+}
+
+impl<R: BufRead> NdjsonCatalogReader<R> {
+    /// Creates a streaming reader with the required source locale.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApiError`] when frontmatter cannot be read, the source locale
+    /// is empty, or a declared NDJSON `source_locale` does not match.
+    pub fn new(reader: R, source_locale: &str) -> Result<Self, ApiError> {
+        Self::with_options(reader, NdjsonCatalogReaderOptions::new(source_locale))
+    }
+
+    /// Creates a streaming reader with explicit options.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApiError`] when frontmatter cannot be read, the source locale
+    /// is empty, or a declared NDJSON `source_locale` does not match.
+    pub fn with_options(
+        reader: R,
+        options: NdjsonCatalogReaderOptions<'_>,
+    ) -> Result<Self, ApiError> {
+        Ok(Self {
+            inner: NdjsonCanonicalReader::with_options(reader, options)?,
+        })
+    }
+
+    /// Returns the effective catalog locale after applying the optional
+    /// override.
+    #[must_use]
+    pub fn locale(&self) -> Option<&str> {
+        self.inner.locale.as_deref()
+    }
+
+    /// Returns a shared reference to the wrapped reader.
+    #[must_use]
+    pub const fn get_ref(&self) -> &R {
+        &self.inner.reader
+    }
+
+    /// Returns a mutable reference to the wrapped reader.
+    pub const fn get_mut(&mut self) -> &mut R {
+        &mut self.inner.reader
+    }
+
+    /// Consumes the streaming reader and returns the wrapped reader.
+    #[must_use]
+    pub fn into_inner(self) -> R {
+        self.inner.reader
+    }
+}
+
+impl<R: BufRead> Iterator for NdjsonCatalogReader<R> {
+    type Item = Result<CatalogMessage, ApiError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|message| message.map(public_message_from_canonical))
+    }
+}
+
+/// Options for constructing an [`NdjsonCatalogWriter`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct NdjsonCatalogWriterOptions<'a> {
+    /// Locale to write into NDJSON frontmatter.
+    pub locale: Option<&'a str>,
+    /// Source locale to write into NDJSON frontmatter.
+    pub source_locale: &'a str,
+}
+
+impl<'a> NdjsonCatalogWriterOptions<'a> {
+    /// Creates writer options with the required source locale set.
+    #[must_use]
+    pub const fn new(source_locale: &'a str) -> Self {
+        Self {
+            locale: None,
+            source_locale,
+        }
+    }
+}
+
+/// Streaming writer for Ferrocat NDJSON catalog records.
+///
+/// The writer emits frontmatter during construction and then appends one JSON
+/// record per [`CatalogMessage`] written.
+pub struct NdjsonCatalogWriter<W> {
+    writer: W,
+}
+
+impl<W: Write> NdjsonCatalogWriter<W> {
+    /// Creates a streaming writer with the required source locale.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApiError`] when the source locale is empty or the frontmatter
+    /// cannot be written.
+    pub fn new(writer: W, source_locale: &str) -> Result<Self, ApiError> {
+        Self::with_options(writer, NdjsonCatalogWriterOptions::new(source_locale))
+    }
+
+    /// Creates a streaming writer with explicit options.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApiError`] when the source locale is empty or the frontmatter
+    /// cannot be written.
+    pub fn with_options(
+        mut writer: W,
+        options: NdjsonCatalogWriterOptions<'_>,
+    ) -> Result<Self, ApiError> {
+        super::validate_source_locale(options.source_locale)?;
+        write_frontmatter(&mut writer, options.locale, options.source_locale)?;
+        Ok(Self { writer })
+    }
+
+    /// Writes one catalog message as an NDJSON body record.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApiError`] when the underlying writer fails.
+    pub fn write_message(&mut self, message: &CatalogMessage) -> Result<(), ApiError> {
+        let record = ndjson_record_from_public_message(message);
+        write_record(&mut self.writer, &record)
+    }
+
+    /// Returns a shared reference to the wrapped writer.
+    #[must_use]
+    pub const fn get_ref(&self) -> &W {
+        &self.writer
+    }
+
+    /// Returns a mutable reference to the wrapped writer.
+    pub const fn get_mut(&mut self) -> &mut W {
+        &mut self.writer
+    }
+
+    /// Flushes and returns the wrapped writer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApiError`] when flushing the underlying writer fails.
+    pub fn finish(mut self) -> Result<W, ApiError> {
+        self.writer.flush()?;
+        Ok(self.writer)
+    }
+}
+
 #[derive(Debug, Default)]
 struct Frontmatter {
     locale: Option<String>,
     source_locale: Option<String>,
+}
+
+struct NdjsonCanonicalReader<R> {
+    reader: R,
+    locale: Option<String>,
+    line_number: usize,
+    seen: BTreeSet<(String, Option<String>)>,
+}
+
+impl<R: BufRead> NdjsonCanonicalReader<R> {
+    fn with_options(
+        mut reader: R,
+        options: NdjsonCatalogReaderOptions<'_>,
+    ) -> Result<Self, ApiError> {
+        super::validate_source_locale(options.source_locale)?;
+        let mut line_number = 0;
+        let frontmatter = read_frontmatter(&mut reader, &mut line_number)?;
+        if let Some(header_source_locale) = &frontmatter.source_locale
+            && header_source_locale != options.source_locale
+        {
+            return Err(ApiError::InvalidArguments(format!(
+                "NDJSON source_locale {:?} did not match requested source_locale {:?}",
+                header_source_locale, options.source_locale
+            )));
+        }
+
+        Ok(Self {
+            reader,
+            locale: options.locale.map(str::to_owned).or(frontmatter.locale),
+            line_number,
+            seen: BTreeSet::new(),
+        })
+    }
+}
+
+impl<R: BufRead> Iterator for NdjsonCanonicalReader<R> {
+    type Item = Result<CanonicalMessage, ApiError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let line = match read_line(&mut self.reader, &mut self.line_number) {
+                Ok(Some(line)) => line,
+                Ok(None) => return None,
+                Err(error) => return Some(Err(error)),
+            };
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let record = match serde_json::from_str::<NdjsonRecord>(trimmed) {
+                Ok(record) => record,
+                Err(error) => {
+                    return Some(Err(ApiError::InvalidArguments(format!(
+                        "invalid NDJSON record on line {}: {error}",
+                        self.line_number
+                    ))));
+                }
+            };
+            let key = (record.id.clone(), record.ctx.clone());
+            if !self.seen.insert(key.clone()) {
+                return Some(Err(ApiError::Conflict(format!(
+                    "duplicate NDJSON message for id {:?} and context {:?}",
+                    key.0, key.1
+                ))));
+            }
+
+            return Some(canonical_message_from_record(record));
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,65 +321,17 @@ pub(super) fn parse_catalog_to_internal_ndjson(
     }
 
     let normalized = normalize_input(content);
-    let (frontmatter, body) = parse_frontmatter(normalized.as_ref())?;
-    if let Some(header_source_locale) = &frontmatter.source_locale
-        && header_source_locale != source_locale
-    {
-        return Err(ApiError::InvalidArguments(format!(
-            "NDJSON source_locale {:?} did not match requested source_locale {:?}",
-            header_source_locale, source_locale
-        )));
-    }
-
-    let locale = locale_override.map(str::to_owned).or(frontmatter.locale);
-
-    let diagnostics = Vec::new();
-    let mut seen = BTreeSet::<(String, Option<String>)>::new();
+    let mut reader = NdjsonCanonicalReader::with_options(
+        std::io::Cursor::new(normalized.as_bytes()),
+        NdjsonCatalogReaderOptions {
+            locale: locale_override,
+            source_locale,
+        },
+    )?;
+    let locale = reader.locale.clone();
     let mut messages = Vec::new();
-
-    for (index, line) in body.lines().enumerate() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let record = serde_json::from_str::<NdjsonRecord>(trimmed).map_err(|error| {
-            ApiError::InvalidArguments(format!(
-                "invalid NDJSON record on line {}: {error}",
-                index + 1
-            ))
-        })?;
-        let key = (record.id.clone(), record.ctx.clone());
-        if !seen.insert(key.clone()) {
-            return Err(ApiError::Conflict(format!(
-                "duplicate NDJSON message for id {:?} and context {:?}",
-                key.0, key.1
-            )));
-        }
-
-        let (comments, placeholders) = split_placeholder_comments(record.comments);
-        let extra = record.extra.unwrap_or_default();
-        if let Some(metadata) = &record.mt {
-            validate_machine_translation_metadata(metadata)?;
-        }
-        messages.push(CanonicalMessage {
-            msgid: record.id,
-            msgctxt: record.ctx,
-            translation: CanonicalTranslation::Singular { value: record.str },
-            comments,
-            origins: record
-                .origin
-                .into_iter()
-                .map(|origin| CatalogOrigin {
-                    file: origin.file,
-                    line: origin.line,
-                })
-                .collect(),
-            placeholders,
-            obsolete: record.obsolete,
-            machine_translation: record.mt,
-            translator_comments: extra.translator_comments,
-            flags: extra.flags,
-        });
+    for message in &mut reader {
+        messages.push(message?);
     }
 
     Ok(Catalog {
@@ -140,7 +340,7 @@ pub(super) fn parse_catalog_to_internal_ndjson(
         file_comments: Vec::new(),
         file_extracted_comments: Vec::new(),
         messages,
-        diagnostics,
+        diagnostics: Vec::new(),
     })
 }
 
@@ -150,62 +350,92 @@ pub(super) fn stringify_catalog_ndjson(
     source_locale: &str,
     placeholder_comment_mode: &PlaceholderCommentMode,
 ) -> String {
-    let records = catalog
-        .messages
-        .iter()
-        .map(|message| {
-            let mut comments = message.comments.clone();
-            append_placeholder_comments(
-                &mut comments,
-                &message.placeholders,
-                placeholder_comment_mode,
-            );
-
-            NdjsonRecord {
-                id: ndjson_id(message),
-                str: ndjson_translation(message),
-                ctx: message.msgctxt.clone(),
-                comments,
-                origin: message
-                    .origins
-                    .iter()
-                    .map(|origin| NdjsonOrigin {
-                        file: origin.file.clone(),
-                        line: origin.line,
-                    })
-                    .collect(),
-                obsolete: message.obsolete,
-                extra: ndjson_extra(message),
-                mt: ndjson_machine_translation(message),
-            }
-        })
-        .collect::<Vec<_>>();
-
-    let mut rendered = String::new();
-    rendered.push_str(FRONTMATTER_DELIMITER);
-    rendered.push('\n');
-    rendered.push_str("format: ");
-    rendered.push_str(NDJSON_FORMAT_V1);
-    rendered.push('\n');
-    if let Some(locale) = locale {
-        rendered.push_str("locale: ");
-        rendered.push_str(locale);
-        rendered.push('\n');
+    let mut rendered = Vec::new();
+    write_frontmatter(&mut rendered, locale, source_locale)
+        .expect("writing NDJSON frontmatter into a Vec must succeed");
+    for message in &catalog.messages {
+        let record = ndjson_record_from_canonical(message, placeholder_comment_mode);
+        write_record(&mut rendered, &record)
+            .expect("writing NDJSON record into a Vec must succeed");
     }
-    rendered.push_str("source_locale: ");
-    rendered.push_str(source_locale);
-    rendered.push('\n');
-    rendered.push_str(FRONTMATTER_DELIMITER);
-    rendered.push('\n');
+    String::from_utf8(rendered).expect("NDJSON renderer writes UTF-8")
+}
 
-    for record in records {
-        rendered.push_str(
-            &serde_json::to_string(&record).expect("NDJSON record serialization must succeed"),
-        );
-        rendered.push('\n');
+fn canonical_message_from_record(record: NdjsonRecord) -> Result<CanonicalMessage, ApiError> {
+    let (comments, placeholders) = split_placeholder_comments(record.comments);
+    let extra = record.extra.unwrap_or_default();
+    if let Some(metadata) = &record.mt {
+        validate_machine_translation_metadata(metadata)?;
     }
+    Ok(CanonicalMessage {
+        msgid: record.id,
+        msgctxt: record.ctx,
+        translation: CanonicalTranslation::Singular { value: record.str },
+        comments,
+        origins: record
+            .origin
+            .into_iter()
+            .map(|origin| CatalogOrigin {
+                file: origin.file,
+                line: origin.line,
+            })
+            .collect(),
+        placeholders,
+        obsolete: record.obsolete,
+        machine_translation: record.mt,
+        translator_comments: extra.translator_comments,
+        flags: extra.flags,
+    })
+}
 
-    rendered
+fn ndjson_record_from_canonical(
+    message: &CanonicalMessage,
+    placeholder_comment_mode: &PlaceholderCommentMode,
+) -> NdjsonRecord {
+    let mut comments = message.comments.clone();
+    append_placeholder_comments(
+        &mut comments,
+        &message.placeholders,
+        placeholder_comment_mode,
+    );
+
+    NdjsonRecord {
+        id: ndjson_id(message),
+        str: ndjson_translation(message),
+        ctx: message.msgctxt.clone(),
+        comments,
+        origin: message
+            .origins
+            .iter()
+            .map(|origin| NdjsonOrigin {
+                file: origin.file.clone(),
+                line: origin.line,
+            })
+            .collect(),
+        obsolete: message.obsolete,
+        extra: ndjson_extra(message),
+        mt: ndjson_machine_translation(message),
+    }
+}
+
+fn ndjson_record_from_public_message(message: &CatalogMessage) -> NdjsonRecord {
+    NdjsonRecord {
+        id: ndjson_public_id(message),
+        str: ndjson_public_translation(message),
+        ctx: message.msgctxt.clone(),
+        comments: message.comments.clone(),
+        origin: message
+            .origin
+            .iter()
+            .map(|origin| NdjsonOrigin {
+                file: origin.file.clone(),
+                line: origin.line,
+            })
+            .collect(),
+        obsolete: message.obsolete,
+        extra: ndjson_public_extra(message.extra.as_ref()),
+        mt: ndjson_public_machine_translation(message),
+    }
 }
 
 fn ndjson_machine_translation(message: &CanonicalMessage) -> Option<MachineTranslationMetadata> {
@@ -258,8 +488,83 @@ fn ndjson_extra(message: &CanonicalMessage) -> Option<NdjsonExtra> {
     }
 }
 
-fn parse_frontmatter(input: &str) -> Result<(Frontmatter, &str), ApiError> {
-    let Some((first_line, mut cursor)) = take_line(input, 0) else {
+fn ndjson_public_machine_translation(
+    message: &CatalogMessage,
+) -> Option<MachineTranslationMetadata> {
+    let metadata = message.machine_translation.as_ref()?;
+    if validate_machine_translation_metadata(metadata).is_err() {
+        return None;
+    }
+    (metadata.hash == machine_translation_hash(message.effective_translation()))
+        .then(|| metadata.clone())
+}
+
+fn ndjson_public_id(message: &CatalogMessage) -> String {
+    match &message.translation {
+        TranslationShape::Singular { .. } => message.msgid.clone(),
+        TranslationShape::Plural {
+            source, variable, ..
+        } => synthesize_icu_plural(variable, &plural_source_branches(source)),
+    }
+}
+
+fn ndjson_public_translation(message: &CatalogMessage) -> String {
+    match &message.translation {
+        TranslationShape::Singular { value } => value.clone(),
+        TranslationShape::Plural {
+            translation,
+            variable,
+            ..
+        } => synthesize_icu_plural(variable, translation),
+    }
+}
+
+fn ndjson_public_extra(extra: Option<&CatalogMessageExtra>) -> Option<NdjsonExtra> {
+    let extra = extra?;
+    if extra.translator_comments.is_empty() && extra.flags.is_empty() {
+        None
+    } else {
+        Some(NdjsonExtra {
+            translator_comments: extra.translator_comments.clone(),
+            flags: extra.flags.clone(),
+        })
+    }
+}
+
+fn write_frontmatter<W: Write>(
+    writer: &mut W,
+    locale: Option<&str>,
+    source_locale: &str,
+) -> Result<(), ApiError> {
+    writer.write_all(FRONTMATTER_DELIMITER.as_bytes())?;
+    writer.write_all(b"\nformat: ")?;
+    writer.write_all(NDJSON_FORMAT_V1.as_bytes())?;
+    writer.write_all(b"\n")?;
+    if let Some(locale) = locale {
+        writer.write_all(b"locale: ")?;
+        writer.write_all(locale.as_bytes())?;
+        writer.write_all(b"\n")?;
+    }
+    writer.write_all(b"source_locale: ")?;
+    writer.write_all(source_locale.as_bytes())?;
+    writer.write_all(b"\n")?;
+    writer.write_all(FRONTMATTER_DELIMITER.as_bytes())?;
+    writer.write_all(b"\n")?;
+    Ok(())
+}
+
+fn write_record<W: Write>(writer: &mut W, record: &NdjsonRecord) -> Result<(), ApiError> {
+    let line = serde_json::to_string(record).expect("NDJSON record serialization must succeed");
+    writer.write_all(line.as_bytes())?;
+    writer.write_all(b"\n")?;
+    Ok(())
+}
+
+fn read_frontmatter<R: BufRead>(
+    reader: &mut R,
+    line_number: &mut usize,
+) -> Result<Frontmatter, ApiError> {
+    let Some(first_line) = read_line(reader, line_number)? else {
         return Err(ApiError::InvalidArguments(
             "NDJSON catalog must start with a frontmatter block".to_owned(),
         ));
@@ -273,19 +578,17 @@ fn parse_frontmatter(input: &str) -> Result<(Frontmatter, &str), ApiError> {
     let mut header = Frontmatter::default();
     let mut seen = BTreeSet::new();
 
-    while let Some((line, next_cursor)) = take_line(input, cursor) {
+    while let Some(line) = read_line(reader, line_number)? {
         if line.trim() == FRONTMATTER_DELIMITER {
-            let body = input.get(next_cursor..).unwrap_or_default();
             if !seen.contains("format") {
                 return Err(ApiError::InvalidArguments(
                     "NDJSON frontmatter is missing required `format`".to_owned(),
                 ));
             }
-            return Ok((header, body));
+            return Ok(header);
         }
         let trimmed = line.trim();
         if trimmed.is_empty() {
-            cursor = next_cursor;
             continue;
         }
         let (key, value) = trimmed.split_once(':').ok_or_else(|| {
@@ -316,12 +619,32 @@ fn parse_frontmatter(input: &str) -> Result<(Frontmatter, &str), ApiError> {
                 )));
             }
         }
-        cursor = next_cursor;
     }
 
     Err(ApiError::InvalidArguments(
         "NDJSON frontmatter was not closed with `---`".to_owned(),
     ))
+}
+
+fn read_line<R: BufRead>(
+    reader: &mut R,
+    line_number: &mut usize,
+) -> Result<Option<String>, ApiError> {
+    let mut line = String::new();
+    if reader.read_line(&mut line)? == 0 {
+        return Ok(None);
+    }
+    *line_number += 1;
+    if *line_number == 1 {
+        line = line.strip_prefix('\u{feff}').unwrap_or(&line).to_owned();
+    }
+    if line.ends_with('\n') {
+        line.pop();
+    }
+    if line.ends_with('\r') {
+        line.pop();
+    }
+    Ok(Some(line))
 }
 
 fn normalize_input(input: &str) -> std::borrow::Cow<'_, str> {
@@ -337,27 +660,20 @@ const fn is_false(value: &bool) -> bool {
     !*value
 }
 
-fn take_line(input: &str, start: usize) -> Option<(&str, usize)> {
-    if start >= input.len() {
-        return None;
-    }
-    match input[start..].find('\n') {
-        Some(offset) => {
-            let end = start + offset;
-            Some((&input[start..end], end + 1))
-        }
-        None => Some((&input[start..], input.len())),
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{
+        collections::BTreeMap,
+        io::{Cursor, Read},
+    };
 
     use super::{
-        CanonicalMessage, CanonicalTranslation, Catalog, CatalogOrigin, CatalogSemantics,
-        NDJSON_FORMAT_V1, PlaceholderCommentMode, normalize_input,
-        parse_catalog_to_internal_ndjson, parse_frontmatter, stringify_catalog_ndjson, take_line,
+        CanonicalMessage, CanonicalTranslation, Catalog, CatalogMessage, CatalogMessageExtra,
+        CatalogOrigin, CatalogSemantics, EffectiveTranslationRef, MachineTranslationMetadata,
+        NDJSON_FORMAT_V1, NdjsonCatalogReader, NdjsonCatalogReaderOptions, NdjsonCatalogWriter,
+        NdjsonCatalogWriterOptions, PlaceholderCommentMode, TranslationShape,
+        machine_translation_hash, normalize_input, parse_catalog_to_internal_ndjson,
+        read_frontmatter, read_line, stringify_catalog_ndjson,
     };
 
     fn sample_catalog() -> Catalog {
@@ -413,17 +729,21 @@ mod tests {
 
     #[test]
     fn frontmatter_parser_accepts_valid_blocks_and_rejects_invalid_ones() {
-        let (frontmatter, body) = parse_frontmatter(concat!(
+        let mut reader = Cursor::new(concat!(
             "---\n",
             "format: ferrocat.ndjson.v1\n",
             "locale: de\n",
             "source_locale: en\n",
             "---\n",
             "{\"id\":\"About us\",\"str\":\"Ueber uns\"}\n",
-        ))
-        .expect("frontmatter");
+        ));
+        let mut line_number = 0;
+        let frontmatter = read_frontmatter(&mut reader, &mut line_number).expect("frontmatter");
         assert_eq!(frontmatter.locale.as_deref(), Some("de"));
         assert_eq!(frontmatter.source_locale.as_deref(), Some("en"));
+        assert_eq!(line_number, 5);
+        let mut body = String::new();
+        reader.read_to_string(&mut body).expect("body");
         assert!(body.contains("\"About us\""));
 
         for invalid in [
@@ -434,16 +754,31 @@ mod tests {
             "---\nformat: ferrocat.ndjson.v1\nunknown: value\n---\n",
             "---\nformat: ferrocat.ndjson.v1\n",
         ] {
-            assert!(parse_frontmatter(invalid).is_err(), "{invalid:?}");
+            let mut reader = Cursor::new(invalid);
+            let mut line_number = 0;
+            assert!(
+                read_frontmatter(&mut reader, &mut line_number).is_err(),
+                "{invalid:?}"
+            );
         }
     }
 
     #[test]
-    fn normalize_input_and_take_line_handle_bom_and_crlf() {
+    fn normalize_input_and_streaming_line_reader_handle_bom_and_crlf() {
         assert_eq!(normalize_input("\u{feff}a\r\nb\r").as_ref(), "a\nb\n");
-        assert_eq!(take_line("alpha\nbeta", 0), Some(("alpha", 6)));
-        assert_eq!(take_line("alpha\nbeta", 6), Some(("beta", 10)));
-        assert_eq!(take_line("alpha\nbeta", 10), None);
+
+        let mut reader = Cursor::new("\u{feff}alpha\r\nbeta\n");
+        let mut line_number = 0;
+        assert_eq!(
+            read_line(&mut reader, &mut line_number).expect("line"),
+            Some("alpha".to_owned())
+        );
+        assert_eq!(
+            read_line(&mut reader, &mut line_number).expect("line"),
+            Some("beta".to_owned())
+        );
+        assert_eq!(read_line(&mut reader, &mut line_number).expect("eof"), None);
+        assert_eq!(line_number, 2);
     }
 
     #[test]
@@ -478,6 +813,165 @@ mod tests {
         );
         assert_eq!(parsed.messages[0].flags, vec!["fuzzy".to_owned()]);
         assert!(parsed.messages[1].obsolete);
+    }
+
+    #[test]
+    fn ndjson_streaming_reader_yields_public_catalog_messages() {
+        let rendered = stringify_catalog_ndjson(
+            &sample_catalog(),
+            Some("de"),
+            "en",
+            &PlaceholderCommentMode::Disabled,
+        );
+        let mut reader = NdjsonCatalogReader::with_options(
+            Cursor::new(rendered.as_bytes()),
+            NdjsonCatalogReaderOptions {
+                locale: None,
+                source_locale: "en",
+            },
+        )
+        .expect("streaming reader");
+
+        assert_eq!(reader.locale(), Some("de"));
+        let messages = reader
+            .by_ref()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("stream messages");
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].msgid, "About us");
+        assert_eq!(messages[0].msgctxt.as_deref(), Some("nav"));
+        assert!(matches!(
+            messages[0].translation,
+            TranslationShape::Singular { ref value } if value == "Ueber uns"
+        ));
+        assert_eq!(messages[0].origin[0].file, "src/nav.rs");
+        assert_eq!(
+            messages[0]
+                .extra
+                .as_ref()
+                .expect("extra")
+                .translator_comments,
+            vec!["Keep short".to_owned()]
+        );
+    }
+
+    #[test]
+    fn ndjson_streaming_writer_emits_parseable_records() {
+        let mut writer = NdjsonCatalogWriter::with_options(
+            Vec::new(),
+            NdjsonCatalogWriterOptions {
+                locale: Some("de"),
+                source_locale: "en",
+            },
+        )
+        .expect("streaming writer");
+
+        writer
+            .write_message(&CatalogMessage {
+                msgid: "Checkout".to_owned(),
+                msgctxt: Some("button".to_owned()),
+                translation: TranslationShape::Singular {
+                    value: "Zur Kasse".to_owned(),
+                },
+                comments: vec!["Short button label".to_owned()],
+                origin: vec![CatalogOrigin {
+                    file: "src/checkout.rs".to_owned(),
+                    line: Some(12),
+                }],
+                obsolete: false,
+                machine_translation: None,
+                extra: Some(CatalogMessageExtra {
+                    translator_comments: vec!["Keep concise".to_owned()],
+                    flags: vec!["rust-format".to_owned()],
+                }),
+            })
+            .expect("write message");
+
+        let rendered = String::from_utf8(writer.finish().expect("finish")).expect("utf8");
+        assert!(rendered.starts_with("---\nformat: ferrocat.ndjson.v1\n"));
+        assert!(rendered.contains("\"ctx\":\"button\""));
+        assert!(rendered.contains("\"translator_comments\":[\"Keep concise\"]"));
+
+        let parsed = parse_catalog_to_internal_ndjson(
+            &rendered,
+            None,
+            "en",
+            CatalogSemantics::IcuNative,
+            false,
+        )
+        .expect("parse streamed output");
+        assert_eq!(parsed.locale.as_deref(), Some("de"));
+        assert_eq!(parsed.messages[0].msgid, "Checkout");
+        assert_eq!(parsed.messages[0].flags, vec!["rust-format".to_owned()]);
+    }
+
+    #[test]
+    fn ndjson_streaming_reader_convenience_methods_expose_inner_reader() {
+        let input = concat!(
+            "---\n",
+            "format: ferrocat.ndjson.v1\n",
+            "source_locale: en\n",
+            "---\n",
+            "{\"id\":\"Checkout\",\"str\":\"Zur Kasse\"}\n",
+        );
+        let mut reader = NdjsonCatalogReader::new(Cursor::new(input.as_bytes()), "en")
+            .expect("streaming reader");
+
+        assert!(reader.get_ref().position() > 0);
+        assert!(reader.get_mut().position() > 0);
+        let message = reader
+            .next()
+            .expect("record")
+            .expect("streamed catalog message");
+        assert_eq!(message.msgid, "Checkout");
+        assert_eq!(reader.into_inner().position() as usize, input.len());
+    }
+
+    #[test]
+    fn ndjson_streaming_writer_convenience_methods_and_plural_records_work() {
+        let mut writer = NdjsonCatalogWriter::new(Vec::new(), "en").expect("streaming writer");
+        assert!(
+            writer
+                .get_ref()
+                .starts_with(b"---\nformat: ferrocat.ndjson.v1")
+        );
+        assert!(!writer.get_mut().is_empty());
+
+        let translation = BTreeMap::from([
+            ("one".to_owned(), "# Datei".to_owned()),
+            ("other".to_owned(), "# Dateien".to_owned()),
+        ]);
+        let hash = machine_translation_hash(EffectiveTranslationRef::Plural(&translation));
+        writer
+            .write_message(&CatalogMessage {
+                msgid: "files".to_owned(),
+                msgctxt: None,
+                translation: TranslationShape::Plural {
+                    source: super::super::PluralSource {
+                        one: Some("# file".to_owned()),
+                        other: "# files".to_owned(),
+                    },
+                    translation,
+                    variable: "count".to_owned(),
+                },
+                comments: Vec::new(),
+                origin: Vec::new(),
+                obsolete: false,
+                machine_translation: Some(MachineTranslationMetadata {
+                    model: "test/model".to_owned(),
+                    modified: None,
+                    confidence: Some(90),
+                    hash,
+                }),
+                extra: None,
+            })
+            .expect("write plural");
+
+        let rendered = String::from_utf8(writer.finish().expect("finish")).expect("utf8");
+        assert!(rendered.contains("{count, plural, one {# file} other {# files}}"));
+        assert!(rendered.contains("{count, plural, one {# Datei} other {# Dateien}}"));
+        assert!(rendered.contains("\"mt\":{\"model\":\"test/model\""));
     }
 
     #[test]

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -103,11 +103,12 @@ pub use api::{
     CompiledKeyStrategy, CompiledMessage, CompiledTranslation, DescribeCompiledIdsReport,
     Diagnostic, DiagnosticSeverity, EffectiveTranslation, EffectiveTranslationRef,
     ExtractedMessage, ExtractedPluralMessage, ExtractedSingularMessage, MachineTranslationMetadata,
-    NormalizedParsedCatalog, ObsoleteStrategy, OrderBy, ParseCatalogOptions, ParsedCatalog,
-    PlaceholderCommentMode, PluralEncoding, PluralSource, SourceExtractedMessage, TranslationShape,
-    UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs, combine_catalogs,
-    compile_catalog_artifact, compile_catalog_artifact_selected, compiled_key,
-    machine_translation_hash, parse_catalog, update_catalog, update_catalog_file,
+    NdjsonCatalogReader, NdjsonCatalogReaderOptions, NdjsonCatalogWriter,
+    NdjsonCatalogWriterOptions, NormalizedParsedCatalog, ObsoleteStrategy, OrderBy,
+    ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode, PluralEncoding, PluralSource,
+    SourceExtractedMessage, TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions,
+    audit_catalogs, combine_catalogs, compile_catalog_artifact, compile_catalog_artifact_selected,
+    compiled_key, machine_translation_hash, parse_catalog, update_catalog, update_catalog_file,
 };
 pub use borrowed::{
     BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, parse_po_borrowed,

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -515,6 +515,57 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+For large or pipeline-oriented NDJSON catalogs, use the `ferrocat-po`
+streaming primitives directly. `NdjsonCatalogReader` validates frontmatter once
+and then yields `CatalogMessage` records from any `BufRead`;
+`NdjsonCatalogWriter` writes frontmatter once and appends one record at a time
+to any `Write`.
+
+```rust
+use std::io::Cursor;
+
+use ferrocat_po::{
+    CatalogMessage, NdjsonCatalogReader, NdjsonCatalogWriter, NdjsonCatalogWriterOptions,
+    TranslationShape,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let input = concat!(
+        "---\n",
+        "format: ferrocat.ndjson.v1\n",
+        "source_locale: en\n",
+        "---\n",
+        "{\"id\":\"Checkout\",\"str\":\"Zur Kasse\"}\n",
+    );
+    let messages = NdjsonCatalogReader::new(Cursor::new(input.as_bytes()), "en")?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut writer = NdjsonCatalogWriter::with_options(
+        Vec::new(),
+        NdjsonCatalogWriterOptions {
+            locale: Some("de"),
+            source_locale: "en",
+        },
+    )?;
+    writer.write_message(&CatalogMessage {
+        msgid: messages[0].msgid.clone(),
+        msgctxt: None,
+        translation: TranslationShape::Singular {
+            value: "Zur Kasse".to_owned(),
+        },
+        comments: Vec::new(),
+        origin: Vec::new(),
+        obsolete: false,
+        machine_translation: None,
+        extra: None,
+    })?;
+
+    let rendered = String::from_utf8(writer.finish()?)?;
+    assert!(rendered.contains("\"id\":\"Checkout\""));
+    Ok(())
+}
+```
+
 ### Machine-translation metadata
 
 `CatalogMessage::machine_translation` stores optional translation-side metadata


### PR DESCRIPTION
## Summary
- add `NdjsonCatalogReader` over `BufRead` that validates frontmatter once and yields public `CatalogMessage` records line by line
- add `NdjsonCatalogWriter` over `Write` that emits frontmatter once and writes one `CatalogMessage` per NDJSON record
- route the internal in-memory NDJSON parser and renderer through the same streaming-oriented helpers
- document the `ferrocat-po` streaming API in the reference overview

Part of #62. This is intentionally based on #52 because the feature-profile work fixes the package verification model that this public `ferrocat-po` API depends on. I did not add an umbrella `ferrocat` re-export in this slice because `cargo package -p ferrocat` verifies against the already-published `ferrocat-po` version and cannot import newly-added lower-crate symbols in the same package verification step.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p ferrocat-po --all-features --locked`
- `cargo check -p ferrocat-po --no-default-features --locked`
- `cargo check -p ferrocat --no-default-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo +1.93.0 check --workspace --all-targets --all-features --locked`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat --locked`
- from `docs/`: `pnpm build`