### PR TITLE
ci(msrv): run workspace tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,8 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
 
-      - name: Check workspace with MSRV
-        run: cargo +1.93.0 check --workspace --all-targets --all-features --locked
+      - name: Test workspace with MSRV
+        run: cargo +1.93.0 test --workspace --all-features --locked
 
   test:
     name: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- switch the MSRV CI job from `cargo check` to `cargo test`
- keep the policy/MSRV wording unchanged because it is already aligned around OXC tracking

Closes the actionable CI part of #69.

## Validation
- `git diff --check`
- `cargo +1.93.0 test --workspace --all-features --locked`