### PR TITLE
docs(msrv): document bump policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Examples:
   plus smoke tests. Add an explicit threshold when executable umbrella code
   grows.
 - If you add or change dependencies, make sure `Cargo.lock` is updated and the locked checks still pass before push.
-- Keep the declared MSRV in `Cargo.toml` covered by CI. The MSRV policy is to align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain.
+- Keep the declared MSRV in `Cargo.toml` covered by CI. The MSRV policy is to align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain. Before `1.0`, raising the MSRV is allowed in a minor release when the changelog calls it out; patch releases should not raise the MSRV.
 
 ## Public API Changes
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Ferrocat's ICU scope is currently MessageFormat v1. MessageFormat 2 is tracked a
 
 - **MSRV:** Rust `1.93.0`
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
+- **MSRV bumps:** before `1.0`, raising the MSRV is allowed in a minor release
+  when the changelog calls it out; patch releases should not raise the MSRV.
 - **Semver:** the public API is treated seriously, but the project is still pre-`1.0`
 - **Error surface:** PO parse errors are intentionally compact today and do not yet expose source positions; adding structured positions would be a semver-relevant API change.
 - **Documentation surface:** README examples, rustdoc examples, and the docs site aim to stay aligned

--- a/docs/app/routes/guide/getting-started.mdx
+++ b/docs/app/routes/guide/getting-started.mdx
@@ -59,6 +59,8 @@ msgstr "world"
 
 - **MSRV:** Rust `1.93.0`
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
+- **MSRV bumps:** before `1.0`, raising the MSRV is allowed in a minor release
+  when the changelog calls it out; patch releases should not raise the MSRV.
 - **Semver:** the public API is treated seriously, but the project is still pre-`1.0`
 - **Docs surface:** README examples, rustdoc, and the site should stay aligned
 

--- a/docs/app/routes/guide/project-status.mdx
+++ b/docs/app/routes/guide/project-status.mdx
@@ -22,6 +22,8 @@ Ferrocat is an actively developed pre-`1.0` Rust project. The goal is stable and
 
 - **MSRV:** `1.93.0`
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
+- **MSRV bumps:** before `1.0`, raising the MSRV is allowed in a minor release
+  when the changelog calls it out; patch releases should not raise the MSRV.
 - **Semver:** the public API is treated seriously, but carefully documented breaking changes may still happen before `1.0`
 - **Documentation:** README examples, rustdoc, and repository docs aim to stay aligned
 - **Host bindings:** Ferrocat is currently a pure-Rust engine. JS/TS access

--- a/docs/app/routes/guide/upgrading.mdx
+++ b/docs/app/routes/guide/upgrading.mdx
@@ -23,6 +23,11 @@ Release Please generates these changelogs from Conventional Commits. Breaking
 changes should be marked with `feat!:` or a `BREAKING CHANGE` note so they are
 visible in release notes and changelog sections.
 
+MSRV bumps follow the same release-note rule. Ferrocat aligns its declared MSRV
+with OXC when practical while avoiding churn from tracking only the newest
+stable toolchain. Before `1.0`, raising the MSRV is allowed in a minor release
+when the changelog calls it out; patch releases should not raise the MSRV.
+
 ## Lockstep versions
 
 The public library crates are released in lockstep. In normal application code,


### PR DESCRIPTION
Closes #69.

## Summary
- documents the pre-1.0 MSRV bump rule in README, AGENTS, and docs pages
- keeps the existing OXC-aligned MSRV policy wording unchanged
- leaves CI unchanged because PR #113 already moved MSRV coverage to workspace tests

## Validation
- `git diff --check`
- `pnpm build` from `docs/`

## Notes
MSRV bumps before 1.0 are now documented as minor-release changes that must be called out in the changelog; patch releases should not raise MSRV.
