### PR TITLE
feat(po): add bytes parser charset guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,13 @@ msgstr "world"
 
 For the common "merge fresh extracted messages into an existing catalog" workflow, `merge_catalog` is the lean Gettext-style entry point. For N-way catalog overlays and `msgcat`-style set operations, use `combine_catalogs`. For release checks across a source catalog and target catalogs, use `audit_catalogs`. For application delivery, compile requested-locale artifacts with fallback and ICU diagnostics. For richer high-level flows across PO and NDJSON storage, the docs site's [API overview](https://sebastian-software.github.io/ferrocat/reference/api-overview) is the best next stop.
 
-`parse_po_borrowed` is the allocation-light PO parser for read-heavy paths. It borrows from the source buffer where possible, but it currently requires LF-only input; normalize CRLF input first or use `parse_po`, which handles line-ending normalization internally.
+`parse_po_bytes` is the byte-oriented owned parser for UTF-8 PO input. It
+rejects declared non-UTF-8 charsets before decoding and reports invalid UTF-8
+through Ferrocat's `ParseError` instead of making callers do their own
+`String::from_utf8` step. `parse_po_borrowed` is the allocation-light PO parser
+for read-heavy paths. It borrows from the source buffer where possible, but it
+currently requires LF-only input; normalize CRLF input first or use `parse_po`,
+which handles line-ending normalization internally.
 
 ICU-native workflows can use `analyze_icu`, `compare_icu_messages`, and `validate_icu_formatter_support` to catch missing arguments, formatter changes, unsupported runtime formatter kinds or styles, tag mismatches, select/plural branch drift, and discouraged pattern-style formatters. Runtime artifact compilation can opt into the same source/translation checks with `icu_compatibility`.
 

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -2,7 +2,8 @@
 //! Performance-first PO parsing and serialization.
 //!
 //! The crate exposes both owned and borrowed parsers for gettext PO files,
-//! plus helpers for serialization and higher-level catalog update workflows.
+//! a byte-oriented UTF-8 parser entry point, plus helpers for serialization
+//! and higher-level catalog update workflows.
 //!
 //! # Examples
 //!
@@ -15,6 +16,15 @@
 //!
 //! let output = stringify_po(&file, &SerializeOptions::default());
 //! assert!(output.contains("msgid \"Hello\""));
+//! # Ok::<(), ferrocat_po::ParseError>(())
+//! ```
+//!
+//! ```rust
+//! use ferrocat_po::parse_po_bytes;
+//!
+//! let input = b"msgid \"Hello\"\nmsgstr \"Hallo\"\n";
+//! let file = parse_po_bytes(input)?;
+//! assert_eq!(file.items[0].msgstr[0], "Hallo");
 //! # Ok::<(), ferrocat_po::ParseError>(())
 //! ```
 //!
@@ -103,7 +113,7 @@ pub use borrowed::{
     BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, parse_po_borrowed,
 };
 pub use merge::{ExtractedMessage as MergeExtractedMessage, merge_catalog};
-pub use parse::parse_po;
+pub use parse::{parse_po, parse_po_bytes};
 pub use serialize::stringify_po;
 pub use text::{escape_string, extract_quoted, extract_quoted_cow, unescape_string};
 
@@ -467,7 +477,10 @@ impl std::error::Error for ParseError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{Header, MsgStr, ParseError, ParsePosition, PoFile, PoItem};
+    use super::{MsgStr, ParseError, ParsePosition};
+
+    #[cfg(feature = "serde")]
+    use super::{Header, PoFile, PoItem};
 
     #[test]
     fn parse_error_accessors_preserve_message_and_optional_position() {

--- a/crates/ferrocat-po/src/parse.rs
+++ b/crates/ferrocat-po/src/parse.rs
@@ -170,9 +170,85 @@ pub fn parse_po(input: &str) -> Result<PoFile, ParseError> {
     Ok(file)
 }
 
+/// Parses UTF-8 PO bytes into the owned [`PoFile`] representation.
+///
+/// This is the byte-oriented companion to [`parse_po`]. It rejects declared
+/// non-UTF-8 PO charsets before decoding, validates the input bytes as UTF-8,
+/// then delegates to [`parse_po`] for syntax parsing.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] when the PO header declares an unsupported non-UTF-8
+/// charset, when the input bytes are not valid UTF-8, or when the decoded input
+/// is not valid PO syntax.
+pub fn parse_po_bytes(input: &[u8]) -> Result<PoFile, ParseError> {
+    reject_unsupported_declared_charset(input)?;
+
+    let input = std::str::from_utf8(input).map_err(|error| {
+        ParseError::new(format!(
+            "PO input is not valid UTF-8 at byte {}",
+            error.valid_up_to()
+        ))
+    })?;
+
+    parse_po(input)
+}
+
 #[inline]
 fn strip_utf8_bom(input: &str) -> &str {
     input.strip_prefix('\u{feff}').unwrap_or(input)
+}
+
+fn reject_unsupported_declared_charset(input: &[u8]) -> Result<(), ParseError> {
+    let Some(charset) = declared_charset(input) else {
+        return Ok(());
+    };
+
+    if charset.eq_ignore_ascii_case("utf-8") || charset.eq_ignore_ascii_case("utf8") {
+        return Ok(());
+    }
+
+    Err(ParseError::new(format!(
+        "unsupported PO charset `{charset}`; parse_po_bytes accepts UTF-8 input"
+    )))
+}
+
+fn declared_charset(input: &[u8]) -> Option<&str> {
+    const CONTENT_TYPE: &[u8] = b"content-type:";
+    const CHARSET: &[u8] = b"charset=";
+
+    if let Some(content_type_start) = find_ascii_case(input, CONTENT_TYPE) {
+        let line_end = input[content_type_start..]
+            .iter()
+            .position(|byte| matches!(byte, b'\n' | b'\r'))
+            .map_or(input.len(), |relative_end| {
+                content_type_start + relative_end
+            });
+
+        let line = &input[content_type_start..line_end];
+        let charset_start = find_ascii_case(line, CHARSET)? + CHARSET.len();
+
+        let value_end = line[charset_start..]
+            .iter()
+            .position(|byte| {
+                matches!(byte, b'\\' | b'"' | b'\'' | b';') || byte.is_ascii_whitespace()
+            })
+            .map_or(line.len(), |relative| charset_start + relative);
+
+        if value_end == charset_start {
+            return None;
+        }
+
+        return std::str::from_utf8(&line[charset_start..value_end]).ok();
+    }
+
+    None
+}
+
+fn find_ascii_case(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window.eq_ignore_ascii_case(needle))
 }
 
 fn parse_line(
@@ -450,7 +526,7 @@ fn trimmed_string(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_po;
+    use super::{declared_charset, parse_po, parse_po_bytes};
 
     const MULTI_LINE: &str = r#"# French translation of Link (6.x-2.9)
 # Copyright (c) 2011 by the French translation team
@@ -640,6 +716,67 @@ msgstr "Datei"
         assert_eq!(po.items.len(), 1);
         assert_eq!(po.items[0].msgid, "foo");
         assert_eq!(po.items[0].msgstr[0], "bar");
+    }
+
+    #[test]
+    fn parse_po_bytes_accepts_utf8_po_content() {
+        let input = b"msgid \"foo\"\nmsgstr \"bar\"\n";
+        let po = parse_po_bytes(input).expect("parse bytes");
+
+        assert_eq!(po.items.len(), 1);
+        assert_eq!(po.items[0].msgid, "foo");
+        assert_eq!(po.items[0].msgstr[0], "bar");
+    }
+
+    #[test]
+    fn parse_po_bytes_accepts_declared_utf8_charset() {
+        let input = b"msgid \"\"\nmsgstr \"\"\n\"Content-Type: text/plain; charset=UTF-8\\n\"\n\n";
+        let po = parse_po_bytes(input).expect("parse bytes");
+
+        assert_eq!(po.headers[0].key, "Content-Type");
+        assert_eq!(po.headers[0].value, "text/plain; charset=UTF-8");
+    }
+
+    #[test]
+    fn parse_po_bytes_rejects_declared_non_utf8_charset() {
+        let input =
+            b"msgid \"\"\nmsgstr \"\"\n\"Content-Type: text/plain; charset=ISO-8859-1\\n\"\n\n";
+        let error = parse_po_bytes(input).expect_err("non-utf8 charset should fail");
+
+        assert!(error.message().contains("unsupported PO charset"));
+        assert!(error.message().contains("ISO-8859-1"));
+    }
+
+    #[test]
+    fn parse_po_bytes_reports_invalid_utf8_input() {
+        let input = b"msgid \"caf\xe9\"\nmsgstr \"\"\n";
+        let error = parse_po_bytes(input).expect_err("invalid utf8 should fail");
+
+        assert!(error.message().contains("not valid UTF-8"));
+        assert!(error.message().contains("byte 10"));
+    }
+
+    #[test]
+    fn parse_po_bytes_reports_declared_charset_before_utf8_error() {
+        let input = b"msgid \"\"\nmsgstr \"\"\n\"Content-Type: text/plain; charset=ISO-8859-1\\n\"\n\nmsgid \"caf\xe9\"\nmsgstr \"\"\n";
+        let error = parse_po_bytes(input).expect_err("declared charset should fail first");
+
+        assert!(error.message().contains("unsupported PO charset"));
+        assert!(error.message().contains("ISO-8859-1"));
+    }
+
+    #[test]
+    fn declared_charset_reads_header_value_case_insensitively() {
+        let input = b"msgid \"\"\nmsgstr \"\"\n\"Content-Type: text/plain; CHARSET=utf8\\n\"\n\n";
+
+        assert_eq!(declared_charset(input), Some("utf8"));
+    }
+
+    #[test]
+    fn declared_charset_ignores_non_header_text() {
+        let input = b"msgid \"charset=ISO-8859-1\"\nmsgstr \"\"\n";
+
+        assert_eq!(declared_charset(input), None);
     }
 
     #[test]

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -787,7 +787,7 @@ part of this source-side metadata format.
 
 ## Error Surface
 
-`ApiError` and the lower-level `ParseError` are intentionally small today. `ApiError` distinguishes parse, I/O, invalid-argument, conflict, and unsupported-operation failures, and its `std::error::Error::source()` implementation preserves underlying parse and I/O causes. Disk helpers that know the affected path attach path context to `ApiError::Io`; call `ApiError::path()` to read that context without parsing the display string. PO `ParseError` keeps the existing human-readable display message and exposes `message()` plus optional `position()` metadata for tooling. Position metadata reports a zero-based byte offset plus one-based line and column when the parser can attach source context.
+`ApiError` and the lower-level `ParseError` are intentionally small today. `ApiError` distinguishes parse, I/O, invalid-argument, conflict, and unsupported-operation failures, and its `std::error::Error::source()` implementation preserves underlying parse and I/O causes. Disk helpers that know the affected path attach path context to `ApiError::Io`; call `ApiError::path()` to read that context without parsing the display string. PO `ParseError` keeps the existing human-readable display message and exposes `message()` plus optional `position()` metadata for tooling. Position metadata reports a zero-based byte offset plus one-based line and column when the parser can attach source context. For file or network input, use `ferrocat_po::parse_po_bytes` when you want Ferrocat to validate UTF-8 bytes and reject declared non-UTF-8 PO charsets before syntax parsing.
 
 ## Practical Rule Of Thumb
 


### PR DESCRIPTION
Closes #59.

## Summary
- adds `ferrocat_po::parse_po_bytes` as the byte-oriented owned PO parser
- rejects declared non-UTF-8 `Content-Type` charsets before decoding
- reports invalid UTF-8 input as Ferrocat `ParseError`
- documents the new API in crate docs, README, and the API overview

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p ferrocat-po --all-features --locked`
- `cargo test -p ferrocat-po --no-default-features --lib --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `pnpm build` from `docs/`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked`

## Notes
The new parser is intentionally exposed from `ferrocat-po` only in this PR. The umbrella `ferrocat` crate should not re-export newly added lower-crate API until the lower crate version containing it has been published.
