### PR TITLE
feat(api): re-export ndjson streaming APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ msgstr "world"
 }
 ```
 
-For the common "merge fresh extracted messages into an existing catalog" workflow, `merge_catalog` is the lean Gettext-style entry point. For N-way catalog overlays and `msgcat`-style set operations, use `combine_catalogs`. For release checks across a source catalog and target catalogs, use `audit_catalogs`. For application delivery, compile requested-locale artifacts with fallback and ICU diagnostics. For richer high-level flows across PO and NDJSON storage, the docs site's [API overview](https://sebastian-software.github.io/ferrocat/reference/api-overview) is the best next stop.
+For the common "merge fresh extracted messages into an existing catalog" workflow, `merge_catalog` is the lean Gettext-style entry point. For N-way catalog overlays and `msgcat`-style set operations, use `combine_catalogs`. For release checks across a source catalog and target catalogs, use `audit_catalogs`. For application delivery, compile requested-locale artifacts with fallback and ICU diagnostics. For large NDJSON pipelines, `ferrocat::catalog::NdjsonCatalogReader` and `NdjsonCatalogWriter` expose one-record-at-a-time streaming without requiring a direct `ferrocat-po` dependency. For richer high-level flows across PO and NDJSON storage, the docs site's [API overview](https://sebastian-software.github.io/ferrocat/reference/api-overview) is the best next stop.
 
 `parse_po_bytes` is the byte-oriented owned parser for UTF-8 PO input. It
 rejects declared non-UTF-8 charsets before decoding and reports invalid UTF-8

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -66,6 +66,25 @@
 //! assert!(report.has_errors());
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
+//!
+//! ```rust
+//! use std::io::Cursor;
+//!
+//! use ferrocat::catalog::NdjsonCatalogReader;
+//!
+//! let input = concat!(
+//!     "---\n",
+//!     "format: ferrocat.ndjson.v1\n",
+//!     "source_locale: en\n",
+//!     "---\n",
+//!     "{\"id\":\"Checkout\",\"str\":\"Zur Kasse\"}\n",
+//! );
+//! let messages = NdjsonCatalogReader::new(Cursor::new(input.as_bytes()), "en")?
+//!     .collect::<Result<Vec<_>, _>>()?;
+//!
+//! assert_eq!(messages[0].msgid, "Checkout");
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
 
 /// High-level catalog maintenance, audit, and runtime artifact APIs.
 pub mod catalog {
@@ -83,12 +102,14 @@ pub mod catalog {
         CompiledCatalogUnavailableId, CompiledKeyStrategy, CompiledMessage, CompiledTranslation,
         DescribeCompiledIdsReport, Diagnostic, DiagnosticSeverity, EffectiveTranslation,
         EffectiveTranslationRef, ExtractedMessage, ExtractedPluralMessage,
-        ExtractedSingularMessage, MachineTranslationMetadata, NormalizedParsedCatalog,
-        ObsoleteStrategy, OrderBy, ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode,
-        PluralEncoding, PluralSource, RenderOptions, SourceExtractedMessage, TranslationShape,
-        UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs, combine_catalogs,
-        compile_catalog_artifact, compile_catalog_artifact_selected, compiled_key,
-        machine_translation_hash, parse_catalog, update_catalog, update_catalog_file,
+        ExtractedSingularMessage, MachineTranslationMetadata, NdjsonCatalogReader,
+        NdjsonCatalogReaderOptions, NdjsonCatalogWriter, NdjsonCatalogWriterOptions,
+        NormalizedParsedCatalog, ObsoleteStrategy, OrderBy, ParseCatalogOptions, ParsedCatalog,
+        PlaceholderCommentMode, PluralEncoding, PluralSource, RenderOptions,
+        SourceExtractedMessage, TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions,
+        audit_catalogs, combine_catalogs, compile_catalog_artifact,
+        compile_catalog_artifact_selected, compiled_key, machine_translation_hash, parse_catalog,
+        update_catalog, update_catalog_file,
     };
 }
 
@@ -166,11 +187,13 @@ pub use ferrocat_po::{
     CompiledKeyStrategy, CompiledMessage, CompiledTranslation, DescribeCompiledIdsReport,
     Diagnostic, DiagnosticSeverity, EffectiveTranslation, EffectiveTranslationRef,
     ExtractedMessage, ExtractedPluralMessage, ExtractedSingularMessage, MachineTranslationMetadata,
-    NormalizedParsedCatalog, ObsoleteStrategy, OrderBy, ParseCatalogOptions, ParsedCatalog,
-    PlaceholderCommentMode, PluralEncoding, PluralSource, RenderOptions, SourceExtractedMessage,
-    TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs,
-    combine_catalogs, compile_catalog_artifact, compile_catalog_artifact_selected, compiled_key,
-    machine_translation_hash, parse_catalog, update_catalog, update_catalog_file,
+    NdjsonCatalogReader, NdjsonCatalogReaderOptions, NdjsonCatalogWriter,
+    NdjsonCatalogWriterOptions, NormalizedParsedCatalog, ObsoleteStrategy, OrderBy,
+    ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode, PluralEncoding, PluralSource,
+    RenderOptions, SourceExtractedMessage, TranslationShape, UpdateCatalogFileOptions,
+    UpdateCatalogOptions, audit_catalogs, combine_catalogs, compile_catalog_artifact,
+    compile_catalog_artifact_selected, compiled_key, machine_translation_hash, parse_catalog,
+    update_catalog, update_catalog_file,
 };
 pub use ferrocat_po::{
     BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, Header, MsgStr, MsgStrIter,

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -580,16 +580,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-For large or pipeline-oriented NDJSON catalogs, use the `ferrocat-po`
-streaming primitives directly. `NdjsonCatalogReader` validates frontmatter once
-and then yields `CatalogMessage` records from any `BufRead`;
-`NdjsonCatalogWriter` writes frontmatter once and appends one record at a time
-to any `Write`.
+For large or pipeline-oriented NDJSON catalogs, use the umbrella
+`ferrocat::catalog` streaming primitives directly. `NdjsonCatalogReader`
+validates frontmatter once and then yields `CatalogMessage` records from any
+`BufRead`; `NdjsonCatalogWriter` writes frontmatter once and appends one record
+at a time to any `Write`.
 
 ```rust
 use std::io::Cursor;
 
-use ferrocat_po::{
+use ferrocat::catalog::{
     CatalogMessage, NdjsonCatalogReader, NdjsonCatalogWriter, NdjsonCatalogWriterOptions,
     TranslationShape,
 };


### PR DESCRIPTION
## Summary

- Re-export `NdjsonCatalogReader` and `NdjsonCatalogWriter` from the umbrella `ferrocat` crate.
- Add a rustdoc example that imports the streaming reader through `ferrocat::catalog`.
- Update README and API overview docs to point large NDJSON pipelines at the umbrella API.

Closes #62.

## Verification

- `cargo fmt --all --check`
- `cargo test -p ferrocat --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `pnpm build` from `docs/`
- `cargo test --workspace --all-features --locked`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked`
