### PR TITLE
refactor(po): share borrowed msgstr parser state

### DIFF
--- a/crates/ferrocat-po/src/borrowed.rs
+++ b/crates/ferrocat-po/src/borrowed.rs
@@ -697,6 +697,23 @@ mod tests {
 
     #[test]
     fn borrowed_msgstr_helpers_cover_slot_promotion_and_plural_width() {
+        let mut singular = BorrowedMsgStr::None;
+        singular.set_slot(0, Cow::Borrowed("one"));
+        singular.set_slot(0, Cow::Borrowed("uno"));
+        singular.append_slot(0, Cow::Borrowed(" plus"));
+        assert_eq!(
+            singular,
+            BorrowedMsgStr::Singular(Cow::Borrowed("uno plus"))
+        );
+
+        let mut empty_plural = BorrowedMsgStr::Plural(Vec::new());
+        empty_plural.set_slot(0, Cow::Borrowed("zero"));
+        empty_plural.append_slot(0, Cow::Borrowed(" plus"));
+        assert_eq!(
+            empty_plural,
+            BorrowedMsgStr::Plural(vec![Cow::Borrowed("zero plus")])
+        );
+
         let mut msgstr = BorrowedMsgStr::None;
 
         msgstr.set_slot(1, Cow::Borrowed("two"));
@@ -712,11 +729,11 @@ mod tests {
             BorrowedMsgStr::Plural(vec![Cow::Borrowed("one"), Cow::Borrowed("two plus")])
         );
 
-        let mut singular = BorrowedMsgStr::None;
-        singular.ensure_singular();
-        singular.expand_singular_to_plural_width(3);
+        let mut defaulted = BorrowedMsgStr::None;
+        defaulted.ensure_singular();
+        defaulted.expand_singular_to_plural_width(3);
         assert_eq!(
-            singular,
+            defaulted,
             BorrowedMsgStr::Plural(vec![
                 Cow::Borrowed(""),
                 Cow::Borrowed(""),

--- a/crates/ferrocat-po/src/borrowed.rs
+++ b/crates/ferrocat-po/src/borrowed.rs
@@ -141,17 +141,88 @@ pub enum BorrowedMsgStr<'a> {
     Plural(Vec<Cow<'a, str>>),
 }
 
-impl BorrowedMsgStr<'_> {
-    const fn is_empty(&self) -> bool {
+impl<'a> BorrowedMsgStr<'a> {
+    pub(crate) const fn is_empty(&self) -> bool {
         matches!(self, Self::None)
     }
 
-    fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         match self {
             Self::None => 0,
             Self::Singular(_) => 1,
             Self::Plural(values) => values.len(),
         }
+    }
+
+    pub(crate) fn set_slot(&mut self, plural_index: usize, value: Cow<'a, str>) {
+        match (&mut *self, plural_index) {
+            (Self::None, 0) => *self = Self::Singular(value),
+            (Self::Singular(existing), 0) => *existing = value,
+            (Self::Plural(values), 0) => {
+                if values.is_empty() {
+                    values.push(Cow::Borrowed(""));
+                }
+                values[0] = value;
+            }
+            _ => {
+                let values = self.promote_plural(plural_index);
+                values[plural_index] = value;
+            }
+        }
+    }
+
+    pub(crate) fn append_slot(&mut self, plural_index: usize, value: Cow<'a, str>) {
+        match (&mut *self, plural_index) {
+            (Self::None, 0) => *self = Self::Singular(value),
+            (Self::Singular(existing), 0) => existing.to_mut().push_str(value.as_ref()),
+            (Self::Plural(values), 0) => {
+                if values.is_empty() {
+                    values.push(Cow::Borrowed(""));
+                }
+                values[0].to_mut().push_str(value.as_ref());
+            }
+            _ => {
+                let values = self.promote_plural(plural_index);
+                values[plural_index].to_mut().push_str(value.as_ref());
+            }
+        }
+    }
+
+    pub(crate) fn ensure_singular(&mut self) {
+        if self.is_empty() {
+            *self = Self::Singular(Cow::Borrowed(""));
+        }
+    }
+
+    pub(crate) fn expand_singular_to_plural_width(&mut self, width: usize) {
+        if self.len() != 1 {
+            return;
+        }
+
+        let mut values = match std::mem::take(self) {
+            Self::None => Vec::new(),
+            Self::Singular(value) => vec![value],
+            Self::Plural(values) => values,
+        };
+        values.resize(width.max(1), Cow::Borrowed(""));
+        *self = Self::Plural(values);
+    }
+
+    fn promote_plural(&mut self, plural_index: usize) -> &mut Vec<Cow<'a, str>> {
+        if !matches!(self, Self::Plural(_)) {
+            *self = match std::mem::take(self) {
+                Self::None => Self::Plural(Vec::with_capacity(2)),
+                Self::Singular(value) => Self::Plural(vec![value]),
+                Self::Plural(values) => Self::Plural(values),
+            };
+        }
+        let Self::Plural(values) = self else {
+            unreachable!("plural msgstr promotion must yield plural storage");
+        };
+        if values.len() <= plural_index {
+            values.resize(plural_index + 1, Cow::Borrowed(""));
+        }
+        values
     }
 
     /// Converts the borrowed payload into an owned [`MsgStr`].
@@ -206,63 +277,16 @@ impl<'a> ParserState<'a> {
     }
 
     fn set_msgstr(&mut self, plural_index: usize, value: Cow<'a, str>) {
-        match (&mut self.msgstr, plural_index) {
-            (BorrowedMsgStr::None, 0) => self.msgstr = BorrowedMsgStr::Singular(value),
-            (BorrowedMsgStr::Singular(existing), 0) => *existing = value,
-            (BorrowedMsgStr::Plural(values), 0) => {
-                if values.is_empty() {
-                    values.push(Cow::Borrowed(""));
-                }
-                values[0] = value;
-            }
-            _ => {
-                let msgstr = self.promote_plural_msgstr(plural_index);
-                msgstr[plural_index] = value;
-            }
-        }
+        self.msgstr.set_slot(plural_index, value);
     }
 
     fn append_msgstr(&mut self, plural_index: usize, value: Cow<'a, str>) {
-        match (&mut self.msgstr, plural_index) {
-            (BorrowedMsgStr::None, 0) => self.msgstr = BorrowedMsgStr::Singular(value),
-            (BorrowedMsgStr::Singular(existing), 0) => existing.to_mut().push_str(value.as_ref()),
-            (BorrowedMsgStr::Plural(values), 0) => {
-                if values.is_empty() {
-                    values.push(Cow::Borrowed(""));
-                }
-                values[0].to_mut().push_str(value.as_ref());
-            }
-            _ => {
-                let msgstr = self.promote_plural_msgstr(plural_index);
-                msgstr[plural_index].to_mut().push_str(value.as_ref());
-            }
-        }
+        self.msgstr.append_slot(plural_index, value);
     }
 
     fn materialize_msgstr(&mut self) {
         debug_assert!(self.item.msgstr.is_empty());
         self.item.msgstr = std::mem::take(&mut self.msgstr);
-    }
-
-    fn promote_plural_msgstr(&mut self, plural_index: usize) -> &mut Vec<Cow<'a, str>> {
-        if !matches!(self.msgstr, BorrowedMsgStr::Plural(_)) {
-            self.msgstr = match std::mem::take(&mut self.msgstr) {
-                BorrowedMsgStr::None => BorrowedMsgStr::Plural(Vec::with_capacity(2)),
-                BorrowedMsgStr::Singular(value) => {
-                    let mut values = Vec::with_capacity(2);
-                    values.push(value);
-                    BorrowedMsgStr::Plural(values)
-                }
-                BorrowedMsgStr::Plural(values) => BorrowedMsgStr::Plural(values),
-            };
-        }
-        let BorrowedMsgStr::Plural(values) = &mut self.msgstr else {
-            unreachable!("plural msgstr promotion must yield plural storage");
-        };
-        if values.len() <= plural_index {
-            values.resize(plural_index + 1, Cow::Borrowed(""));
-        }
-        values
     }
 }
 
@@ -523,17 +547,12 @@ fn finish_item<'a>(
 
     state.materialize_msgstr();
 
-    if state.item.msgstr.is_empty() {
-        state.item.msgstr = BorrowedMsgStr::Singular(Cow::Borrowed(""));
-    }
-    if state.item.msgid_plural.is_some() && state.item.msgstr.len() == 1 {
-        let mut values = match std::mem::take(&mut state.item.msgstr) {
-            BorrowedMsgStr::None => Vec::new(),
-            BorrowedMsgStr::Singular(value) => vec![value],
-            BorrowedMsgStr::Plural(values) => values,
-        };
-        values.resize(state.item.nplurals.max(1), Cow::Borrowed(""));
-        state.item.msgstr = BorrowedMsgStr::Plural(values);
+    state.item.msgstr.ensure_singular();
+    if state.item.msgid_plural.is_some() {
+        state
+            .item
+            .msgstr
+            .expand_singular_to_plural_width(state.item.nplurals);
     }
 
     state.item.nplurals = *current_nplurals;

--- a/crates/ferrocat-po/src/borrowed.rs
+++ b/crates/ferrocat-po/src/borrowed.rs
@@ -146,14 +146,6 @@ impl<'a> BorrowedMsgStr<'a> {
         matches!(self, Self::None)
     }
 
-    pub(crate) fn len(&self) -> usize {
-        match self {
-            Self::None => 0,
-            Self::Singular(_) => 1,
-            Self::Plural(values) => values.len(),
-        }
-    }
-
     pub(crate) fn set_slot(&mut self, plural_index: usize, value: Cow<'a, str>) {
         match (&mut *self, plural_index) {
             (Self::None, 0) => *self = Self::Singular(value),
@@ -195,34 +187,37 @@ impl<'a> BorrowedMsgStr<'a> {
     }
 
     pub(crate) fn expand_singular_to_plural_width(&mut self, width: usize) {
-        if self.len() != 1 {
-            return;
+        match self {
+            Self::Singular(value) => {
+                let mut values = vec![std::mem::take(value)];
+                values.resize(width.max(1), Cow::Borrowed(""));
+                *self = Self::Plural(values);
+            }
+            Self::Plural(values) if values.len() == 1 => {
+                values.resize(width.max(1), Cow::Borrowed(""));
+            }
+            Self::None | Self::Plural(_) => {}
         }
-
-        let mut values = match std::mem::take(self) {
-            Self::None => Vec::new(),
-            Self::Singular(value) => vec![value],
-            Self::Plural(values) => values,
-        };
-        values.resize(width.max(1), Cow::Borrowed(""));
-        *self = Self::Plural(values);
     }
 
     fn promote_plural(&mut self, plural_index: usize) -> &mut Vec<Cow<'a, str>> {
-        if !matches!(self, Self::Plural(_)) {
-            *self = match std::mem::take(self) {
-                Self::None => Self::Plural(Vec::with_capacity(2)),
-                Self::Singular(value) => Self::Plural(vec![value]),
-                Self::Plural(values) => Self::Plural(values),
-            };
+        match self {
+            Self::None => {
+                *self = Self::Plural(Vec::with_capacity(2));
+                self.promote_plural(plural_index)
+            }
+            Self::Singular(value) => {
+                let value = std::mem::take(value);
+                *self = Self::Plural(vec![value]);
+                self.promote_plural(plural_index)
+            }
+            Self::Plural(values) => {
+                if values.len() <= plural_index {
+                    values.resize(plural_index + 1, Cow::Borrowed(""));
+                }
+                values
+            }
         }
-        let Self::Plural(values) = self else {
-            unreachable!("plural msgstr promotion must yield plural storage");
-        };
-        if values.len() <= plural_index {
-            values.resize(plural_index + 1, Cow::Borrowed(""));
-        }
-        values
     }
 
     /// Converts the borrowed payload into an owned [`MsgStr`].
@@ -693,10 +688,21 @@ fn trimmed_cow(bytes: &[u8]) -> Cow<'_, str> {
 mod tests {
     use std::borrow::Cow;
 
+    use crate::MsgStr;
+
     use super::{BorrowedMsgStr, parse_po_borrowed};
 
     #[test]
     fn borrowed_msgstr_helpers_cover_slot_promotion_and_plural_width() {
+        assert_eq!(BorrowedMsgStr::None.into_owned(), MsgStr::None);
+
+        let mut appended_none = BorrowedMsgStr::None;
+        appended_none.append_slot(0, Cow::Borrowed("one"));
+        assert_eq!(
+            appended_none,
+            BorrowedMsgStr::Singular(Cow::Borrowed("one"))
+        );
+
         let mut singular = BorrowedMsgStr::None;
         singular.set_slot(0, Cow::Borrowed("one"));
         singular.set_slot(0, Cow::Borrowed("uno"));
@@ -704,6 +710,13 @@ mod tests {
         assert_eq!(
             singular,
             BorrowedMsgStr::Singular(Cow::Borrowed("uno plus"))
+        );
+
+        let mut append_empty_plural = BorrowedMsgStr::Plural(Vec::new());
+        append_empty_plural.append_slot(0, Cow::Borrowed("zero"));
+        assert_eq!(
+            append_empty_plural,
+            BorrowedMsgStr::Plural(vec![Cow::Borrowed("zero")])
         );
 
         let mut empty_plural = BorrowedMsgStr::Plural(Vec::new());
@@ -739,6 +752,13 @@ mod tests {
                 Cow::Borrowed(""),
                 Cow::Borrowed(""),
             ])
+        );
+
+        let mut existing_plural = BorrowedMsgStr::Plural(vec![Cow::Borrowed("one")]);
+        existing_plural.expand_singular_to_plural_width(2);
+        assert_eq!(
+            existing_plural,
+            BorrowedMsgStr::Plural(vec![Cow::Borrowed("one"), Cow::Borrowed("")])
         );
     }
 

--- a/crates/ferrocat-po/src/borrowed.rs
+++ b/crates/ferrocat-po/src/borrowed.rs
@@ -696,6 +696,36 @@ mod tests {
     use super::{BorrowedMsgStr, parse_po_borrowed};
 
     #[test]
+    fn borrowed_msgstr_helpers_cover_slot_promotion_and_plural_width() {
+        let mut msgstr = BorrowedMsgStr::None;
+
+        msgstr.set_slot(1, Cow::Borrowed("two"));
+        assert_eq!(
+            msgstr,
+            BorrowedMsgStr::Plural(vec![Cow::Borrowed(""), Cow::Borrowed("two")])
+        );
+
+        msgstr.append_slot(1, Cow::Borrowed(" plus"));
+        msgstr.append_slot(0, Cow::Borrowed("one"));
+        assert_eq!(
+            msgstr,
+            BorrowedMsgStr::Plural(vec![Cow::Borrowed("one"), Cow::Borrowed("two plus")])
+        );
+
+        let mut singular = BorrowedMsgStr::None;
+        singular.ensure_singular();
+        singular.expand_singular_to_plural_width(3);
+        assert_eq!(
+            singular,
+            BorrowedMsgStr::Plural(vec![
+                Cow::Borrowed(""),
+                Cow::Borrowed(""),
+                Cow::Borrowed(""),
+            ])
+        );
+    }
+
+    #[test]
     fn borrows_simple_fields() {
         let input = r#"
 # translator

--- a/crates/ferrocat-po/src/merge.rs
+++ b/crates/ferrocat-po/src/merge.rs
@@ -115,58 +115,15 @@ impl<'a> ParserState<'a> {
     }
 
     fn set_msgstr(&mut self, plural_index: usize, value: Cow<'a, str>) {
-        match (&mut self.msgstr, plural_index) {
-            (BorrowedMsgStr::None, 0) => self.msgstr = BorrowedMsgStr::Singular(value),
-            (BorrowedMsgStr::Singular(existing), 0) => *existing = value,
-            (BorrowedMsgStr::Plural(values), 0) => {
-                if values.is_empty() {
-                    values.push(Cow::Borrowed(""));
-                }
-                values[0] = value;
-            }
-            _ => {
-                let msgstr = self.promote_plural_msgstr(plural_index);
-                msgstr[plural_index] = value;
-            }
-        }
+        self.msgstr.set_slot(plural_index, value);
     }
 
     fn append_msgstr(&mut self, plural_index: usize, value: Cow<'a, str>) {
-        match (&mut self.msgstr, plural_index) {
-            (BorrowedMsgStr::None, 0) => self.msgstr = BorrowedMsgStr::Singular(value),
-            (BorrowedMsgStr::Singular(existing), 0) => existing.to_mut().push_str(value.as_ref()),
-            (BorrowedMsgStr::Plural(values), 0) => {
-                if values.is_empty() {
-                    values.push(Cow::Borrowed(""));
-                }
-                values[0].to_mut().push_str(value.as_ref());
-            }
-            _ => {
-                let msgstr = self.promote_plural_msgstr(plural_index);
-                msgstr[plural_index].to_mut().push_str(value.as_ref());
-            }
-        }
+        self.msgstr.append_slot(plural_index, value);
     }
 
     fn materialize_msgstr(&mut self) {
         self.item.msgstr = std::mem::take(&mut self.msgstr);
-    }
-
-    fn promote_plural_msgstr(&mut self, plural_index: usize) -> &mut Vec<Cow<'a, str>> {
-        if !matches!(self.msgstr, BorrowedMsgStr::Plural(_)) {
-            self.msgstr = match std::mem::take(&mut self.msgstr) {
-                BorrowedMsgStr::None => BorrowedMsgStr::Plural(Vec::with_capacity(2)),
-                BorrowedMsgStr::Singular(value) => BorrowedMsgStr::Plural(vec![value]),
-                BorrowedMsgStr::Plural(values) => BorrowedMsgStr::Plural(values),
-            };
-        }
-        let BorrowedMsgStr::Plural(values) = &mut self.msgstr else {
-            unreachable!("plural msgstr promotion must yield plural storage");
-        };
-        if values.len() <= plural_index {
-            values.resize(plural_index + 1, Cow::Borrowed(""));
-        }
-        values
     }
 }
 
@@ -507,17 +464,12 @@ fn finish_item<'a>(
 
     state.materialize_msgstr();
 
-    if matches!(state.item.msgstr, BorrowedMsgStr::None) {
-        state.item.msgstr = BorrowedMsgStr::Singular(Cow::Borrowed(""));
-    }
-    if state.item.msgid_plural.is_some() && msgstr_len(&state.item.msgstr) == 1 {
-        let mut values = match std::mem::take(&mut state.item.msgstr) {
-            BorrowedMsgStr::None => Vec::new(),
-            BorrowedMsgStr::Singular(value) => vec![value],
-            BorrowedMsgStr::Plural(values) => values,
-        };
-        values.resize(state.item.nplurals.max(1), Cow::Borrowed(""));
-        state.item.msgstr = BorrowedMsgStr::Plural(values);
+    state.item.msgstr.ensure_singular();
+    if state.item.msgid_plural.is_some() {
+        state
+            .item
+            .msgstr
+            .expand_singular_to_plural_width(state.item.nplurals);
     }
 
     state.item.nplurals = *current_nplurals;
@@ -525,19 +477,11 @@ fn finish_item<'a>(
     state.reset_after_take(*current_nplurals);
 }
 
-fn msgstr_len(msgstr: &BorrowedMsgStr<'_>) -> usize {
-    match msgstr {
-        BorrowedMsgStr::None => 0,
-        BorrowedMsgStr::Singular(_) => 1,
-        BorrowedMsgStr::Plural(values) => values.len(),
-    }
-}
-
 fn is_header_state(state: &ParserState<'_>) -> bool {
     state.item.msgid.is_empty()
         && state.item.msgctxt.is_none()
         && state.item.msgid_plural.is_none()
-        && !matches!(state.msgstr, BorrowedMsgStr::None)
+        && !state.msgstr.is_empty()
 }
 
 fn is_header_candidate(state: &ParserState<'_>) -> bool {


### PR DESCRIPTION
## Summary

- Move borrowed `msgstr` slot set, append, promotion, and plural-width handling onto the shared `BorrowedMsgStr` type.
- Update both the borrowed parser and merge parser to call the same internal state helpers.
- Keep parse behavior unchanged; this is the first consolidation slice under the existing differential parser tests.

Refs #51.

## Verification

- `cargo fmt --all --check`
- `cargo test -p ferrocat-po --test parser_differential --all-features --locked`
- `cargo test -p ferrocat-po --test parser_differential --no-default-features --locked`
- `cargo test -p ferrocat-po --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo +1.93.0 check --workspace --all-targets --all-features --locked`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked`
