### PR TITLE
refactor(po): share parser line state

### DIFF
--- a/crates/ferrocat-po/src/borrowed.rs
+++ b/crates/ferrocat-po/src/borrowed.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use crate::line_state::{PoLineContext, PoLineState};
 use crate::scan::{
     CommentKind, Keyword, LineKind, LineScanner, classify_line, find_quoted_bounds, has_byte,
     parse_plural_index, split_once_byte, trim_ascii, unrecognized_po_line,
@@ -233,24 +234,12 @@ impl<'a> BorrowedMsgStr<'a> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Context {
-    Id,
-    IdPlural,
-    Str,
-    Ctxt,
-}
-
 #[derive(Debug)]
 struct ParserState<'a> {
     item: BorrowedPoItem<'a>,
     header_entries: Vec<BorrowedHeader<'a>>,
     msgstr: BorrowedMsgStr<'a>,
-    context: Option<Context>,
-    plural_index: usize,
-    obsolete_line_count: usize,
-    content_line_count: usize,
-    has_keyword: bool,
+    line: PoLineState,
 }
 
 impl<'a> ParserState<'a> {
@@ -259,11 +248,7 @@ impl<'a> ParserState<'a> {
             item: BorrowedPoItem::new(nplurals),
             header_entries: Vec::new(),
             msgstr: BorrowedMsgStr::None,
-            context: None,
-            plural_index: 0,
-            obsolete_line_count: 0,
-            content_line_count: 0,
-            has_keyword: false,
+            line: PoLineState::default(),
         }
     }
 
@@ -424,27 +409,24 @@ fn parse_keyword_line<'a>(
 ) -> Result<(), ParseError> {
     match keyword {
         Keyword::IdPlural => {
-            state.obsolete_line_count += usize::from(obsolete);
+            state
+                .line
+                .mark_keyword(PoLineContext::IdPlural, 0, obsolete);
             state.item.msgid_plural = Some(at_line_position(
                 extract_quoted_bytes_cow(line_bytes),
                 position,
             )?);
-            state.context = Some(Context::IdPlural);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
         Keyword::Id => {
             finish_item(state, file, current_nplurals);
-            state.obsolete_line_count += usize::from(obsolete);
+            state.line.mark_keyword(PoLineContext::Id, 0, obsolete);
             state.item.msgid = at_line_position(extract_quoted_bytes_cow(line_bytes), position)?;
-            state.context = Some(Context::Id);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
         Keyword::Str => {
             let plural_index = parse_plural_index(line_bytes).unwrap_or(0);
-            state.plural_index = plural_index;
-            state.obsolete_line_count += usize::from(obsolete);
+            state
+                .line
+                .mark_keyword(PoLineContext::Str, plural_index, obsolete);
             state.set_msgstr(
                 plural_index,
                 at_line_position(extract_quoted_bytes_cow(line_bytes), position)?,
@@ -453,20 +435,14 @@ fn parse_keyword_line<'a>(
                 let headers = at_line_position(parse_header_fragment(line_bytes), position)?;
                 state.header_entries.extend(headers);
             }
-            state.context = Some(Context::Str);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
         Keyword::Ctxt => {
             finish_item(state, file, current_nplurals);
-            state.obsolete_line_count += usize::from(obsolete);
+            state.line.mark_keyword(PoLineContext::Ctxt, 0, obsolete);
             state.item.msgctxt = Some(at_line_position(
                 extract_quoted_bytes_cow(line_bytes),
                 position,
             )?);
-            state.context = Some(Context::Ctxt);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
     }
 
@@ -479,24 +455,23 @@ fn append_continuation<'a>(
     position: ParsePosition,
     state: &mut ParserState<'a>,
 ) -> Result<(), ParseError> {
-    state.obsolete_line_count += usize::from(obsolete);
-    state.content_line_count += 1;
+    state.line.mark_continuation(obsolete);
     let value = at_line_position(extract_quoted_bytes_cow(line_bytes), position)?;
 
-    match state.context {
-        Some(Context::Str) => {
-            state.append_msgstr(state.plural_index, value);
+    match state.line.context() {
+        Some(PoLineContext::Str) => {
+            state.append_msgstr(state.line.plural_index(), value);
             if is_header_candidate(state) {
                 let headers = at_line_position(parse_header_fragment(line_bytes), position)?;
                 state.header_entries.extend(headers);
             }
         }
-        Some(Context::Id) => state.item.msgid.to_mut().push_str(value.as_ref()),
-        Some(Context::IdPlural) => {
+        Some(PoLineContext::Id) => state.item.msgid.to_mut().push_str(value.as_ref()),
+        Some(PoLineContext::IdPlural) => {
             let target = state.item.msgid_plural.get_or_insert(Cow::Borrowed(""));
             target.to_mut().push_str(value.as_ref());
         }
-        Some(Context::Ctxt) => {
+        Some(PoLineContext::Ctxt) => {
             let target = state.item.msgctxt.get_or_insert(Cow::Borrowed(""));
             target.to_mut().push_str(value.as_ref());
         }
@@ -519,7 +494,7 @@ fn finish_item<'a>(
     file: &mut BorrowedPoFile<'a>,
     current_nplurals: &mut usize,
 ) {
-    if !state.has_keyword {
+    if !state.line.has_keyword() {
         return;
     }
 
@@ -527,7 +502,7 @@ fn finish_item<'a>(
         return;
     }
 
-    if state.obsolete_line_count >= state.content_line_count && state.content_line_count > 0 {
+    if state.line.is_obsolete_item() {
         state.item.obsolete = true;
     }
 
@@ -566,7 +541,7 @@ fn is_header_candidate(state: &ParserState<'_>) -> bool {
     state.item.msgid.is_empty()
         && state.item.msgctxt.is_none()
         && state.item.msgid_plural.is_none()
-        && state.plural_index == 0
+        && state.line.plural_index() == 0
 }
 
 fn parse_header_fragment(line_bytes: &[u8]) -> Result<Vec<BorrowedHeader<'_>>, ParseError> {

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -80,6 +80,7 @@
 mod api;
 mod borrowed;
 pub mod diagnostic_codes;
+mod line_state;
 mod merge;
 mod parse;
 mod scan;

--- a/crates/ferrocat-po/src/line_state.rs
+++ b/crates/ferrocat-po/src/line_state.rs
@@ -1,0 +1,69 @@
+/// Active PO keyword context for continuation lines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PoLineContext {
+    /// Continuations append to `msgid`.
+    Id,
+    /// Continuations append to `msgid_plural`.
+    IdPlural,
+    /// Continuations append to `msgstr` or `msgstr[n]`.
+    Str,
+    /// Continuations append to `msgctxt`.
+    Ctxt,
+}
+
+/// Shared line-level parser state used by owned, borrowed, and merge parsing.
+#[derive(Debug, Default)]
+pub(crate) struct PoLineState {
+    context: Option<PoLineContext>,
+    plural_index: usize,
+    obsolete_line_count: usize,
+    content_line_count: usize,
+    has_keyword: bool,
+}
+
+impl PoLineState {
+    /// Resets keyword context and content counters for the next parsed item.
+    pub(crate) fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Records a PO keyword line and the active continuation target it creates.
+    pub(crate) fn mark_keyword(
+        &mut self,
+        context: PoLineContext,
+        plural_index: usize,
+        obsolete: bool,
+    ) {
+        self.context = Some(context);
+        self.plural_index = plural_index;
+        self.obsolete_line_count += usize::from(obsolete);
+        self.content_line_count += 1;
+        self.has_keyword = true;
+    }
+
+    /// Records a quoted continuation line.
+    pub(crate) fn mark_continuation(&mut self, obsolete: bool) {
+        self.obsolete_line_count += usize::from(obsolete);
+        self.content_line_count += 1;
+    }
+
+    /// Returns the current continuation context, when any keyword has set one.
+    pub(crate) const fn context(&self) -> Option<PoLineContext> {
+        self.context
+    }
+
+    /// Returns the current plural translation slot.
+    pub(crate) const fn plural_index(&self) -> usize {
+        self.plural_index
+    }
+
+    /// Returns whether the current parser item has seen at least one keyword.
+    pub(crate) const fn has_keyword(&self) -> bool {
+        self.has_keyword
+    }
+
+    /// Returns whether every content line in the current item was obsolete.
+    pub(crate) const fn is_obsolete_item(&self) -> bool {
+        self.content_line_count > 0 && self.obsolete_line_count >= self.content_line_count
+    }
+}

--- a/crates/ferrocat-po/src/merge.rs
+++ b/crates/ferrocat-po/src/merge.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use crate::line_state::{PoLineContext, PoLineState};
 use crate::scan::{
     CommentKind, Keyword, LineKind, LineScanner, classify_line, find_byte, find_quoted_bounds,
     has_byte, parse_plural_index, split_once_byte, trim_ascii, unrecognized_po_line,
@@ -64,24 +65,12 @@ impl MergeBorrowedItem<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Context {
-    Id,
-    IdPlural,
-    Str,
-    Ctxt,
-}
-
 #[derive(Debug)]
 struct ParserState<'a> {
     item: MergeBorrowedItem<'a>,
     header_entries: Vec<MergeHeader<'a>>,
     msgstr: BorrowedMsgStr<'a>,
-    context: Option<Context>,
-    plural_index: usize,
-    obsolete_line_count: usize,
-    content_line_count: usize,
-    has_keyword: bool,
+    line: PoLineState,
 }
 
 impl<'a> ParserState<'a> {
@@ -90,11 +79,7 @@ impl<'a> ParserState<'a> {
             item: MergeBorrowedItem::new(nplurals),
             header_entries: Vec::new(),
             msgstr: BorrowedMsgStr::None,
-            context: None,
-            plural_index: 0,
-            obsolete_line_count: 0,
-            content_line_count: 0,
-            has_keyword: false,
+            line: PoLineState::default(),
         }
     }
 
@@ -107,11 +92,7 @@ impl<'a> ParserState<'a> {
         self.item.nplurals = nplurals;
         self.header_entries.clear();
         self.msgstr = BorrowedMsgStr::None;
-        self.context = None;
-        self.plural_index = 0;
-        self.obsolete_line_count = 0;
-        self.content_line_count = 0;
-        self.has_keyword = false;
+        self.line.reset();
     }
 
     fn set_msgstr(&mut self, plural_index: usize, value: Cow<'a, str>) {
@@ -346,27 +327,24 @@ fn parse_keyword_line<'a>(
 ) -> Result<(), ParseError> {
     match keyword {
         Keyword::IdPlural => {
-            state.obsolete_line_count += usize::from(obsolete);
+            state
+                .line
+                .mark_keyword(PoLineContext::IdPlural, 0, obsolete);
             state.item.msgid_plural = Some(at_line_position(
                 extract_merge_quoted_cow(line_bytes),
                 position,
             )?);
-            state.context = Some(Context::IdPlural);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
         Keyword::Id => {
             finish_item(state, file, current_nplurals);
-            state.obsolete_line_count += usize::from(obsolete);
+            state.line.mark_keyword(PoLineContext::Id, 0, obsolete);
             state.item.msgid = at_line_position(extract_merge_quoted_cow(line_bytes), position)?;
-            state.context = Some(Context::Id);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
         Keyword::Str => {
             let plural_index = parse_plural_index(line_bytes).unwrap_or(0);
-            state.plural_index = plural_index;
-            state.obsolete_line_count += usize::from(obsolete);
+            state
+                .line
+                .mark_keyword(PoLineContext::Str, plural_index, obsolete);
             state.set_msgstr(
                 plural_index,
                 at_line_position(extract_merge_quoted_cow(line_bytes), position)?,
@@ -375,20 +353,14 @@ fn parse_keyword_line<'a>(
                 let headers = at_line_position(parse_header_fragment(line_bytes), position)?;
                 state.header_entries.extend(headers);
             }
-            state.context = Some(Context::Str);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
         Keyword::Ctxt => {
             finish_item(state, file, current_nplurals);
-            state.obsolete_line_count += usize::from(obsolete);
+            state.line.mark_keyword(PoLineContext::Ctxt, 0, obsolete);
             state.item.msgctxt = Some(at_line_position(
                 extract_merge_quoted_cow(line_bytes),
                 position,
             )?);
-            state.context = Some(Context::Ctxt);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
     }
 
@@ -401,24 +373,23 @@ fn append_continuation<'a>(
     position: ParsePosition,
     state: &mut ParserState<'a>,
 ) -> Result<(), ParseError> {
-    state.obsolete_line_count += usize::from(obsolete);
-    state.content_line_count += 1;
+    state.line.mark_continuation(obsolete);
     let value = at_line_position(extract_merge_quoted_cow(line_bytes), position)?;
 
-    match state.context {
-        Some(Context::Str) => {
-            state.append_msgstr(state.plural_index, value);
+    match state.line.context() {
+        Some(PoLineContext::Str) => {
+            state.append_msgstr(state.line.plural_index(), value);
             if is_header_candidate(state) {
                 let headers = at_line_position(parse_header_fragment(line_bytes), position)?;
                 state.header_entries.extend(headers);
             }
         }
-        Some(Context::Id) => state.item.msgid.to_mut().push_str(value.as_ref()),
-        Some(Context::IdPlural) => {
+        Some(PoLineContext::Id) => state.item.msgid.to_mut().push_str(value.as_ref()),
+        Some(PoLineContext::IdPlural) => {
             let target = state.item.msgid_plural.get_or_insert(Cow::Borrowed(""));
             target.to_mut().push_str(value.as_ref());
         }
-        Some(Context::Ctxt) => {
+        Some(PoLineContext::Ctxt) => {
             let target = state.item.msgctxt.get_or_insert(Cow::Borrowed(""));
             target.to_mut().push_str(value.as_ref());
         }
@@ -441,7 +412,7 @@ fn finish_item<'a>(
     file: &mut MergeBorrowedFile<'a>,
     current_nplurals: &mut usize,
 ) {
-    if !state.has_keyword {
+    if !state.line.has_keyword() {
         return;
     }
 
@@ -449,7 +420,7 @@ fn finish_item<'a>(
         return;
     }
 
-    if state.obsolete_line_count >= state.content_line_count && state.content_line_count > 0 {
+    if state.line.is_obsolete_item() {
         state.item.obsolete = true;
     }
 
@@ -488,7 +459,7 @@ fn is_header_candidate(state: &ParserState<'_>) -> bool {
     state.item.msgid.is_empty()
         && state.item.msgctxt.is_none()
         && state.item.msgid_plural.is_none()
-        && state.plural_index == 0
+        && state.line.plural_index() == 0
 }
 
 fn parse_header_fragment(line_bytes: &[u8]) -> Result<Vec<MergeHeader<'_>>, ParseError> {

--- a/crates/ferrocat-po/src/parse.rs
+++ b/crates/ferrocat-po/src/parse.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use memchr::memchr_iter;
 
+use crate::line_state::{PoLineContext, PoLineState};
 use crate::scan::{
     CommentKind, Keyword, LineKind, LineScanner, classify_line, parse_plural_index,
     split_once_byte, trim_ascii, unrecognized_po_line,
@@ -10,23 +11,11 @@ use crate::text::{extract_quoted_bytes_cow, split_reference_comment};
 use crate::utf8::input_slice_as_str;
 use crate::{Header, MsgStr, ParseError, ParsePosition, PoFile, PoItem};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Context {
-    Id,
-    IdPlural,
-    Str,
-    Ctxt,
-}
-
 #[derive(Debug)]
 struct ParserState {
     item: PoItem,
     msgstr: MsgStr,
-    context: Option<Context>,
-    plural_index: usize,
-    obsolete_line_count: usize,
-    content_line_count: usize,
-    has_keyword: bool,
+    line: PoLineState,
 }
 
 impl ParserState {
@@ -34,11 +23,7 @@ impl ParserState {
         Self {
             item: PoItem::new(nplurals),
             msgstr: MsgStr::None,
-            context: None,
-            plural_index: 0,
-            obsolete_line_count: 0,
-            content_line_count: 0,
-            has_keyword: false,
+            line: PoLineState::default(),
         }
     }
 
@@ -50,11 +35,7 @@ impl ParserState {
     fn reset_after_take(&mut self, nplurals: usize) {
         self.item.nplurals = nplurals;
         self.msgstr = MsgStr::None;
-        self.context = None;
-        self.plural_index = 0;
-        self.obsolete_line_count = 0;
-        self.content_line_count = 0;
-        self.has_keyword = false;
+        self.line.reset();
     }
 
     fn set_msgstr(&mut self, plural_index: usize, value: String) {
@@ -345,44 +326,35 @@ fn parse_keyword_line(
 ) -> Result<(), ParseError> {
     match keyword {
         Keyword::IdPlural => {
-            state.obsolete_line_count += usize::from(obsolete);
+            state
+                .line
+                .mark_keyword(PoLineContext::IdPlural, 0, obsolete);
             state.item.msgid_plural = Some(
                 at_line_position(extract_quoted_bytes_cow(line_bytes), position)?.into_owned(),
             );
-            state.context = Some(Context::IdPlural);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
         Keyword::Id => {
             finish_item(state, file, current_nplurals);
-            state.obsolete_line_count += usize::from(obsolete);
+            state.line.mark_keyword(PoLineContext::Id, 0, obsolete);
             state.item.msgid =
                 at_line_position(extract_quoted_bytes_cow(line_bytes), position)?.into_owned();
-            state.context = Some(Context::Id);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
         Keyword::Str => {
             let plural_index = parse_plural_index(line_bytes).unwrap_or(0);
-            state.plural_index = plural_index;
-            state.obsolete_line_count += usize::from(obsolete);
+            state
+                .line
+                .mark_keyword(PoLineContext::Str, plural_index, obsolete);
             state.set_msgstr(
                 plural_index,
                 at_line_position(extract_quoted_bytes_cow(line_bytes), position)?.into_owned(),
             );
-            state.context = Some(Context::Str);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
         Keyword::Ctxt => {
             finish_item(state, file, current_nplurals);
-            state.obsolete_line_count += usize::from(obsolete);
+            state.line.mark_keyword(PoLineContext::Ctxt, 0, obsolete);
             state.item.msgctxt = Some(
                 at_line_position(extract_quoted_bytes_cow(line_bytes), position)?.into_owned(),
             );
-            state.context = Some(Context::Ctxt);
-            state.content_line_count += 1;
-            state.has_keyword = true;
         }
     }
 
@@ -395,20 +367,19 @@ fn append_continuation(
     position: ParsePosition,
     state: &mut ParserState,
 ) -> Result<(), ParseError> {
-    state.obsolete_line_count += usize::from(obsolete);
-    state.content_line_count += 1;
+    state.line.mark_continuation(obsolete);
     let value = at_line_position(extract_quoted_bytes_cow(line_bytes), position)?;
 
-    match state.context {
-        Some(Context::Str) => {
-            state.append_msgstr(state.plural_index, value.as_ref());
+    match state.line.context() {
+        Some(PoLineContext::Str) => {
+            state.append_msgstr(state.line.plural_index(), value.as_ref());
         }
-        Some(Context::Id) => state.item.msgid.push_str(value.as_ref()),
-        Some(Context::IdPlural) => {
+        Some(PoLineContext::Id) => state.item.msgid.push_str(value.as_ref()),
+        Some(PoLineContext::IdPlural) => {
             let target = state.item.msgid_plural.get_or_insert_with(String::new);
             target.push_str(value.as_ref());
         }
-        Some(Context::Ctxt) => {
+        Some(PoLineContext::Ctxt) => {
             let target = state.item.msgctxt.get_or_insert_with(String::new);
             target.push_str(value.as_ref());
         }
@@ -427,7 +398,7 @@ fn at_line_position<T>(
 }
 
 fn finish_item(state: &mut ParserState, file: &mut PoFile, current_nplurals: &mut usize) {
-    if !state.has_keyword {
+    if !state.line.has_keyword() {
         return;
     }
 
@@ -435,7 +406,7 @@ fn finish_item(state: &mut ParserState, file: &mut PoFile, current_nplurals: &mu
         return;
     }
 
-    if state.obsolete_line_count >= state.content_line_count && state.content_line_count > 0 {
+    if state.line.is_obsolete_item() {
         state.item.obsolete = true;
     }
 


### PR DESCRIPTION
Refs #51

## Summary

- add a shared private `PoLineState` for keyword context, plural slot, obsolete-line accounting, and item keyword tracking
- switch the owned parser, borrowed parser, and low-level merge parser to use that shared line state
- keep parser-specific storage and header handling local to each parser, so public parse behavior stays unchanged

## Scope

This is an incremental parser-state cleanup for #51. It does not resolve the CRLF policy divergence or fully unify parser state machines behind a shared sink, so #51 should stay open after this PR merges.

## Validation

- `cargo fmt --all --check`
- `cargo test -p ferrocat-po --test parser_differential --all-features --locked`
- `cargo test -p ferrocat-po --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo +1.93.0 check --workspace --all-targets --all-features --locked`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked`
