### PR TITLE
docs: 1.0 stable polish — footer version fix + pre-1.0 wording

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -25,7 +25,14 @@
     "crates/ferrocat": {
       "release-type": "rust",
       "package-name": "ferrocat",
-      "component": "ferrocat"
+      "component": "ferrocat",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "docs/package.json",
+          "jsonpath": "$.version"
+        }
+      ]
     },
     "crates/ferrocat-po": {
       "release-type": "rust",

--- a/docs/app/root.tsx
+++ b/docs/app/root.tsx
@@ -8,6 +8,7 @@ import type { SidebarItem } from "ardo"
 import config from "virtual:ardo/config"
 import sidebar from "virtual:ardo/sidebar"
 import type { MetaFunction } from "react-router"
+import { version } from "../package.json"
 import {
   BookOpen,
   Box,
@@ -87,7 +88,7 @@ export default function Root() {
         project: undefined,
         children: (
           <p className="ferro-footer-note">
-            Ferrocat Docs v0.9.0
+            Ferrocat Docs v{version}
             <span>Performance-first localization tooling for Gettext, ICU MessageFormat, and JSON-oriented delivery.</span>
           </p>
         ),

--- a/docs/app/routes/guide/getting-started.mdx
+++ b/docs/app/routes/guide/getting-started.mdx
@@ -59,9 +59,9 @@ msgstr "world"
 
 - **MSRV:** Rust `1.93.0`
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
-- **MSRV bumps:** before `1.0`, raising the MSRV is allowed in a minor release
-  when the changelog calls it out; patch releases should not raise the MSRV.
-- **Semver:** the public API is treated seriously, but the project is still pre-`1.0`
+- **MSRV bumps:** raising the MSRV is treated as a minor-version change and
+  called out in the changelog; patch releases should not raise the MSRV.
+- **Semver:** the public API follows semantic versioning; breaking changes ship in a new major version
 - **Docs surface:** README examples, rustdoc, and the site should stay aligned
 
 ## Site-specific development

--- a/docs/app/routes/guide/index.mdx
+++ b/docs/app/routes/guide/index.mdx
@@ -14,5 +14,5 @@ Start here when you want to understand Ferrocat as a product, not just as a crat
 - [Runtime Compilation](/guide/runtime-compilation) for turning catalogs into application-ready artifacts
 - [Ferrocat And Palamedes](/guide/palamedes) for how the catalog engine connects to the JS/TS i18n framework
 - [Project Status](/guide/project-status) for current strengths, roadmap themes, and compatibility policy
-- [Releases And Upgrading](/guide/upgrading) for changelog locations, lockstep versions, and safe pre-`1.0` upgrades
+- [Releases And Upgrading](/guide/upgrading) for changelog locations, lockstep versions, and safe upgrades
 - [Community](/guide/community) for contributing and operational links

--- a/docs/app/routes/guide/palamedes.mdx
+++ b/docs/app/routes/guide/palamedes.mdx
@@ -21,8 +21,8 @@ That boundary includes host bindings. Ferrocat does not ship first-party
 JavaScript, TypeScript, WebAssembly, or N-API bindings from this repository.
 JS/TS access is routed through Palamedes, including the `palamedes-node` N-API
 bridge in the Palamedes repository. Other host environments should treat
-Ferrocat as a Rust engine and integrate through the Rust crates, a future
-Ferrocat CLI surface, or their own host-specific binding layer.
+Ferrocat as a Rust engine and integrate through the Rust crates, the
+Ferrocat CLI, or their own host-specific binding layer.
 
 ## Division Of Responsibility
 

--- a/docs/app/routes/guide/project-status.mdx
+++ b/docs/app/routes/guide/project-status.mdx
@@ -6,7 +6,7 @@ order: 40
 
 # Project Status
 
-Ferrocat is an actively developed pre-`1.0` Rust project. The goal is stable and product-facing: make translation catalogs easier to update, validate, audit, compile, and ship. The public API is already treated with care, but the project is still early enough to make deliberate changes when they improve long-term catalog behavior.
+Ferrocat is a stable, production-ready Rust project. Since the `1.0` release the public API follows semantic versioning, so breaking changes ship only in a new major version and applications can depend on it with confidence. The focus stays product-facing: make translation catalogs easier to update, validate, audit, compile, and ship.
 
 ## Current strengths
 
@@ -22,21 +22,22 @@ Ferrocat is an actively developed pre-`1.0` Rust project. The goal is stable and
 
 - **MSRV:** `1.93.0`
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
-- **MSRV bumps:** before `1.0`, raising the MSRV is allowed in a minor release
-  when the changelog calls it out; patch releases should not raise the MSRV.
-- **Semver:** the public API is treated seriously, but carefully documented breaking changes may still happen before `1.0`
+- **MSRV bumps:** raising the MSRV is treated as a minor-version change and
+  called out in the changelog; patch releases should not raise the MSRV.
+- **Semver:** the public API follows semantic versioning; breaking changes ship in a new major version and are documented in the changelog
 - **Documentation:** README examples, rustdoc, and repository docs aim to stay aligned
 - **Host bindings:** Ferrocat is currently a pure-Rust engine. JS/TS access
   belongs in Palamedes and its `palamedes-node` bridge; other hosts should use
-  the Rust crates, a future CLI surface, or their own binding layer.
+  the Rust crates, the `ferrocat-cli` command-line interface, or their own
+  binding layer.
 
 ## Roadmap themes
 
 - more catalog workflow APIs inspired by practical translation-maintenance jobs, especially filtering, attribute transforms, and structured completeness checks
 - deeper runtime/catalog workflows on top of the compiled catalog layer
-- broader cross-ecosystem tooling, especially a CLI and host-specific bindings
-  that stay outside the Ferrocat core crate boundary unless a future ADR
-  deliberately changes that split
+- broader cross-ecosystem tooling on top of the `ferrocat-cli` foundation,
+  especially host-specific bindings that stay outside the Ferrocat core crate
+  boundary unless a future ADR deliberately changes that split
 - continued conformance growth and publication-grade benchmarking discipline
 
 MessageFormat 2 is deliberately not a near-term roadmap item. Ferrocat tracks
@@ -47,7 +48,7 @@ problems without taking on a second transitional message syntax.
 
 ## Why the project direction matters
 
-Today Ferrocat is Rust-first. The longer-term goal is broader: a trustworthy translation core that can serve multiple ecosystems from one implementation, without forcing each host environment to re-implement catalog semantics, compiled key derivation, and locale resolution separately. That does not mean every host binding belongs in this repository. The core contract is the Rust API plus host-neutral formats and diagnostics; Palamedes, a CLI, or host-specific adapter projects can expose those contracts to application environments.
+Today Ferrocat is Rust-first. The longer-term goal is broader: a trustworthy translation core that can serve multiple ecosystems from one implementation, without forcing each host environment to re-implement catalog semantics, compiled key derivation, and locale resolution separately. That does not mean every host binding belongs in this repository. The core contract is the Rust API plus host-neutral formats and diagnostics; Palamedes, the `ferrocat-cli`, or host-specific adapter projects can expose those contracts to application environments.
 
 ## Follow-up reading
 

--- a/docs/app/routes/guide/upgrading.mdx
+++ b/docs/app/routes/guide/upgrading.mdx
@@ -1,14 +1,15 @@
 ---
 title: Releases And Upgrading
-description: Where Ferrocat changelogs live and how to upgrade pre-1.0 versions safely.
+description: Where Ferrocat changelogs live and how to upgrade between stable releases safely.
 order: 45
 ---
 
 # Releases And Upgrading
 
-Ferrocat is still pre-`1.0`, so public APIs are treated carefully but minor
-version upgrades can still carry semver-relevant changes. Start every upgrade
-from the changelog and keep the workspace crate versions aligned.
+Ferrocat follows semantic versioning from `1.0` onward: breaking API changes
+ship in a new major version, while minor and patch releases stay backward
+compatible. Start every upgrade from the changelog and keep the workspace crate
+versions aligned.
 
 ## Where release notes live
 
@@ -25,43 +26,47 @@ visible in release notes and changelog sections.
 
 MSRV bumps follow the same release-note rule. Ferrocat aligns its declared MSRV
 with OXC when practical while avoiding churn from tracking only the newest
-stable toolchain. Before `1.0`, raising the MSRV is allowed in a minor release
-when the changelog calls it out; patch releases should not raise the MSRV.
+stable toolchain. Raising the MSRV is treated as a minor-version change and
+called out in the changelog; patch releases should not raise the MSRV.
 
 ## Lockstep versions
 
-The public library crates are released in lockstep. In normal application code,
-prefer depending on the umbrella crate:
+The public library crates are released in lockstep: every release advances all
+of them to the same version. In normal application code, prefer depending on the
+umbrella crate:
 
 ```toml
 [dependencies]
-ferrocat = "0.13"
+ferrocat = "1"
 ```
 
 If you depend on lower-level crates directly, keep every Ferrocat crate on the
-same minor version:
+same version line so you get the combination that was released and tested
+together:
 
 ```toml
 [dependencies]
-ferrocat-po = "0.13"
-ferrocat-icu = "0.13"
+ferrocat-po = "1"
+ferrocat-icu = "1"
 ```
 
-Do not mix the umbrella crate and direct sub-crate dependencies at different
-pre-`1.0` minors, for example `ferrocat = "0.13"` with
-`ferrocat-po = "0.12"`. Cargo treats `0.12` and `0.13` as incompatible version
-lines, so the build can contain two copies of the Ferrocat types and then fail
-with confusing type-mismatch errors.
+Within the `1.x` line, minor and patch releases stay backward compatible, so
+Cargo resolves a shared `"1"` requirement to a single, latest-compatible
+version. Avoid pinning the umbrella crate and a direct sub-crate to different
+exact versions, for example `ferrocat = "=1.2.0"` with `ferrocat-po = "=1.0.0"`:
+that can pull two copies of the Ferrocat types into the build and fail with
+confusing type-mismatch errors.
 
 ## Upgrade routine
 
 1. Read the `ferrocat` changelog for the target version.
 2. If you use direct sub-crates, read their matching changelogs too.
-3. Update all Ferrocat crate requirements to the same minor version.
+3. Update all Ferrocat crate requirements to the same version line.
 4. Run `cargo update -p ferrocat -p ferrocat-po -p ferrocat-icu` when those
    packages are present in your lockfile.
 5. Run your normal test suite plus the Ferrocat APIs you call in release or CI
    paths.
 
-When a future `0.x` release needs a durable migration note, this page should
-link that note from the upgrade routine instead of leaving it buried in a PR.
+When a future release needs a durable migration note — for example a major
+version with breaking changes — this page should link that note from the upgrade
+routine instead of leaving it buried in a PR.

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -72,7 +72,7 @@ See [ADR 0019](/architecture/adr/0019-versioned-artifact-json-contract) for the
 compatibility rules around the compiled artifact JSON contract.
 ## API Compatibility
 
-Ferrocat is still pre-1.0, but growth-prone public enums are deliberately marked as non-exhaustive where new variants are realistic. Downstream code should keep fallback match arms for ICU AST nodes, catalog storage formats, compiled key strategies, and API-level error categories.
+Growth-prone public enums are deliberately marked as non-exhaustive where new variants are realistic, so new variants can be added without a breaking change within the `1.x` line. Downstream code should keep fallback match arms for ICU AST nodes, catalog storage formats, compiled key strategies, and API-level error categories.
 
 Semantically closed option enums such as `CatalogSemantics` and `PluralEncoding` remain exhaustive so callers can continue to match every documented mode directly.
 ## Umbrella Crate Namespaces

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "private": true,
   "packageManager": "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f",
   "type": "module",


### PR DESCRIPTION
## Overview

Two related documentation improvements around the 1.0 release.

### 1. Footer version (fix)
The footer hardcoded `v0.9.0` and stayed stale after the 1.0 release. The version is now read dynamically from `docs/package.json` (set to `1.0.0`), and Release Please keeps that file in sync via an `extra-files` entry — so the displayed version tracks releases automatically and cannot go stale again.

### 2. Wording for stable (docs)
Replaced pre-1.0 framing across the living docs:
- **Upgrading guide:** documented semantic-versioning rules from 1.0 onward; fixed the old 0.x Cargo examples (`0.13` → `"1"`) and the lockstep compatibility note
- **Project status:** "stable, production-ready" instead of "actively developed pre-1.0"
- **getting-started / api-overview:** post-1.0 semver and MSRV policy
- **ferrocat-cli** is now presented as shipping, instead of being described as a "future CLI"

## Testing
- `pnpm build` runs cleanly
- Rendered HTML shows `v1.0.0` and the new wording
- No pre-1.0 / "future CLI" remnants in the living docs

## Note
ADR-0014 is left unchanged as a historical record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)