### PR TITLE
fix(po): align parser line ending handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,8 @@ For the common "merge fresh extracted messages into an existing catalog" workflo
 rejects declared non-UTF-8 charsets before decoding and reports invalid UTF-8
 through Ferrocat's `ParseError` instead of making callers do their own
 `String::from_utf8` step. `parse_po_borrowed` is the allocation-light PO parser
-for read-heavy paths. It borrows from the source buffer where possible, but it
-currently requires LF-only input; normalize CRLF input first or use `parse_po`,
-which handles line-ending normalization internally.
+for read-heavy paths. It borrows from the source buffer where possible and uses
+the same LF, CRLF, and bare CR line-ending policy as `parse_po`.
 
 ICU-native workflows can use `analyze_icu`, `compare_icu_messages`, and `validate_icu_formatter_support` to catch missing arguments, formatter changes, unsupported runtime formatter kinds or styles, tag mismatches, select/plural branch drift, and discouraged pattern-style formatters. Runtime artifact compilation can opt into the same source/translation checks with `icu_compatibility`.
 

--- a/crates/ferrocat-po/README.md
+++ b/crates/ferrocat-po/README.md
@@ -36,6 +36,6 @@ anything. The default report checks completeness, target-only stale messages,
 ICU syntax, ICU source/translation compatibility, semantic metadata conflicts,
 obsolete entries, and visible `fuzzy` flags.
 
-`parse_po_borrowed` keeps many fields as references into the input buffer, so it currently accepts LF-only content. If your source can contain CRLF or bare CR line endings, normalize it before calling `parse_po_borrowed` or use the owned `parse_po` parser.
+`parse_po_borrowed` keeps many fields as references into the input buffer and accepts the same LF, CRLF, and bare CR line-ending forms as the owned `parse_po` parser.
 
 If you want the umbrella dependency instead, use [`ferrocat`](https://docs.rs/ferrocat).

--- a/crates/ferrocat-po/src/borrowed.rs
+++ b/crates/ferrocat-po/src/borrowed.rs
@@ -281,17 +281,13 @@ struct BorrowedLine<'a> {
 ///
 /// This parser keeps references into `input` for fields that do not need
 /// unescaping, which reduces allocations compared with [`crate::parse_po`].
+/// LF, CRLF, and bare CR line endings are accepted.
 ///
 /// # Errors
 ///
 /// Returns [`ParseError`] when the input is not valid PO syntax.
 pub fn parse_po_borrowed(input: &str) -> Result<BorrowedPoFile<'_>, ParseError> {
     let input = input.strip_prefix('\u{feff}').unwrap_or(input);
-    if input.as_bytes().contains(&b'\r') {
-        return Err(ParseError::new(
-            "borrowed PO parsing currently requires LF-only input",
-        ));
-    }
 
     let mut file = BorrowedPoFile::default();
     file.items.reserve((input.len() / 96).max(1));
@@ -802,10 +798,15 @@ msgstr "world"
     }
 
     #[test]
-    fn rejects_crlf_input_for_borrowed_parsing() {
-        let error = parse_po_borrowed("msgid \"foo\"\r\nmsgstr \"bar\"\r\n")
-            .expect_err("crlf should be rejected");
-        assert!(error.to_string().contains("LF-only"));
+    fn accepts_crlf_input_for_borrowed_parsing() {
+        let file = parse_po_borrowed("msgid \"foo\"\r\nmsgstr \"bar\"\r\n")
+            .expect("borrowed parse with crlf");
+
+        assert_eq!(file.items[0].msgid, Cow::Borrowed("foo"));
+        assert_eq!(
+            file.items[0].msgstr,
+            super::BorrowedMsgStr::Singular(Cow::Borrowed("bar"))
+        );
     }
 
     #[test]

--- a/crates/ferrocat-po/src/merge.rs
+++ b/crates/ferrocat-po/src/merge.rs
@@ -145,18 +145,10 @@ pub fn merge_catalog<'a>(
     existing_po: &'a str,
     extracted_messages: &[ExtractedMessage<'a>],
 ) -> Result<String, ParseError> {
-    let normalized;
-    let input = if existing_po.as_bytes().contains(&b'\r') {
-        normalized = existing_po.replace("\r\n", "\n").replace('\r', "\n");
-        normalized.as_str()
-    } else {
-        existing_po
-    };
-
-    let existing = parse_merge_po(input)?;
+    let existing = parse_merge_po(existing_po)?;
     let nplurals = parse_nplurals(&existing.headers).unwrap_or(2);
     let options = SerializeOptions::default();
-    let mut out = String::with_capacity(estimate_merge_capacity(input, extracted_messages));
+    let mut out = String::with_capacity(estimate_merge_capacity(existing_po, extracted_messages));
     let mut scratch = String::new();
 
     write_file_preamble(&mut out, &existing);

--- a/crates/ferrocat-po/src/parse.rs
+++ b/crates/ferrocat-po/src/parse.rs
@@ -112,21 +112,14 @@ struct BorrowedLine<'a> {
 
 /// Parses PO content into the owned [`PoFile`] representation.
 ///
-/// Line endings are normalized before parsing, and the UTF-8 BOM is ignored
-/// when present.
+/// LF, CRLF, and bare CR line endings are accepted, and the UTF-8 BOM is
+/// ignored when present.
 ///
 /// # Errors
 ///
 /// Returns [`ParseError`] when the input is not valid PO syntax.
 pub fn parse_po(input: &str) -> Result<PoFile, ParseError> {
     let input = strip_utf8_bom(input);
-    let normalized;
-    let input = if input.as_bytes().contains(&b'\r') {
-        normalized = input.replace("\r\n", "\n").replace('\r', "\n");
-        normalized.as_str()
-    } else {
-        input
-    };
 
     let mut file = PoFile::default();
     file.items.reserve((input.len() / 96).max(1));

--- a/crates/ferrocat-po/src/scan.rs
+++ b/crates/ferrocat-po/src/scan.rs
@@ -1,9 +1,7 @@
-use memchr::Memchr;
-
 use crate::{ParseError, ParsePosition};
 
 mod backend {
-    use memchr::{memchr, memchr3, memrchr};
+    use memchr::{memchr, memchr2, memchr3, memrchr};
 
     #[inline]
     pub fn find_byte(byte: u8, haystack: &[u8]) -> Option<usize> {
@@ -11,15 +9,13 @@ mod backend {
     }
 
     #[inline]
-    pub fn find_last_byte(byte: u8, haystack: &[u8]) -> Option<usize> {
-        memrchr(byte, haystack)
+    pub fn find_either(first: u8, second: u8, haystack: &[u8]) -> Option<usize> {
+        memchr2(first, second, haystack)
     }
 
-    #[cfg(test)]
     #[inline]
-    pub fn find_either(first: u8, second: u8, haystack: &[u8]) -> Option<usize> {
-        use memchr::memchr2;
-        memchr2(first, second, haystack)
+    pub fn find_last_byte(byte: u8, haystack: &[u8]) -> Option<usize> {
+        memrchr(byte, haystack)
     }
 
     #[inline]
@@ -155,7 +151,6 @@ pub struct Line<'a> {
 
 pub struct LineScanner<'a> {
     bytes: &'a [u8],
-    newlines: Memchr<'a>,
     offset: usize,
     line_number: usize,
     finished: bool,
@@ -165,7 +160,6 @@ impl<'a> LineScanner<'a> {
     pub fn new(bytes: &'a [u8]) -> Self {
         Self {
             bytes,
-            newlines: Memchr::new(b'\n', bytes),
             offset: 0,
             line_number: 1,
             finished: false,
@@ -179,30 +173,29 @@ impl<'a> Iterator for LineScanner<'a> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         while !self.finished {
-            let next_newline = if let Some(index) = self.newlines.next() {
-                index
-            } else {
+            if self.offset == self.bytes.len() {
                 self.finished = true;
-                self.bytes.len()
-            };
-            if self.finished && self.offset == self.bytes.len() {
                 return None;
             }
             let raw_offset = self.offset;
+            let line_end = find_either(b'\n', b'\r', &self.bytes[self.offset..])
+                .map_or(self.bytes.len(), |relative| self.offset + relative);
+            let separator = self.bytes.get(line_end).copied();
             let line_number = self.line_number;
             self.line_number += 1;
-            let raw = &self.bytes[self.offset..next_newline];
+            let raw = &self.bytes[self.offset..line_end];
 
-            if next_newline < self.bytes.len() {
-                self.offset = next_newline + 1;
-            } else {
-                self.offset = self.bytes.len();
-            }
+            self.offset = match separator {
+                Some(b'\r') if self.bytes.get(line_end + 1) == Some(&b'\n') => line_end + 2,
+                Some(b'\r' | b'\n') => line_end + 1,
+                Some(_) => unreachable!("line separator search only returns CR or LF"),
+                None => self.bytes.len(),
+            };
 
             let mut trimmed = trim_ascii_start(raw);
             let mut content_offset = raw_offset + raw.len() - trimmed.len();
             if trimmed.is_empty() {
-                if next_newline == self.bytes.len() {
+                if self.offset == self.bytes.len() {
                     return None;
                 }
                 continue;
@@ -215,7 +208,7 @@ impl<'a> Iterator for LineScanner<'a> {
                 content_offset += 2 + after_marker.len() - trimmed.len();
                 obsolete = true;
                 if trimmed.is_empty() {
-                    if next_newline == self.bytes.len() {
+                    if self.offset == self.bytes.len() {
                         return None;
                     }
                     continue;
@@ -267,7 +260,6 @@ pub fn find_last_byte(byte: u8, haystack: &[u8]) -> Option<usize> {
     backend::find_last_byte(byte, haystack)
 }
 
-#[cfg(test)]
 pub fn find_either(first: u8, second: u8, haystack: &[u8]) -> Option<usize> {
     backend::find_either(first, second, haystack)
 }
@@ -384,6 +376,27 @@ mod tests {
         assert_eq!(second.position.offset(), 17);
         assert_eq!(second.position.line(), 2);
         assert_eq!(second.position.column(), 4);
+
+        assert!(scanner.next().is_none());
+    }
+
+    #[test]
+    fn scans_crlf_and_bare_cr_line_endings() {
+        let input = b"msgid \"x\"\r\nmsgstr \"y\"\r#~ msgid \"old\"\r\n";
+        let mut scanner = LineScanner::new(input);
+
+        let first = scanner.next().expect("first line");
+        assert_eq!(first.trimmed, b"msgid \"x\"");
+        assert_eq!(first.position.line(), 1);
+
+        let second = scanner.next().expect("second line");
+        assert_eq!(second.trimmed, b"msgstr \"y\"");
+        assert_eq!(second.position.line(), 2);
+
+        let third = scanner.next().expect("third line");
+        assert_eq!(third.trimmed, b"msgid \"old\"");
+        assert!(third.obsolete);
+        assert_eq!(third.position.line(), 3);
 
         assert!(scanner.next().is_none());
     }

--- a/crates/ferrocat-po/tests/parser_differential.rs
+++ b/crates/ferrocat-po/tests/parser_differential.rs
@@ -55,6 +55,20 @@ fn owned_and_borrowed_parsers_match_on_shared_lf_inputs() {
 }
 
 #[test]
+fn owned_and_borrowed_parsers_match_on_crlf_and_bare_cr_inputs() {
+    for line_ending in ["\r\n", "\r"] {
+        let input = CASES[0].1.replace('\n', line_ending);
+        let owned = parse_po(&input)
+            .unwrap_or_else(|error| panic!("{line_ending:?}: owned parse: {error}"));
+        let borrowed = parse_po_borrowed(&input)
+            .unwrap_or_else(|error| panic!("{line_ending:?}: borrowed parse: {error}"))
+            .into_owned();
+
+        assert_eq!(borrowed, owned, "{line_ending:?}");
+    }
+}
+
+#[test]
 fn merge_parser_preserves_matching_existing_messages() {
     for (name, input) in CASES {
         let owned = parse_po(input).unwrap_or_else(|error| panic!("{name}: owned parse: {error}"));
@@ -65,6 +79,25 @@ fn merge_parser_preserves_matching_existing_messages() {
             parse_po(&merged).unwrap_or_else(|error| panic!("{name}: reparse merged: {error}"));
 
         assert_eq!(reparsed.items, owned.items, "{name}\nmerged:\n{merged}");
+    }
+}
+
+#[test]
+fn merge_parser_preserves_matching_crlf_and_bare_cr_messages() {
+    for line_ending in ["\r\n", "\r"] {
+        let input = CASES[0].1.replace('\n', line_ending);
+        let owned = parse_po(&input)
+            .unwrap_or_else(|error| panic!("{line_ending:?}: owned parse: {error}"));
+        let extracted = extracted_messages_from(&owned);
+        let merged = merge_catalog(&input, &extracted)
+            .unwrap_or_else(|error| panic!("{line_ending:?}: merge parse: {error}"));
+        let reparsed = parse_po(&merged)
+            .unwrap_or_else(|error| panic!("{line_ending:?}: reparse merged: {error}"));
+
+        assert_eq!(
+            reparsed.items, owned.items,
+            "{line_ending:?}\nmerged:\n{merged}"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #51

## Summary

- move LF, CRLF, and bare CR handling into the shared `LineScanner`
- remove the separate CR normalization paths from `parse_po` and `merge_catalog`
- allow `parse_po_borrowed` to parse CRLF/bare CR input without losing borrowability for unescaped fields
- add parser differential coverage for owned, borrowed, and merge parser paths over CRLF and bare CR inputs
- update README text so the borrowed parser no longer documents an LF-only limitation

## Scope

This finishes #51 through the accumulated smaller slices instead of a single high-risk sink rewrite:

- PR #111 added executable differential guardrails
- PR #118 shared borrowed `msgstr` handling between borrowed and merge parsing
- PR #121 shared line-state bookkeeping across owned, borrowed, and merge parsing
- this PR removes the remaining observable CRLF policy divergence through the common scanner

The parser entry points still keep their output-specific storage local, but the duplicated behavior that caused drift is now covered by shared helpers and differential tests.

## Validation

- `cargo fmt --all --check`
- `cargo test -p ferrocat-po --test parser_differential --all-features --locked`
- `cargo test -p ferrocat-po --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo +1.93.0 check --workspace --all-targets --all-features --locked`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked`
