### PR TITLE
docs(adr): clarify catalog packaging boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cargo add ferrocat
 The public Rust entry point is the `ferrocat` crate. It re-exports the stable Rust surface from the lower-level workspace crates:
 
 - `ferrocat`: umbrella crate and recommended dependency for application code
-- `ferrocat-po`: PO parsing, serialization, merge/combine helpers, and higher-level catalog update flows
+- `ferrocat-po`: PO parsing, serialization, low-level merge helpers, and feature-gated higher-level catalog workflows
 - `ferrocat-icu`: ICU MessageFormat parsing, structural helpers, source/translation compatibility diagnostics, and semantic message metadata helpers
 
 For non-Rust CI release gates, install the CLI package and run `ferrocat audit`:

--- a/crates/ferrocat-po/README.md
+++ b/crates/ferrocat-po/README.md
@@ -2,7 +2,7 @@
 
 Performance-first catalog parsing, serialization, merge helpers, release audits, and runtime compilation for `ferrocat`.
 
-This crate is the catalog-workflow layer. Use it when translation files need to be updated, reviewed, checked for release readiness, or compiled into application-facing payloads.
+This crate contains the PO core plus the feature-gated catalog workflow layer. Use it when translation files need to be parsed, serialized, updated, reviewed, checked for release readiness, or compiled into application-facing payloads.
 
 Add it with:
 
@@ -10,7 +10,7 @@ Add it with:
 cargo add ferrocat-po
 ```
 
-This crate covers both the low-level PO surface and the higher-level catalog layer.
+This crate covers both the low-level PO surface and the higher-level catalog layer. For PO-only dependency profiles, disable default features.
 
 At the catalog layer, it supports three explicit modes:
 

--- a/docs/app/routes/architecture/adr/0006-separate-po-core-from-high-level-catalog-api.mdx
+++ b/docs/app/routes/architecture/adr/0006-separate-po-core-from-high-level-catalog-api.mdx
@@ -8,6 +8,7 @@ order: 60
 
 - Status: Accepted
 - Date: 2026-03-16
+- Refined by: [ADR 0020](/architecture/adr/0020-catalog-layer-packaging-boundary)
 
 ## Context
 
@@ -39,6 +40,8 @@ The project now has both layers:
 ## Decision
 
 Keep the PO core and the high-level catalog API as distinct layers with different responsibilities.
+
+ADR 0020 clarifies the 1.x packaging boundary: this distinction is an internal layer and feature-profile boundary inside `ferrocat-po`, not a separate `ferrocat-catalog` crate for the current major version.
 
 The PO core is:
 

--- a/docs/app/routes/architecture/adr/0020-catalog-layer-packaging-boundary.mdx
+++ b/docs/app/routes/architecture/adr/0020-catalog-layer-packaging-boundary.mdx
@@ -1,0 +1,57 @@
+---
+title: "ADR 0020: Keep the 1.x Catalog Layer in ferrocat-po Behind Feature Profiles"
+description: "Accepted architecture decision record: keep the 1.x catalog layer in ferrocat-po behind feature profiles."
+order: 200
+---
+
+# ADR 0020: Keep the 1.x Catalog Layer in ferrocat-po Behind Feature Profiles
+
+- Status: Accepted
+- Date: 2026-06-19
+- Refines: [ADR 0006](/architecture/adr/0006-separate-po-core-from-high-level-catalog-api)
+
+## Context
+
+ADR 0006 separates the low-level PO core from the high-level catalog API by responsibility:
+
+- the PO core owns format-level parsing, borrowed parsing, serialization, and lean merge helpers
+- the high-level catalog API owns task-level operations such as update, combine, audit, NDJSON storage, machine-translation metadata, and runtime artifact compilation
+
+That layering is still correct, but the packaging boundary needs to match the 1.x release reality.
+
+`ferrocat-po` is now a published 1.x crate. Moving `parse_catalog`, `update_catalog`, `combine_catalogs`, audit, compile, NDJSON, and machine-translation APIs into a new `ferrocat-catalog` crate would remove public APIs from `ferrocat-po` or require a dependency cycle where `ferrocat-po` depends on a catalog crate that itself needs the PO core. Either option is a breaking packaging change, not a safe 1.x cleanup.
+
+The immediate dependency-weight concern is already handled by feature profiles:
+
+- `ferrocat-po` with default features exposes the full catalog workflow surface
+- `ferrocat-po` with `default-features = false` keeps the PO parser, borrowed parser, serializer, string helpers, and low-level merge API available without catalog-only dependencies
+- the umbrella `ferrocat` crate remains the stable facade for application users
+
+## Decision
+
+For the 1.x line, keep the high-level catalog layer in `ferrocat-po` and treat the PO-core/catalog separation as an internal layer boundary enforced by modules, feature profiles, tests, and documentation.
+
+Do not extract a `ferrocat-catalog` crate during the 1.x line unless the project intentionally plans a major-version packaging break.
+
+Concretely:
+
+- `ferrocat-po` remains the published crate for both PO-core APIs and opt-in catalog workflow APIs
+- `default-features = false` is the supported pure PO-core dependency profile
+- catalog-only dependencies stay behind the `catalog` feature profile
+- the umbrella `ferrocat::catalog` facade continues to re-export the high-level catalog APIs
+- a future `ferrocat-catalog` crate requires a major-version design because it changes crate ownership and public import paths
+
+## Consequences
+
+Positive:
+
+- the 1.x public API stays semver-compatible
+- PO-only users can avoid catalog-only dependency weight without changing crates
+- the architecture documentation now matches the published crate topology
+- future catalog work can keep improving module boundaries without creating package churn
+
+Negative:
+
+- the crate name `ferrocat-po` continues to carry more than a pure PO format core by default
+- contributors must distinguish the internal layer boundary from the crate boundary
+- a later `ferrocat-catalog` extraction remains possible, but it is a major-version packaging project rather than a routine refactor

--- a/docs/app/routes/architecture/adr/index.mdx
+++ b/docs/app/routes/architecture/adr/index.mdx
@@ -28,3 +28,4 @@ Current records:
 - [0017: Add Catalog Audit Reports Without Reintroducing Fuzzy Matching](/architecture/adr/0017-catalog-audit-reports)
 - [0018: Add Machine-Translation Metadata to Catalog Entries](/architecture/adr/0018-machine-translation-entry-metadata)
 - [0019: Version the Compiled Artifact JSON Contract](/architecture/adr/0019-versioned-artifact-json-contract)
+- [0020: Keep the 1.x Catalog Layer in `ferrocat-po` Behind Feature Profiles](/architecture/adr/0020-catalog-layer-packaging-boundary)

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -31,6 +31,10 @@ escape helpers, and low-level merge API available without pulling in SHA-256
 hashing, tempfile, or ICU4X CLDR plural data. Add the `serde` feature when that
 lean parser output should be serialized for caches or tooling.
 
+See [ADR 0020](/architecture/adr/0020-catalog-layer-packaging-boundary) for why
+the 1.x package boundary keeps the catalog layer in `ferrocat-po` behind feature
+profiles instead of moving it to a separate crate.
+
 The named feature profiles are:
 
 - `full`: the default profile with the complete current API surface


### PR DESCRIPTION
Closes #55

## Summary

- add ADR 0020 to define the 1.x catalog-layer packaging boundary
- clarify that the PO-core/catalog split is an internal layer and feature-profile boundary inside `ferrocat-po` for 1.x
- document why a separate `ferrocat-catalog` crate is a major-version packaging project, not a safe 1.x refactor
- update README and API overview wording so the crate topology matches the architecture docs

## Scope

This resolves the ADR contradiction without moving public APIs out of `ferrocat-po`.

After `ferrocat-po` reached 1.x, extracting `parse_catalog`, `update_catalog`, `combine_catalogs`, audit, compile, NDJSON, and MT metadata into a new crate would either remove public APIs from `ferrocat-po` or require an impossible dependency cycle. The supported 1.x answer is therefore:

- keep catalog APIs in `ferrocat-po` by default
- keep catalog-only dependencies behind the `catalog` feature profile
- support PO-only users through `default-features = false`
- treat any future `ferrocat-catalog` crate as a major-version design

## Validation

- from `docs/`: `pnpm install --frozen-lockfile`
- from `docs/`: `pnpm build`
