### PR TITLE
chore(deps): update formatjs benchmark parser

### DIFF
--- a/benchmark/node/package-lock.json
+++ b/benchmark/node/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": "^3.5.9",
+        "@formatjs/icu-messageformat-parser": "^3.5.11",
         "@messageformat/parser": "^5.1.1",
         "gettext-parser": "^9.0.2",
         "pofile": "^1.1.4",
@@ -17,18 +17,18 @@
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.9",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.9.tgz",
-      "integrity": "sha512-PZm6O9JI/gUPtQV9r2eaMuLb4yWqV2vz+ot03ORHWTKO343LSpZi0TqeXLB2ZZGDXLCw2SbfgsQ0GxoxXMl79g==",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.11.tgz",
+      "integrity": "sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/icu-skeleton-parser": "2.1.9"
+        "@formatjs/icu-skeleton-parser": "2.1.10"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.9.tgz",
-      "integrity": "sha512-rsxswgHMfU1zUgB2byc08fesf83wLGjFnzLCEtuf00mx2doiqc6pYrf67raI37XqdRcGUviQepk2UKGqpng74Q==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.10.tgz",
+      "integrity": "sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==",
       "license": "MIT"
     },
     "node_modules/@messageformat/parser": {

--- a/benchmark/node/package.json
+++ b/benchmark/node/package.json
@@ -5,7 +5,7 @@
   "description": "External Node-based benchmark adapters for ferrocat comparison runs.",
   "license": "MIT",
   "dependencies": {
-    "@formatjs/icu-messageformat-parser": "^3.5.9",
+    "@formatjs/icu-messageformat-parser": "^3.5.11",
     "@messageformat/parser": "^5.1.1",
     "gettext-parser": "^9.0.2",
     "pofile": "^1.1.4",


### PR DESCRIPTION
## Summary

- updates the benchmark Node adapter's FormatJS ICU parser dependency
- refreshes `benchmark/node/package-lock.json`, including the paired `@formatjs/icu-skeleton-parser` transitive patch
- leaves benchmark adapter source unchanged because the existing `parse(message, { captureLocation: false })` path still works

## Dependency group

- Packages: `@formatjs/icu-messageformat-parser` `3.5.9 -> 3.5.11`
- Transitive: `@formatjs/icu-skeleton-parser` `2.1.9 -> 2.1.10`
- Why grouped: the parser and skeleton parser are one FormatJS benchmark-adapter surface, validated through the Node adapter and `ferrocat-bench verify-benchmark-env`

## Upstream changes that matter here

- `@formatjs/icu-messageformat-parser` `3.5.11` still owns the same benchmarked parser import path used by `benchmark/node/adapter.cjs`. Source: https://www.npmjs.com/package/@formatjs/icu-messageformat-parser/v/3.5.11
- The package now depends on `@formatjs/icu-skeleton-parser` `2.1.10`, which is locked alongside it. Source: https://www.npmjs.com/package/@formatjs/icu-skeleton-parser/v/2.1.10
- The upstream release entry is monorepo-wide; the local impact here is the parser package patch plus the skeleton parser transitive patch. Source: https://github.com/formatjs/formatjs/releases/tag/%40formatjs/icu-messageformat-parser%403.5.11
- No local source migration was needed after checking the adapter import and parse call.

## Verification

- [x] `npm install`
- [x] `npm outdated --json`
- [x] `node benchmark/node/adapter.cjs --check`
- [x] FormatJS adapter smoke request with simple, plural, and rich-text-tag ICU messages
- [x] `./benchmark/python/setup.sh`
- [x] `cargo run -p ferrocat-bench -- verify-benchmark-env`

## Notes

- No public Rust API or docs-site behavior change.
- Benchmark source is unchanged; this only changes the external FormatJS parser version used in comparison runs.
