### PR TITLE
chore(release): simplify release-please config

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "rust",
   "separate-pull-requests": false,
   "plugins": [
     {
@@ -23,40 +24,21 @@
   ],
   "packages": {
     "crates/ferrocat": {
-      "release-type": "rust",
-      "package-name": "ferrocat",
-      "component": "ferrocat",
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "docs/package.json",
-          "jsonpath": "$.version"
-        }
-      ]
+      "component": "ferrocat"
     },
     "crates/ferrocat-po": {
-      "release-type": "rust",
-      "package-name": "ferrocat-po",
       "component": "ferrocat-po"
     },
     "crates/ferrocat-icu": {
-      "release-type": "rust",
-      "package-name": "ferrocat-icu",
       "component": "ferrocat-icu"
     },
     "crates/ferrocat-conformance": {
-      "release-type": "rust",
-      "package-name": "ferrocat-conformance",
       "component": "ferrocat-conformance"
     },
     "crates/ferrocat-bench": {
-      "release-type": "rust",
-      "package-name": "ferrocat-bench",
       "component": "ferrocat-bench"
     },
     "crates/ferrocat-cli": {
-      "release-type": "rust",
-      "package-name": "ferrocat-cli",
       "component": "ferrocat-cli"
     }
   }


### PR DESCRIPTION
## Summary

- moves the common Release Please `release-type` to the top-level config
- leaves each crate package entry as just its `component`
- keeps `cargo-workspace` plus `linked-versions` as the mechanism that releases all Ferrocat crates at the same version
- removes the ineffective `docs/package.json` extra-file mapping; Release Please resolved it relative to `crates/ferrocat`, and parent-directory paths are rejected

## Validation

- `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync(".release-please-config.json","utf8")); JSON.parse(fs.readFileSync(".release-please-manifest.json","utf8")); console.log("release-please JSON OK");'`
- `pnpm dlx release-please debug-config --repo-url=sebastian-software/ferrocat --target-branch=codex/release-please-rust-default --config-file=.release-please-config.json --manifest-file=.release-please-manifest.json --dry-run`
- `pnpm dlx release-please release-pr --repo-url=sebastian-software/ferrocat --target-branch=codex/release-please-rust-default --config-file=.release-please-config.json --manifest-file=.release-please-manifest.json --dry-run --token=$(gh auth token)`

## Notes

- The final release-pr dry run still produced one combined release PR with all six Rust crates linked at `1.1.1`.
- The docs package version is not updated by this Release Please config. The prior `extra-files` entry was not actually reaching `docs/package.json`.
