### PR TITLE
ci(fuzz): add scheduled parser fuzzing

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,78 @@
+name: Fuzz
+
+on:
+  workflow_dispatch:
+    inputs:
+      max_total_time:
+        description: "Per-target fuzzing budget in seconds"
+        required: false
+        default: "45"
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  FUZZ_MAX_TOTAL_TIME: ${{ github.event.inputs.max_total_time || '45' }}
+
+jobs:
+  fuzz:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: parse_po
+            seed_dir: seed-corpus/po
+          - target: parse_po_borrowed
+            seed_dir: seed-corpus/po
+          - target: parse_catalog_po
+            seed_dir: seed-corpus/po
+          - target: parse_catalog_ndjson
+            seed_dir: seed-corpus/ndjson
+          - target: parse_icu
+            seed_dir: seed-corpus/icu
+          - target: merge_catalog
+            seed_dir: seed-corpus/po
+          - target: update_catalog
+            seed_dir: seed-corpus/po
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up nightly Rust
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz -> target
+
+      - name: Install cargo-fuzz
+        uses: taiki-e/install-action@cargo-fuzz
+
+      - name: Prepare target corpus
+        run: |
+          mkdir -p "fuzz/corpus/${{ matrix.target }}" "fuzz/artifacts/${{ matrix.target }}"
+          cp -R "fuzz/${{ matrix.seed_dir }}/." "fuzz/corpus/${{ matrix.target }}/"
+
+      - name: Run bounded fuzz target
+        run: >-
+          cargo fuzz run ${{ matrix.target }} fuzz/corpus/${{ matrix.target }}
+          --
+          -max_total_time="${FUZZ_MAX_TOTAL_TIME}"
+          -timeout=10
+          -rss_limit_mb=2048
+          -artifact_prefix="fuzz/artifacts/${{ matrix.target }}/"
+
+      - name: Upload fuzz artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}
+          if-no-files-found: ignore

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -114,14 +114,14 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ferrocat-po"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -3,13 +3,22 @@
 This directory contains local `cargo-fuzz` harnesses for parser and catalog
 entry points that accept untrusted catalog content.
 
-The first target set is intentionally local-only. Scheduled CI fuzzing should
-be added after these harnesses have produced stable, useful corpora.
+The target set runs locally and in the scheduled GitHub Actions fuzz workflow.
+CI uses short, bounded libFuzzer runs so parser panics, timeouts, OOMs, and
+crashes become a stability signal without turning every pull request into a
+long-running fuzz campaign.
+
+Install the local runner with:
+
+```bash
+rustup toolchain install nightly
+cargo install cargo-fuzz
+```
 
 Run a target with:
 
 ```bash
-cargo fuzz run parse_po
+cargo +nightly fuzz run parse_po fuzz/seed-corpus/po -- -max_total_time=60
 ```
 
 Available targets:
@@ -21,3 +30,15 @@ Available targets:
 - `parse_icu`
 - `merge_catalog`
 - `update_catalog`
+
+The checked-in seed corpus lives under `fuzz/seed-corpus/`. Generated corpus
+growth remains ignored under `fuzz/corpus/`; promote only reduced, stable crash
+inputs or especially useful fixtures into the seed corpus.
+
+When fuzzing finds a crash:
+
+1. Reproduce it locally with the failing target and artifact path from the CI
+   artifact.
+2. Minimize the input with `cargo +nightly fuzz tmin <target> <artifact>`.
+3. Add the minimized input as a regression test or seed-corpus fixture.
+4. Keep the new fixture small enough to review in a normal pull request.

--- a/fuzz/seed-corpus/README.md
+++ b/fuzz/seed-corpus/README.md
@@ -1,0 +1,9 @@
+# Fuzz Seed Corpus
+
+These inputs bootstrap the scheduled fuzz workflow. They are intentionally
+small, deterministic examples that cover valid and invalid PO, NDJSON, and ICU
+MessageFormat shapes before libFuzzer mutates them.
+
+Do not store generated corpus growth here. Keep `fuzz/corpus/` ignored and
+promote only reduced, stable crash reproducers or high-value fixtures into this
+directory.

--- a/fuzz/seed-corpus/icu/literal.txt
+++ b/fuzz/seed-corpus/icu/literal.txt
@@ -1,0 +1,1 @@
+Hello {name}

--- a/fuzz/seed-corpus/icu/malformed.txt
+++ b/fuzz/seed-corpus/icu/malformed.txt
@@ -1,0 +1,1 @@
+{count, plural, one {# item}

--- a/fuzz/seed-corpus/icu/nested.txt
+++ b/fuzz/seed-corpus/icu/nested.txt
@@ -1,0 +1,1 @@
+{gender, select, female {{count, plural, one {She has # item} other {She has # items}}} other {They have {count} items}}

--- a/fuzz/seed-corpus/icu/plural.txt
+++ b/fuzz/seed-corpus/icu/plural.txt
@@ -1,0 +1,1 @@
+{count, plural, one {# item} other {# items}}

--- a/fuzz/seed-corpus/ndjson/malformed.ndjson
+++ b/fuzz/seed-corpus/ndjson/malformed.ndjson
@@ -1,0 +1,7 @@
+---
+format: ferrocat.ndjson.v1
+locale: de
+source_locale: en
+---
+{"id":"missing translation"}
+{"id":"bad-json","str":

--- a/fuzz/seed-corpus/ndjson/minimal.ndjson
+++ b/fuzz/seed-corpus/ndjson/minimal.ndjson
@@ -1,0 +1,7 @@
+---
+format: ferrocat.ndjson.v1
+locale: de
+source_locale: en
+---
+{"id":"Hello {name}","str":"Hallo {name}","origin":[{"file":"app.rs","line":10}]}
+{"id":"cart.item_count","str":"{count, plural, one {# Element} other {# Elemente}}","ctx":"checkout","comments":["ICU plural seed"],"origin":[{"file":"cart.rs","line":12}],"extra":{"translator_comments":["Keep placeholder intact"],"flags":["fuzzy"]}}

--- a/fuzz/seed-corpus/po/malformed.po
+++ b/fuzz/seed-corpus/po/malformed.po
@@ -1,0 +1,6 @@
+msgid "unterminated
+msgstr ""
+
+#: broken.rs:1
+msgid "{count, plural, one {# item}"
+msgstr ""

--- a/fuzz/seed-corpus/po/minimal.po
+++ b/fuzz/seed-corpus/po/minimal.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: app.rs:10
+msgid "Hello {name}"
+msgstr "Hallo {name}"
+
+#. Translator note
+#, fuzzy
+msgctxt "dashboard"
+msgid "Project"
+msgstr "Projekt"
+
+#: cart.rs:12
+msgid "{count} item"
+msgid_plural "{count} items"
+msgstr[0] "{count} Element"
+msgstr[1] "{count} Elemente"


### PR DESCRIPTION
Closes #145

## Summary

- adds a scheduled and manually runnable fuzz workflow for all existing parser/catalog fuzz targets
- seeds small deterministic PO, NDJSON, and ICU corpora for bounded CI fuzz runs
- documents local cargo-fuzz setup, CI behavior, and how to promote minimized crash inputs
- refreshes the fuzz lockfile to the current 1.2.0 workspace crate versions

## Validation

- `cargo fmt --all --check`
- `cargo check --manifest-path fuzz/Cargo.toml --bins --offline`

`cargo-fuzz` is not installed in my local environment, so I validated that all fuzz targets compile through the fuzz manifest instead of running live libFuzzer jobs locally.
