### PR TITLE
ci(coverage): gate cli coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
         # coverage-gate but not threshold-gated while it only re-exports lower
         # level crates plus smoke tests. Add a threshold here when executable
         # umbrella code grows.
-        run: node scripts/coverage-gate.mjs target/coverage-summary.json ferrocat-po=95 ferrocat-icu=95
+        run: node scripts/coverage-gate.mjs target/coverage-summary.json ferrocat-cli=85 ferrocat-po=95 ferrocat-icu=95
 
       - name: Upload coverage to Codecov
         if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'dependabot/')) }}

--- a/crates/ferrocat-cli/src/main.rs
+++ b/crates/ferrocat-cli/src/main.rs
@@ -31,13 +31,23 @@ Audit options:
 
 fn main() -> ExitCode {
     let mut stdout = io::stdout().lock();
-    match run_with_writer(env::args().skip(1), &mut stdout) {
+    let mut stderr = io::stderr().lock();
+    run_cli(env::args().skip(1), &mut stdout, &mut stderr)
+}
+
+fn run_cli<I, W, E>(args: I, stdout: &mut W, stderr: &mut E) -> ExitCode
+where
+    I: IntoIterator<Item = String>,
+    W: Write,
+    E: Write,
+{
+    match run_with_writer(args, stdout) {
         Ok(exit_code) => exit_code,
         Err(error) => {
-            eprintln!("{error}");
+            let _ = writeln!(stderr, "{error}");
             if matches!(error, CliError::Usage(_)) {
-                eprintln!();
-                eprint!("{USAGE}");
+                let _ = writeln!(stderr);
+                let _ = write!(stderr, "{USAGE}");
             }
             ExitCode::from(EXIT_USAGE_OR_RUNTIME_ERROR)
         }
@@ -456,8 +466,8 @@ mod tests {
     use std::fs;
 
     use super::{
-        AuditConfig, CliStorageFormat, EXIT_AUDIT_FAILED, OutputFormat, TargetCatalog,
-        run_with_writer,
+        AuditConfig, CliStorageFormat, EXIT_AUDIT_FAILED, EXIT_USAGE_OR_RUNTIME_ERROR,
+        OutputFormat, TargetCatalog, run_cli, run_with_writer,
     };
 
     #[test]
@@ -583,7 +593,182 @@ mod tests {
         assert_eq!(json["summary"]["target_locales"], 1);
     }
 
+    #[test]
+    fn cli_returns_usage_exit_code_for_unknown_command() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let exit_code = run_cli(["unknown".to_owned()], &mut stdout, &mut stderr);
+
+        assert_eq!(
+            exit_code,
+            std::process::ExitCode::from(EXIT_USAGE_OR_RUNTIME_ERROR)
+        );
+        assert!(stdout.is_empty());
+        let error = String::from_utf8(stderr).expect("stderr should be UTF-8");
+        assert!(error.contains("unknown command `unknown`"));
+        assert!(error.contains("Usage:"));
+    }
+
+    #[test]
+    fn cli_returns_usage_exit_code_for_missing_flag_value() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let exit_code = run_cli(
+            ["audit".to_owned(), "--source-locale".to_owned()],
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(
+            exit_code,
+            std::process::ExitCode::from(EXIT_USAGE_OR_RUNTIME_ERROR)
+        );
+        let error = String::from_utf8(stderr).expect("stderr should be UTF-8");
+        assert!(error.contains("--source-locale requires a value"));
+        assert!(error.contains("Usage:"));
+    }
+
+    #[test]
+    fn cli_returns_runtime_exit_code_for_missing_source_file() {
+        let tempdir = tempfile_dir();
+        let target_path = tempdir.path().join("de.po");
+        fs::write(&target_path, "msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n")
+            .expect("write target fixture");
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let exit_code = run_cli(
+            [
+                "audit".to_owned(),
+                "--source-locale".to_owned(),
+                "en".to_owned(),
+                "--source".to_owned(),
+                tempdir.path().join("missing.po").display().to_string(),
+                "--target".to_owned(),
+                format!("de={}", target_path.display()),
+            ],
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(
+            exit_code,
+            std::process::ExitCode::from(EXIT_USAGE_OR_RUNTIME_ERROR)
+        );
+        let error = String::from_utf8(stderr).expect("stderr should be UTF-8");
+        assert!(error.contains("failed to read"));
+        assert!(!error.contains("Usage:"));
+    }
+
+    #[test]
+    fn audit_command_filters_requested_target_locale() {
+        let tempdir = tempfile_dir();
+        let source_path = tempdir.path().join("en.po");
+        let de_path = tempdir.path().join("de.po");
+        let fr_path = tempdir.path().join("fr.po");
+        fs::write(&source_path, "msgid \"Checkout\"\nmsgstr \"Checkout\"\n")
+            .expect("write source fixture");
+        fs::write(&de_path, "").expect("write incomplete German fixture");
+        fs::write(&fr_path, "msgid \"Checkout\"\nmsgstr \"Paiement\"\n")
+            .expect("write French fixture");
+
+        let mut stdout = Vec::new();
+        let exit_code = run_with_writer(
+            [
+                "audit".to_owned(),
+                "--source-locale".to_owned(),
+                "en".to_owned(),
+                "--source".to_owned(),
+                source_path.display().to_string(),
+                "--target".to_owned(),
+                format!("de={}", de_path.display()),
+                "--target".to_owned(),
+                format!("fr={}", fr_path.display()),
+                "--locale".to_owned(),
+                "fr".to_owned(),
+            ],
+            &mut stdout,
+        )
+        .expect("filtered audit should run");
+
+        assert_eq!(exit_code, std::process::ExitCode::SUCCESS);
+        let output = String::from_utf8(stdout).expect("text output should be UTF-8");
+        assert!(output.contains("1 target locales"));
+        assert!(!output.contains("catalog.missing_translation"));
+    }
+
+    #[test]
+    fn audit_command_reads_ndjson_catalogs() {
+        let tempdir = tempfile_dir();
+        let source_path = tempdir.path().join("en.ndjson");
+        let target_path = tempdir.path().join("de.ndjson");
+        fs::write(&source_path, ndjson_catalog("en", "Checkout")).expect("write source fixture");
+        fs::write(&target_path, ndjson_catalog("de", "Zur Kasse")).expect("write target fixture");
+
+        let mut stdout = Vec::new();
+        let exit_code = run_with_writer(
+            [
+                "audit".to_owned(),
+                "--source-locale".to_owned(),
+                "en".to_owned(),
+                "--source".to_owned(),
+                source_path.display().to_string(),
+                "--target".to_owned(),
+                format!("de={}", target_path.display()),
+                "--storage".to_owned(),
+                "ndjson".to_owned(),
+                "--format".to_owned(),
+                "json".to_owned(),
+            ],
+            &mut stdout,
+        )
+        .expect("NDJSON audit should run");
+
+        assert_eq!(exit_code, std::process::ExitCode::SUCCESS);
+        let json: serde_json::Value =
+            serde_json::from_slice(&stdout).expect("JSON output should parse");
+        assert_eq!(json["summary"]["errors"], 0);
+    }
+
+    #[test]
+    fn audit_command_reports_ndjson_parse_errors() {
+        let tempdir = tempfile_dir();
+        let source_path = tempdir.path().join("en.ndjson");
+        let target_path = tempdir.path().join("de.ndjson");
+        fs::write(
+            &source_path,
+            "---\nformat: ferrocat.ndjson.v1\nlocale: en\nsource_locale: en\n---\n{\"id\":\"broken\"",
+        )
+        .expect("write malformed source fixture");
+        fs::write(&target_path, ndjson_catalog("de", "Zur Kasse")).expect("write target fixture");
+
+        let mut stdout = Vec::new();
+        let error = run_with_writer(
+            [
+                "audit".to_owned(),
+                "--source-locale".to_owned(),
+                "en".to_owned(),
+                "--source".to_owned(),
+                source_path.display().to_string(),
+                "--target".to_owned(),
+                format!("de={}", target_path.display()),
+                "--storage".to_owned(),
+                "ndjson".to_owned(),
+            ],
+            &mut stdout,
+        )
+        .expect_err("malformed NDJSON should fail");
+
+        assert!(error.to_string().contains("failed to parse"));
+    }
+
     fn tempfile_dir() -> tempfile::TempDir {
         tempfile::tempdir().expect("tempdir should be created")
+    }
+
+    fn ndjson_catalog(locale: &str, translation: &str) -> String {
+        format!(
+            "---\nformat: ferrocat.ndjson.v1\nlocale: {locale}\nsource_locale: en\n---\n{{\"id\":\"Checkout\",\"str\":\"{translation}\"}}\n"
+        )
     }
 }

--- a/docs/app/routes/quality/test-coverage.mdx
+++ b/docs/app/routes/quality/test-coverage.mdx
@@ -11,6 +11,7 @@ The repository exposes workspace-local Cargo aliases for coverage reporting thro
 
 The long-term goal for the shipped library surface is:
 
+- `85%+` line coverage for `ferrocat-cli`, with room to ratchet toward the library threshold as more CLI workflows ship
 - `95%+` line coverage for `ferrocat-po`
 - `95%+` line coverage for `ferrocat-icu`
 - `95%+` line coverage for `ferrocat` once the umbrella crate contains measurable executable logic beyond re-exports
@@ -23,25 +24,29 @@ The coverage commands intentionally exclude:
 That keeps the report focused on the public and internal library crates that matter most in day-to-day development:
 
 - `ferrocat`
+- `ferrocat-cli`
 - `ferrocat-po`
 - `ferrocat-icu`
 
 ## Current Gate
 
-Measured locally on `2026-05-12` with `cargo coverage-lcov`, a JSON summary export, and the crate-aware gate script:
+Measured locally on `2026-06-23` with the CI coverage commands, a JSON summary export, and the crate-aware gate script:
 
-- `ferrocat-po`: `95.08%` line coverage
-- `ferrocat-icu`: `96.00%` line coverage
+- `ferrocat-cli`: `87.32%` line coverage
+- `ferrocat-po`: `96.82%` line coverage
+- `ferrocat-icu`: `96.98%` line coverage
 - `ferrocat`: `N/A` in `llvm-cov` today because the umbrella crate is almost entirely re-exports and does not currently surface measurable executable lines in the report
 
 The CI coverage job enforces these crate-level thresholds:
 
+- `ferrocat-cli >= 85%`
 - `ferrocat-po >= 95%`
 - `ferrocat-icu >= 95%`
 - `ferrocat` is still reported, but not percentage-gated until `llvm-cov` has measurable lines for the crate
 
 The next high-yield test targets are:
 
+- `crates/ferrocat-cli/src/main.rs`
 - `ferrocat-po/src/api/catalog.rs`
 - `ferrocat-po/src/api/compile.rs`
 - `ferrocat-po/src/api/audit.rs`

--- a/scripts/coverage-gate.mjs
+++ b/scripts/coverage-gate.mjs
@@ -14,7 +14,7 @@ if (!summaryPath) {
 
 const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
 const files = summary?.data?.[0]?.files ?? [];
-const crates = ["ferrocat", "ferrocat-po", "ferrocat-icu"];
+const crates = ["ferrocat", "ferrocat-cli", "ferrocat-po", "ferrocat-icu"];
 const thresholds = new Map();
 
 for (const arg of thresholdArgs) {


### PR DESCRIPTION
Closes #146

## Summary

- includes `ferrocat-cli` in the crate-aware coverage reporter and CI threshold gate
- adds focused CLI tests for usage errors, runtime errors, locale filtering, NDJSON storage, JSON output, and audit exit codes
- gates CLI line coverage at 85%, with the current local summary at 87.32%
- refreshes the coverage documentation with the current gated crate list and measured values

## Validation

- `cargo fmt --all --check`
- `cargo test -p ferrocat-cli --locked`
- `cargo clippy -p ferrocat-cli --all-targets --all-features --locked -- -D warnings`
- `cargo llvm-cov --workspace --all-features --locked --lcov --output-path target/lcov.info --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'`
- `cargo llvm-cov report --json --summary-only --output-path target/coverage-summary.json --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'`
- `node scripts/coverage-gate.mjs target/coverage-summary.json ferrocat-cli=85 ferrocat-po=95 ferrocat-icu=95`

Coverage gate output:

```text
ferrocat: N/A (no measurable executable lines in llvm-cov report)
ferrocat-cli: 87.32% (482/552) against 85.00% => PASS
ferrocat-po: 96.82% (9397/9706) against 95.00% => PASS
ferrocat-icu: 96.98% (2315/2387) against 95.00% => PASS
```
