### PR TITLE
ci(release): add linux musl CLI artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,40 @@ jobs:
       - name: Test workspace with MSRV
         run: cargo +1.93.0 test --workspace --all-features --locked
 
+  musl:
+    name: Linux musl target
+    runs-on: ubuntu-24.04
+    env:
+      MUSL_TARGET: x86_64-unknown-linux-musl
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install musl linker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ env.MUSL_TARGET }}
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: musl-${{ env.MUSL_TARGET }}
+
+      - name: Build workspace for musl
+        run: cargo build --workspace --all-targets --all-features --locked --target "$MUSL_TARGET"
+
+      - name: Run workspace tests for musl
+        run: cargo test --workspace --all-features --locked --target "$MUSL_TARGET"
+
+      - name: Smoke test musl CLI
+        run: "./target/${MUSL_TARGET}/debug/ferrocat --help"
+
   test:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
   publish-cli-musl:
     needs: release-please
-    if: ${{ needs.release-please.outputs.ferrocat_cli_release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -55,6 +55,35 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+
+      - name: Resolve ferrocat CLI release
+        id: cli-release
+        shell: bash
+        env:
+          RELEASE_PLEASE_CLI_TAG: ${{ needs.release-please.outputs.ferrocat_cli_tag_name }}
+          RELEASE_PLEASE_CLI_VERSION: ${{ needs.release-please.outputs.ferrocat_cli_version }}
+        run: |
+          version="$RELEASE_PLEASE_CLI_VERSION"
+          if [ -z "$version" ]; then
+            package_id="$(cargo pkgid -p ferrocat-cli)"
+            version="${package_id##*#}"
+          fi
+
+          tag="$RELEASE_PLEASE_CLI_TAG"
+          if [ -z "$tag" ]; then
+            tag="ferrocat-cli-v${version}"
+          fi
+
+          artifact_name="ferrocat-${version}-${MUSL_TARGET}"
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=${artifact_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Confirm ferrocat CLI release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release view "${{ steps.cli-release.outputs.tag }}" --json tagName,url
 
       - name: Install musl linker
         run: |
@@ -79,10 +108,10 @@ jobs:
 
       - name: Package musl CLI artifact
         shell: bash
+        env:
+          ARTIFACT_NAME: ${{ steps.cli-release.outputs.artifact_name }}
         run: |
-          version="${{ needs.release-please.outputs.ferrocat_cli_version }}"
-          artifact_name="ferrocat-${version}-${MUSL_TARGET}"
-          artifact_dir="target/dist/${artifact_name}"
+          artifact_dir="target/dist/${ARTIFACT_NAME}"
 
           mkdir -p "$artifact_dir"
           cp "target/${MUSL_TARGET}/release/ferrocat" "$artifact_dir/ferrocat"
@@ -90,17 +119,17 @@ jobs:
           cp README.md "$artifact_dir/README.md"
           cp crates/ferrocat-cli/README.md "$artifact_dir/CLI-README.md"
 
-          tar -C target/dist -czf "target/dist/${artifact_name}.tar.gz" "$artifact_name"
-          sha256sum "target/dist/${artifact_name}.tar.gz" > "target/dist/${artifact_name}.tar.gz.sha256"
+          tar -C target/dist -czf "target/dist/${ARTIFACT_NAME}.tar.gz" "$ARTIFACT_NAME"
+          ( cd target/dist && sha256sum "${ARTIFACT_NAME}.tar.gz" > "${ARTIFACT_NAME}.tar.gz.sha256" )
 
       - name: Upload musl CLI artifact to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
           gh release upload
-          "${{ needs.release-please.outputs.ferrocat_cli_tag_name }}"
-          "target/dist/ferrocat-${{ needs.release-please.outputs.ferrocat_cli_version }}-${{ env.MUSL_TARGET }}.tar.gz"
-          "target/dist/ferrocat-${{ needs.release-please.outputs.ferrocat_cli_version }}-${{ env.MUSL_TARGET }}.tar.gz.sha256"
+          "${{ steps.cli-release.outputs.tag }}"
+          "target/dist/${{ steps.cli-release.outputs.artifact_name }}.tar.gz"
+          "target/dist/${{ steps.cli-release.outputs.artifact_name }}.tar.gz.sha256"
           --clobber
 
   publish-rust:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,9 @@ jobs:
       pull-requests: write
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
+      ferrocat_cli_release_created: ${{ steps.release.outputs['crates/ferrocat-cli--release_created'] }}
+      ferrocat_cli_tag_name: ${{ steps.release.outputs['crates/ferrocat-cli--tag_name'] }}
+      ferrocat_cli_version: ${{ steps.release.outputs['crates/ferrocat-cli--version'] }}
 
     steps:
       - name: Check out repository
@@ -39,6 +42,66 @@ jobs:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+  publish-cli-musl:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.ferrocat_cli_release_created == 'true' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    env:
+      MUSL_TARGET: x86_64-unknown-linux-musl
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install musl linker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ env.MUSL_TARGET }}
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: publish-cli-musl-${{ env.MUSL_TARGET }}
+
+      - name: Build ferrocat CLI for musl
+        run: cargo build --release -p ferrocat-cli --locked --target "$MUSL_TARGET"
+
+      - name: Smoke test musl CLI
+        run: "./target/${MUSL_TARGET}/release/ferrocat --help"
+
+      - name: Package musl CLI artifact
+        shell: bash
+        run: |
+          version="${{ needs.release-please.outputs.ferrocat_cli_version }}"
+          artifact_name="ferrocat-${version}-${MUSL_TARGET}"
+          artifact_dir="target/dist/${artifact_name}"
+
+          mkdir -p "$artifact_dir"
+          cp "target/${MUSL_TARGET}/release/ferrocat" "$artifact_dir/ferrocat"
+          cp LICENSE "$artifact_dir/LICENSE"
+          cp README.md "$artifact_dir/README.md"
+          cp crates/ferrocat-cli/README.md "$artifact_dir/CLI-README.md"
+
+          tar -C target/dist -czf "target/dist/${artifact_name}.tar.gz" "$artifact_name"
+          sha256sum "target/dist/${artifact_name}.tar.gz" > "target/dist/${artifact_name}.tar.gz.sha256"
+
+      - name: Upload musl CLI artifact to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          gh release upload
+          "${{ needs.release-please.outputs.ferrocat_cli_tag_name }}"
+          "target/dist/ferrocat-${{ needs.release-please.outputs.ferrocat_cli_version }}-${{ env.MUSL_TARGET }}.tar.gz"
+          "target/dist/ferrocat-${{ needs.release-please.outputs.ferrocat_cli_version }}-${{ env.MUSL_TARGET }}.tar.gz.sha256"
+          --clobber
 
   publish-rust:
     needs: release-please

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ cargo install ferrocat-cli
 ferrocat audit --source-locale en --source locales/en.po --target de=locales/de.po
 ```
 
+The `ferrocat-cli` GitHub release also publishes a prebuilt Linux musl archive
+for `x86_64-unknown-linux-musl`. The archive is named
+`ferrocat-<version>-x86_64-unknown-linux-musl.tar.gz` and contains the
+`ferrocat` binary plus license and README metadata. CI builds and tests the
+workspace for that target and smoke-tests the CLI before uploading the release
+asset.
+
 ## Quick Start
 
 ```rust
@@ -163,6 +170,8 @@ Beyond the basics, Ferrocat exposes byte-oriented and allocation-light borrowed 
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
 - **MSRV bumps:** raising the MSRV is treated as a minor-version change and
   called out in the changelog; patch releases do not raise the MSRV.
+- **Prebuilt CLI target:** `x86_64-unknown-linux-musl` is validated in CI and
+  published as a smoke-tested GitHub Release archive for `ferrocat-cli`.
 - **Semver:** the public API follows semantic versioning; breaking changes ship in a new major version and are documented in the changelog
 - **Error surface:** PO parse errors are intentionally compact today and do not yet expose source positions; adding structured positions would be a semver-relevant API change.
 - **Documentation surface:** README examples, rustdoc examples, and the docs site aim to stay aligned

--- a/crates/ferrocat-cli/README.md
+++ b/crates/ferrocat-cli/README.md
@@ -13,6 +13,10 @@ ferrocat audit \
   --format text
 ```
 
+`ferrocat-cli` releases include a prebuilt `x86_64-unknown-linux-musl` archive
+named `ferrocat-<version>-x86_64-unknown-linux-musl.tar.gz`. The release
+workflow smoke-tests the packaged `ferrocat` binary before uploading it.
+
 Exit codes:
 
 - `0`: audit completed with no error diagnostics

--- a/docs/app/routes/guide/getting-started.mdx
+++ b/docs/app/routes/guide/getting-started.mdx
@@ -55,12 +55,20 @@ msgstr "world"
 - Open [API Overview](/reference/api-overview) when you need to choose between low-level PO parsing, high-level catalog workflows, and ICU helpers.
 - Open [Gettext Task Landscape](/reference/gettext-task-landscape) when you already know established Gettext-style jobs and want to map them to Ferrocat APIs.
 
+`ferrocat-cli` GitHub releases also include a prebuilt
+`x86_64-unknown-linux-musl` archive named
+`ferrocat-<version>-x86_64-unknown-linux-musl.tar.gz`. Use that artifact when a
+hosted or containerized Linux environment needs a musl-friendly `ferrocat`
+binary without compiling from crates.io.
+
 ## Compatibility policy
 
 - **MSRV:** Rust `1.93.0`
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
 - **MSRV bumps:** raising the MSRV is treated as a minor-version change and
   called out in the changelog; patch releases should not raise the MSRV.
+- **Prebuilt CLI target:** `x86_64-unknown-linux-musl` is validated in CI and
+  published as a smoke-tested GitHub Release archive for `ferrocat-cli`.
 - **Semver:** the public API follows semantic versioning; breaking changes ship in a new major version
 - **Docs surface:** README examples, rustdoc, and the site should stay aligned
 

--- a/docs/app/routes/guide/project-status.mdx
+++ b/docs/app/routes/guide/project-status.mdx
@@ -24,6 +24,8 @@ Ferrocat is a stable, production-ready Rust project. Since the `1.0` release the
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
 - **MSRV bumps:** raising the MSRV is treated as a minor-version change and
   called out in the changelog; patch releases should not raise the MSRV.
+- **Prebuilt CLI target:** `x86_64-unknown-linux-musl` is validated in CI and
+  published as a smoke-tested GitHub Release archive for `ferrocat-cli`.
 - **Semver:** the public API follows semantic versioning; breaking changes ship in a new major version and are documented in the changelog
 - **Documentation:** README examples, rustdoc, and repository docs aim to stay aligned
 - **Host bindings:** Ferrocat is currently a pure-Rust engine. JS/TS access

--- a/docs/app/routes/operations/release-verification.mdx
+++ b/docs/app/routes/operations/release-verification.mdx
@@ -20,6 +20,9 @@ This checklist verifies a real Rust-only `ferrocat` release after the publish wo
 - Confirm the workspace-only crates in the repo are also version-aligned with the published crates.
 - Confirm internal `ferrocat*` path dependencies in the crate manifests were updated to matching versions where applicable.
 - Confirm the GitHub release tag matches the published version created by Release Please.
+- For `ferrocat-cli` releases, confirm the
+  `ferrocat-<version>-x86_64-unknown-linux-musl.tar.gz` asset and matching
+  `.sha256` file were uploaded to the GitHub release.
 
 ## 3. Confirm package viability
 
@@ -39,6 +42,8 @@ release gate.
 
 - In a clean scratch project, run `cargo add ferrocat`.
 - Build a tiny smoke example that calls `parse_po` and `parse_icu` through the umbrella crate.
+- Download the `x86_64-unknown-linux-musl` CLI release archive when validating
+  the binary channel, verify its `.sha256` file, and run `ferrocat --help`.
 - Confirm docs.rs builds for `ferrocat` and that the README example still matches the published surface.
 - Confirm the crate READMEs published for `ferrocat`, `ferrocat-po`, and `ferrocat-icu` still describe the current public surface accurately.
 - Confirm the site API overview covers any new public APIs or semver-relevant behavior added in the release.


### PR DESCRIPTION
## Summary

- adds an explicit `x86_64-unknown-linux-musl` CI job that builds/tests the workspace and smoke-tests the CLI
- adds release automation for a smoke-tested `ferrocat-cli` musl archive plus SHA256 checksum on the CLI GitHub release
- documents the musl artifact shape in README, CLI README, docs guide, project status, and release verification

Closes #158.

## Verification

- [x] `git diff --check`
- [x] YAML parsed with Ruby for `.github/workflows/ci.yml` and `.github/workflows/publish.yml`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `rustup target add x86_64-unknown-linux-musl`
- [x] `cargo check --workspace --all-targets --all-features --locked --target x86_64-unknown-linux-musl`
- [x] from `docs/`: `pnpm install --frozen-lockfile`
- [x] from `docs/`: `pnpm build`
- [x] `cargo test --workspace --all-features --locked`
- [x] `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked`

## Notes

The local host is macOS, so the full musl link/runtime path is covered by the new Ubuntu GitHub Actions job rather than by a local `cargo build --target x86_64-unknown-linux-musl` run.