### PR TITLE
perf(po): cut redundant scans and allocations on the parse hot path

### DIFF
--- a/crates/ferrocat-po/src/merge.rs
+++ b/crates/ferrocat-po/src/merge.rs
@@ -6,7 +6,7 @@ use crate::scan::{
     has_byte, parse_plural_index, split_once_byte, trim_ascii, unrecognized_po_line,
 };
 use crate::serialize::{write_keyword, write_prefixed_line};
-use crate::text::{escape_string_into, unescape_string, validate_quoted_content};
+use crate::text::{escape_string_into, unescape_string_known, validate_quoted_content};
 use crate::utf8::input_slice_as_str;
 use crate::{BorrowedMsgStr, ParseError, ParsePosition, SerializeOptions};
 
@@ -535,12 +535,11 @@ fn extract_merge_quoted_cow(line_bytes: &[u8]) -> Result<Cow<'_, str>, ParseErro
         return Ok(Cow::Borrowed(""));
     };
 
-    validate_quoted_content(raw)?;
-    if !has_byte(b'\\', raw) {
+    if !validate_quoted_content(raw)? {
         return Ok(Cow::Borrowed(bytes_to_str(raw)));
     }
 
-    Ok(Cow::Owned(unescape_string(bytes_to_str(raw))?))
+    Ok(Cow::Owned(unescape_string_known(bytes_to_str(raw))?))
 }
 
 #[inline]

--- a/crates/ferrocat-po/src/text.rs
+++ b/crates/ferrocat-po/src/text.rs
@@ -170,6 +170,15 @@ pub fn split_reference_comment(input: &str) -> Vec<Cow<'_, str>> {
         return vec![Cow::Borrowed("")];
     }
 
+    // Fast path for the overwhelmingly common single-reference line (e.g.
+    // `src/app.rs:42`). A run of graphic ASCII bytes cannot contain a
+    // whitespace split point or a multi-byte directional isolate, so it is one
+    // token by definition. Returning it directly skips the char-by-char scan
+    // and the throwaway `parts` buffer the slow path would otherwise allocate.
+    if trimmed.bytes().all(|byte| byte.is_ascii_graphic()) {
+        return vec![Cow::Borrowed(trimmed)];
+    }
+
     let mut parts = Vec::new();
     let mut start = None;
     let mut isolate_depth = 0usize;
@@ -433,6 +442,14 @@ mod tests {
         assert_eq!(
             split_reference_comment("src/app.js:1 src/lib.js:2"),
             vec![Cow::Borrowed("src/app.js:1"), Cow::Borrowed("src/lib.js:2")]
+        );
+    }
+
+    #[test]
+    fn borrows_single_reference_token_via_fast_path() {
+        assert_eq!(
+            split_reference_comment("src/app.js:1"),
+            vec![Cow::Borrowed("src/app.js:1")]
         );
     }
 

--- a/crates/ferrocat-po/src/text.rs
+++ b/crates/ferrocat-po/src/text.rs
@@ -48,11 +48,21 @@ pub fn escape_string_into_with_first_escape(
 ///
 /// Returns [`ParseError`] when the escape sequence is malformed.
 pub fn unescape_string(input: &str) -> Result<String, ParseError> {
-    let bytes = input.as_bytes();
-    if !has_byte(b'\\', bytes) {
+    if !has_byte(b'\\', input.as_bytes()) {
         return Ok(input.to_owned());
     }
 
+    unescape_string_known(input)
+}
+
+/// Unescapes a PO string literal payload that is already known to contain at
+/// least one backslash, skipping the redundant lookup scan.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] when the escape sequence is malformed.
+pub(crate) fn unescape_string_known(input: &str) -> Result<String, ParseError> {
+    let bytes = input.as_bytes();
     let mut out = Vec::with_capacity(input.len());
     let mut index = 0;
 
@@ -138,12 +148,11 @@ pub fn extract_quoted_bytes_cow(line: &[u8]) -> Result<Cow<'_, str>, ParseError>
     };
 
     let raw = &line[start..end];
-    validate_quoted_content(raw)?;
-    if !has_byte(b'\\', raw) {
+    if !validate_quoted_content(raw)? {
         return Ok(Cow::Borrowed(bytes_to_str(raw)));
     }
 
-    Ok(Cow::Owned(unescape_string(bytes_to_str(raw))?))
+    Ok(Cow::Owned(unescape_string_known(bytes_to_str(raw))?))
 }
 
 /// Extracts and unescapes the first quoted PO string from `line`.
@@ -211,12 +220,25 @@ pub fn split_reference_comment(input: &str) -> Vec<Cow<'_, str>> {
     vec![Cow::Borrowed(trimmed)]
 }
 
-pub fn validate_quoted_content(raw: &[u8]) -> Result<(), ParseError> {
+/// Validates the content between PO quotes and reports whether it contains any
+/// backslash, so callers can skip a redundant escape-lookup scan.
+///
+/// Returns `Ok(true)` when an unescape pass is required, `Ok(false)` when the
+/// content can be borrowed verbatim.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] when an unescaped quote is present.
+pub fn validate_quoted_content(raw: &[u8]) -> Result<bool, ParseError> {
     let mut trailing_backslashes = 0usize;
+    let mut saw_backslash = false;
 
     for &byte in raw {
         match byte {
-            b'\\' => trailing_backslashes += 1,
+            b'\\' => {
+                trailing_backslashes += 1;
+                saw_backslash = true;
+            }
             b'"' if has_even_trailing_backslashes(trailing_backslashes) => {
                 return Err(ParseError::new("unescaped quote in string literal"));
             }
@@ -224,7 +246,7 @@ pub fn validate_quoted_content(raw: &[u8]) -> Result<(), ParseError> {
         }
     }
 
-    Ok(())
+    Ok(saw_backslash)
 }
 
 fn has_even_trailing_backslashes(count: usize) -> bool {


### PR DESCRIPTION
## Summary

Two contained perf wins on the PO parse hot path, found by profiling `parse` on a reference-heavy fixture (`gettext-ui-de-10000`). The profile showed **~31% of parse time in `malloc`** and the text helpers near the top of self-time — so both allocation count and redundant scanning were worth attacking.

### 1. Fold backslash lookup into quoted-content validation

`extract_quoted_bytes_cow` scanned quoted content three times on the borrowed path: find quote bounds → validate content → a separate `has_byte(b'\\')` lookup to decide whether unescaping was needed.

`validate_quoted_content` already walks every byte tracking trailing backslashes, so it now returns whether any backslash was present (`Result<bool, ParseError>`) and the redundant lookup is gone — **one full pass less per quoted line**. Fires on every `msgid`/`msgstr`/`msgctxt` and continuation line, across the owned parser, the borrowed parser, and merge.

The owned (rare) path also no longer searches for a backslash a third time: new `unescape_string_known` is the unescape loop without the leading `has_byte` check. `unescape_string` keeps the lookup and delegates to it.

### 2. Single-token fast path in `split_reference_comment`

The common case is one reference per `#:` line (e.g. `src/app.rs:42`), yet the function ran the full `char_indices` scan and allocated a throwaway `parts` buffer before discarding it for the one-element result.

A run of graphic ASCII bytes cannot contain a whitespace split point or a multi-byte directional isolate, so it is a single token by definition. A cheap byte scan now returns `vec![Cow::Borrowed(trimmed)]` directly, skipping both the scan and the throwaway allocation. Exactly equivalent to the slow path's single-token outcome (`normalize_reference_token` borrows when no isolates are present).

## Measurement

`parse gettext-ui-de-10000`, release (fat LTO, codegen-units=1), 5 runs:

| | MiB/s | iter/s |
|---|---|---|
| before | 385 | 212 |
| after #1+#2 | 450 | 248 |

**≈ +17%** end-to-end on this fixture. (#2 is the bulk of it; the gettext fixture is one-reference-per-entry, which is the case it targets.)

## Verification

- `cargo test -p ferrocat-po` — green (incl. borrowed↔owned property tests and PO roundtrip), plus a new fast-path unit test
- `cargo clippy -p ferrocat-po --all-targets` — clean

No behavior change; purely fewer passes and allocations. Further allocation-side work (the ~31% malloc share — object-model construction) is the natural next step but is larger-scope and left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)