### PR TITLE
fix(docs): tidy up the home-page positioning and flow sections

### DIFF
--- a/docs/app/styles/site.css
+++ b/docs/app/styles/site.css
@@ -458,10 +458,10 @@
 
 .ferro-shift-row {
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: 1.5rem;
-  padding: 1.5rem 0;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1.08fr);
+  align-items: start;
+  column-gap: clamp(1.25rem, 2.6vw, 2.25rem);
+  padding: 1.6rem 0;
   border-top: 1px solid var(--ferro-line);
 }
 
@@ -470,21 +470,26 @@
 }
 
 .ferro-shift-before {
+  max-width: 44ch;
   font-size: 1rem;
   line-height: 1.6;
   color: var(--ferro-meta);
+  text-wrap: pretty;
 }
 
 .ferro-shift-arrow {
+  margin-top: 0.3rem;
   color: var(--ferro-ember);
   flex-shrink: 0;
 }
 
 .ferro-shift-after {
+  max-width: 46ch;
   font-size: 1.05rem;
   line-height: 1.6;
   font-weight: 600;
   color: var(--ferro-ink);
+  text-wrap: balance;
 }
 
 /* ── Benefits ── */

--- a/docs/app/styles/site.css
+++ b/docs/app/styles/site.css
@@ -553,7 +553,7 @@
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   gap: 1.6rem;
   counter-reset: none;
 }
@@ -1169,7 +1169,7 @@
 
 /* ── Responsive ── */
 
-@media (max-width: 960px) {
+@media (max-width: 1024px) {
   .ferro-flow-steps {
     grid-template-columns: repeat(2, 1fr);
   }


### PR DESCRIPTION
Two layout fixes on the docs home page, both CSS-only and token-driven (light/dark unchanged).

## 1. Problem → outcome rows (`.ferro-shift-*`)

The rows were vertically centered (`align-items: center`). When an outcome wrapped to two lines, the arrow drifted to the row's mid-point instead of pointing at the **first** line, and long outcomes wrapped with a single orphan word on line two.

- Top-align rows (`align-items: start`) and nudge the arrow (`margin-top`) onto the first text line.
- Balance the outcome wrap (`text-wrap: balance`) and give that column slightly more room (`1.08fr`).
- Cap line length and apply `text-wrap: pretty` to the problem column.

Verified geometrically: arrow center aligns to the first-line center in all rows (offset `0px`, was `+13` to `+27px`); two-line outcomes split evenly instead of orphaning a word.

## 2. "One catalog, five jobs" stepper (`.ferro-flow-steps`)

A 4-column grid held five steps, so the fifth job wrapped onto its own second row (4 + 1) and the connector line ran off the right edge after step four.

- Use a 5-column grid so all five steps sit in one connected row.
- Raise the collapse breakpoint from 960px to 1024px so five columns only stay side by side while they have room, then drop to two columns, then one.

Verified across widths: 1280px and 1100px → five in one row, no text overflow, connector between steps (step 5 has none); ≤1024px → two columns with connectors hidden; ≤720px → single column.

Both sections use a scroll-driven reveal that does not render reliably in headless screenshots, so verification was done by measuring computed geometry in the live dev server rather than by screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)