### PR TITLE
perf(po): cut redundant allocations in catalog import (non-breaking)

### DIFF
--- a/crates/ferrocat-bench/src/main.rs
+++ b/crates/ferrocat-bench/src/main.rs
@@ -101,6 +101,11 @@ fn run() -> Result<(), String> {
             let fixture = load_fixture(&fixture_name)?;
             run_alloc_stats(&fixture)
         }
+        "string-stats" => {
+            let fixture_name = args.next().unwrap_or_else(|| "realistic".to_owned());
+            let fixture = load_fixture(&fixture_name)?;
+            run_string_stats(&fixture)
+        }
         "parse-catalog-po" => {
             let fixture_name = args
                 .next()
@@ -351,6 +356,22 @@ fn run_alloc_stats(fixture: &Fixture) -> Result<(), String> {
     std::hint::black_box(&borrowed);
     drop(borrowed);
 
+    ALLOCS.store(0, Ordering::SeqCst);
+    BYTES.store(0, Ordering::SeqCst);
+    let catalog = parse_catalog(ParseCatalogOptions {
+        content,
+        locale: inferred_fixture_locale(fixture.name()),
+        source_locale: "en",
+        mode: CatalogMode::IcuPo,
+        strict: false,
+    })
+    .map_err(|error| error.to_string())?;
+    let catalog_allocs = ALLOCS.load(Ordering::SeqCst);
+    let catalog_bytes = BYTES.load(Ordering::SeqCst);
+    let catalog_items = catalog.messages.len();
+    std::hint::black_box(&catalog);
+    drop(catalog);
+
     println!("fixture: {} ({} bytes)", fixture.name(), content.len());
     measure(
         "parse_po (owned)   ",
@@ -364,12 +385,105 @@ fn run_alloc_stats(fixture: &Fixture) -> Result<(), String> {
         borrowed_allocs,
         borrowed_bytes,
     );
+    measure(
+        "parse_catalog        ",
+        catalog_items,
+        catalog_allocs,
+        catalog_bytes,
+    );
     Ok(())
 }
 
 #[cfg(not(feature = "count-alloc"))]
 fn run_alloc_stats(_fixture: &Fixture) -> Result<(), String> {
     Err("alloc-stats requires building with --features count-alloc".to_owned())
+}
+
+/// Reports the string-length and collection-size distribution of an owned parse
+/// to gauge how much an inline string (`CompactString`, 24-byte inline) or an
+/// inline vector (`SmallVec`) representation would eliminate heap allocations.
+fn run_string_stats(fixture: &Fixture) -> Result<(), String> {
+    let file = parse_po(fixture.content()).map_err(|error| error.to_string())?;
+
+    let mut lengths: Vec<usize> = Vec::new();
+    let mut record = |value: &str| lengths.push(value.len());
+    for header in &file.headers {
+        record(&header.key);
+        record(&header.value);
+    }
+    for comment in file.comments.iter().chain(&file.extracted_comments) {
+        record(comment);
+    }
+
+    // Collection-size histograms (index 3 == "3 or more") to size SmallVec.
+    let mut reference_hist = [0usize; 4];
+    let mut comment_hist = [0usize; 4];
+    for item in &file.items {
+        record(&item.msgid);
+        if let Some(context) = &item.msgctxt {
+            record(context);
+        }
+        if let Some(plural) = &item.msgid_plural {
+            record(plural);
+        }
+        for value in item.msgstr.iter() {
+            record(value);
+        }
+        for reference in &item.references {
+            record(reference);
+        }
+        for comment in item.comments.iter().chain(&item.extracted_comments) {
+            record(comment);
+        }
+        for flag in &item.flags {
+            record(flag);
+        }
+        reference_hist[item.references.len().min(3)] += 1;
+        comment_hist[(item.comments.len() + item.extracted_comments.len()).min(3)] += 1;
+    }
+
+    let total = lengths.len().max(1);
+    let share = |count: usize| 100.0 * count as f64 / total as f64;
+    let inline = lengths.iter().filter(|&&len| len <= 24).count();
+    let mid = lengths
+        .iter()
+        .filter(|&&len| (25..=48).contains(&len))
+        .count();
+    let long = lengths.iter().filter(|&&len| len > 48).count();
+
+    println!("fixture: {} ({} items)", fixture.name(), file.items.len());
+    println!("strings: {total}");
+    println!(
+        "  <=24 bytes (CompactString inline): {inline} ({:.1}%)",
+        share(inline)
+    );
+    println!(
+        "  25..48 bytes:                       {mid} ({:.1}%)",
+        share(mid)
+    );
+    println!(
+        "  >48 bytes:                          {long} ({:.1}%)",
+        share(long)
+    );
+    let items = file.items.len().max(1);
+    let item_share = |count: usize| 100.0 * count as f64 / items as f64;
+    println!(
+        "references/item: 0={} 1={} 2={} 3+={} (1-or-fewer: {:.1}%)",
+        reference_hist[0],
+        reference_hist[1],
+        reference_hist[2],
+        reference_hist[3],
+        item_share(reference_hist[0] + reference_hist[1]),
+    );
+    println!(
+        "comments/item:   0={} 1={} 2={} 3+={} (1-or-fewer: {:.1}%)",
+        comment_hist[0],
+        comment_hist[1],
+        comment_hist[2],
+        comment_hist[3],
+        item_share(comment_hist[0] + comment_hist[1]),
+    );
+    Ok(())
 }
 
 fn bench_parse(fixture: &Fixture, config: BenchConfig) -> Result<(), String> {

--- a/crates/ferrocat-po/src/api/catalog.rs
+++ b/crates/ferrocat-po/src/api/catalog.rs
@@ -27,7 +27,7 @@ use super::{
     ExtractedMessage, ObsoleteStrategy, OrderBy, ParseCatalogOptions, ParsedCatalog,
     PluralEncoding, PluralSource, TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions,
 };
-use crate::{MsgStr, PoItem, parse_po};
+use crate::{MsgStr, PoFile, PoItem, parse_po};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(super) struct Catalog {
@@ -737,11 +737,15 @@ fn parse_catalog_to_internal_po(
     _plural_encoding: PluralEncoding,
     strict: bool,
 ) -> Result<Catalog, ApiError> {
-    let file = parse_po(content)?;
-    let headers = file
-        .headers
-        .iter()
-        .map(|header| (header.key.clone(), header.value.clone()))
+    let PoFile {
+        headers: po_headers,
+        items: po_items,
+        comments: po_comments,
+        extracted_comments: po_extracted_comments,
+    } = parse_po(content)?;
+    let headers = po_headers
+        .into_iter()
+        .map(|header| (header.key, header.value))
         .collect::<BTreeMap<_, _>>();
     let locale = locale_override
         .map(str::to_owned)
@@ -755,9 +759,9 @@ fn parse_catalog_to_internal_po(
         semantics,
         &mut diagnostics,
     );
-    let mut messages = Vec::with_capacity(file.items.len());
+    let mut messages = Vec::with_capacity(po_items.len());
 
-    for item in file.items {
+    for item in po_items {
         let mut conversion_diagnostics = Vec::new();
         let message = import_message_from_po(
             item,
@@ -774,8 +778,8 @@ fn parse_catalog_to_internal_po(
     Ok(Catalog {
         locale,
         headers,
-        file_comments: file.comments,
-        file_extracted_comments: file.extracted_comments,
+        file_comments: po_comments,
+        file_extracted_comments: po_extracted_comments,
         messages,
         diagnostics,
     })
@@ -797,8 +801,8 @@ fn import_message_from_po(
     let (comments, placeholders) = split_placeholder_comments(item.extracted_comments);
     let origins = item
         .references
-        .iter()
-        .map(|reference| parse_origin(reference))
+        .into_iter()
+        .map(parse_origin_owned)
         .collect();
 
     let translation = if let Some(msgid_plural) = &item.msgid_plural {
@@ -834,7 +838,7 @@ fn import_message_from_po(
             ));
         }
         CanonicalTranslation::Singular {
-            value: item.msgstr.first_str().unwrap_or_default().to_owned(),
+            value: take_first_msgstr(item.msgstr),
         }
     };
 
@@ -898,16 +902,34 @@ fn parse_placeholder_comment(comment: &str) -> Option<(String, String)> {
 }
 
 /// Parses a gettext reference while tolerating plain paths and `path:line`.
-fn parse_origin(reference: &str) -> CatalogOrigin {
-    match reference.rsplit_once(':') {
-        Some((file, line)) if line.chars().all(|ch| ch.is_ascii_digit()) => CatalogOrigin {
-            file: file.to_owned(),
-            line: line.parse::<u32>().ok(),
-        },
-        _ => CatalogOrigin {
-            file: reference.to_owned(),
-            line: None,
-        },
+/// Splits a `file:line` reference into a [`CatalogOrigin`], reusing the owned
+/// reference buffer for the file part instead of allocating a fresh string.
+fn parse_origin_owned(mut reference: String) -> CatalogOrigin {
+    if let Some((file, line)) = reference.rsplit_once(':')
+        && line.chars().all(|ch| ch.is_ascii_digit())
+    {
+        let parsed_line = line.parse::<u32>().ok();
+        let file_len = file.len();
+        reference.truncate(file_len);
+        return CatalogOrigin {
+            file: reference,
+            line: parsed_line,
+        };
+    }
+
+    CatalogOrigin {
+        file: reference,
+        line: None,
+    }
+}
+
+/// Moves the first available translation string out of a [`MsgStr`], matching
+/// the `first_str().unwrap_or_default()` semantics without copying.
+fn take_first_msgstr(msgstr: MsgStr) -> String {
+    match msgstr {
+        MsgStr::Singular(value) => value,
+        MsgStr::Plural(values) => values.into_iter().next().unwrap_or_default(),
+        MsgStr::None => String::new(),
     }
 }
 
@@ -1005,5 +1027,39 @@ pub(super) fn public_message_from_canonical(message: CanonicalMessage) -> Catalo
             translator_comments: message.translator_comments,
             flags: message.flags,
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_origin_owned, take_first_msgstr};
+    use crate::MsgStr;
+
+    #[test]
+    fn parse_origin_owned_handles_file_line_and_bare_references() {
+        let with_line = parse_origin_owned("src/app.rs:42".to_owned());
+        assert_eq!(with_line.file, "src/app.rs");
+        assert_eq!(with_line.line, Some(42));
+
+        // No colon and a non-numeric line suffix both fall back to a line-less
+        // origin that reuses the original buffer verbatim.
+        let bare = parse_origin_owned("README".to_owned());
+        assert_eq!(bare.file, "README");
+        assert_eq!(bare.line, None);
+
+        let non_numeric = parse_origin_owned("a:b:rev".to_owned());
+        assert_eq!(non_numeric.file, "a:b:rev");
+        assert_eq!(non_numeric.line, None);
+    }
+
+    #[test]
+    fn take_first_msgstr_moves_first_available_value() {
+        assert_eq!(take_first_msgstr(MsgStr::Singular("one".to_owned())), "one");
+        assert_eq!(
+            take_first_msgstr(MsgStr::Plural(vec!["a".to_owned(), "b".to_owned()])),
+            "a"
+        );
+        assert_eq!(take_first_msgstr(MsgStr::Plural(Vec::new())), "");
+        assert_eq!(take_first_msgstr(MsgStr::None), "");
     }
 }


### PR DESCRIPTION
## Summary

Non-breaking allocation reductions on the `parse_catalog` path, plus the measurement tooling that quantifies the remaining (breaking) opportunities. This is the "non-breaking first + measure" step agreed after the malloc profiling in #161/#164.

### Fixes (no public type changes)

`parse_catalog` builds an owned `PoFile`, then moves most strings into the catalog representation. Three spots re-allocated unnecessarily:

1. **Header map** — keys/values were cloned into the `BTreeMap`; now moved (the `PoFile` is destructured).
2. **References** — `parse_origin` allocated a fresh `file` string per reference. The new `parse_origin_owned` consumes the owned reference and `truncate`s it in place for the file part — zero new allocation.
3. **Singular msgstr** — was copied via `first_str().to_owned()` even though the owned `String` already existed; now moved out of `MsgStr` via `take_first_msgstr`.

### Results — catalog-modern-de-1000

| metric | before | after | Δ |
|---|---|---|---|
| allocations/item | 7.6 | 5.6 | **−26%** |
| parse-catalog-po throughput | 343 | 400 MiB/s | **+16.5%** |

### Measurement tooling

- `alloc-stats` now also reports `parse_catalog` allocations (next to owned/borrowed).
- New `string-stats` command: string-length buckets and per-item reference/comment counts.

## Data for the next (breaking) step

`string-stats` over the realistic fixtures shows where the remaining ~31% malloc lives and what a breaking representation change would buy:

| | strings ≤24B (CompactString-inline) | refs/item ≤1 | comments/item ≤1 |
|---|---|---|---|
| catalog-modern-de-1000 | 35% | 100% | 100% |
| gettext-ui-de-10000 | 42% | 100% | 99% |

Takeaway for the separate breaking PR: **`SmallVec<[_; 1]>`** on the collection fields would inline the container `Vec` for ~100% of items (the most reliable win), and **`CompactString`** would additionally inline ~35–42% of strings. Both change public `PoItem`/`CatalogMessage` types (semver-major, ripples to Palamedes), so they stay out of this PR.

## Verification

- `cargo test -p ferrocat-po` — green, incl. new unit tests for `parse_origin_owned` and `take_first_msgstr`
- `cargo clippy --workspace --all-targets` (incl. `--features count-alloc`) — clean
- `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)