### PR TITLE
chore(deps): refresh Rust lockfiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -423,9 +423,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -637,9 +637,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -114,14 +114,15 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
+ "memchr",
  "serde",
 ]
 
 [[package]]
 name = "ferrocat-po"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",
@@ -130,6 +131,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "smallvec",
  "tempfile",
 ]
 
@@ -158,26 +160,15 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
-]
-
-[[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -279,7 +270,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom",
  "libc",
 ]
 
@@ -345,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -357,12 +348,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rustix"
@@ -442,6 +427,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -478,7 +466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",


### PR DESCRIPTION
## Summary

- Refreshes the root and fuzz Rust lockfiles for a small patch-level Rust dependency batch.
- Updates `hybrid-array` 0.4.12 -> 0.4.13, `quote` 1.0.45 -> 1.0.46, `time` 0.3.49 -> 0.3.51, and `time-macros` 0.2.29 -> 0.2.30.
- Reconciles `fuzz/Cargo.lock` with the current workspace path crate versions (`ferrocat-icu`/`ferrocat-po` 1.3.2) and removes stale transitive entries from the older local dependency graph.
- No manifest, public API, or runtime code changes.

## Dependency impact

- `hybrid-array` flows through the RustCrypto digest/SHA stack used by `ferrocat-po` and `ferrocat-bench`; upstream: https://github.com/RustCrypto/hybrid-array and https://crates.io/crates/hybrid-array/0.4.13.
- `quote` is used by proc-macro stacks such as serde/ICU derives; upstream: https://github.com/dtolnay/quote and https://crates.io/crates/quote/1.0.46.
- `time`/`time-macros` affect the benchmark crate timestamp/formatting dependency path; upstream: https://github.com/time-rs/time, https://crates.io/crates/time/0.3.51, and https://crates.io/crates/time-macros/0.2.30.
- Updated crate `rust-version` requirements remain below the repository MSRV check toolchain (`1.93.0`).

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- [x] `cargo +1.93.0 check --workspace --all-targets --all-features --locked`
- [x] `cargo check --manifest-path fuzz/Cargo.toml --locked`
- [x] `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked`
- [x] `git diff --check`

## Notes

- Public API or semver-relevant changes: none.
- Benchmark impact: dependency-only lockfile refresh; no benchmark harness or hot-path source changes.