### PR TITLE
docs(catalog): clarify origin scope semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ferrocat is also part of the [Palamedes](https://github.com/sebastian-software/p
 
 ## What Ferrocat Gives You
 
-- **One reliable catalog core.** Keep source text, contexts, translations, notes, source origins (file plus optional scope), plural forms, and obsolete entries in a model that application code can reason about.
+- **One reliable catalog core.** Keep source text, contexts, translations, notes, source origins such as `src/App.tsx#CheckoutButton` or `src/i18n.ts#formatInvoiceStatus`, plural forms, and obsolete entries in a model that application code can reason about.
 - **Predictable updates.** Merge newly extracted messages into existing catalogs without fuzzy guessing, hidden identity changes, or silent conflict resolution.
 - **Release-ready QA.** Audit catalog sets for missing locales, missing translations, empty translations, stale target messages, ICU mistakes, metadata conflicts, and obsolete entries.
 - **Coverage and review reports.** Turn catalog state into completion counters, translator handoff diffs, and machine-managed value freshness checks instead of rebuilding those rules in every host tool.

--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -10,21 +10,25 @@ use super::plural::PluralProfile;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// File and line information for an extracted message origin.
+/// Source origin metadata for an extracted message.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct CatalogOrigin {
-    /// Path-like source identifier where the message came from.
+    /// Path-like source file identifier where the message came from.
     ///
     /// Ferrocat intentionally tracks no line number: line numbers shift on every
     /// edit above a message and add diff and merge churn without identifying
     /// anything the `(msgid, msgctxt)` key does not already.
     pub file: String,
     /// Optional stable scope within the file, such as the enclosing component or
-    /// function name. Unlike a line number it survives edits, so it adds context
-    /// for translators and tools without churn. Producers (e.g. extractors) fill
-    /// it; serialized as `file#scope`.
+    /// function name.
+    ///
+    /// Unlike a line number it survives edits, so it adds context for
+    /// translators and tools without churn. It is metadata, not message
+    /// identity, and it is not a replacement for gettext context / `msgctxt`.
+    /// Producers (e.g. extractors) fill it; serialized with the file as
+    /// `file#scope`.
     pub scope: Option<String>,
 }
 

--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -21,13 +21,14 @@ pub struct CatalogOrigin {
     /// edit above a message and add diff and merge churn without identifying
     /// anything the `(msgid, msgctxt)` key does not already.
     pub file: String,
-    /// Optional stable scope within the file, such as the enclosing component or
-    /// function name.
+    /// Optional stable scope within the file, such as the enclosing component,
+    /// function, class, route handler, or similar named authoring unit.
     ///
     /// Unlike a line number it survives edits, so it adds context for
     /// translators and tools without churn. It is metadata, not message
     /// identity, and it is not a replacement for gettext context / `msgctxt`.
-    /// Producers (e.g. extractors) fill it; serialized with the file as
+    /// Producers (e.g. extractors) fill it with values like `CheckoutButton`,
+    /// `formatInvoiceStatus`, or `SettingsPage`; serialized with the file as
     /// `file#scope`.
     pub scope: Option<String>,
 }

--- a/docs/app/routes/architecture/adr/0024-origin-scope-anchor.mdx
+++ b/docs/app/routes/architecture/adr/0024-origin-scope-anchor.mdx
@@ -23,6 +23,10 @@ translators and tooling context ("this string lives in `Checkout`") and helps
 distinguish the same text used in different places. Producers such as Palamedes
 can extract it; Ferrocat only needs a neutral slot to carry it.
 
+This scope is origin metadata, not message identity. It is separate from
+gettext context / `msgctxt`, and producers should not derive it from `msgctxt`
+by default. Ferrocat still keys catalog messages by `(msgid, msgctxt)`.
+
 ## Decision
 
 Add an optional, stable `scope` to `CatalogOrigin`:

--- a/docs/app/routes/architecture/adr/0024-origin-scope-anchor.mdx
+++ b/docs/app/routes/architecture/adr/0024-origin-scope-anchor.mdx
@@ -26,6 +26,9 @@ can extract it; Ferrocat only needs a neutral slot to carry it.
 This scope is origin metadata, not message identity. It is separate from
 gettext context / `msgctxt`, and producers should not derive it from `msgctxt`
 by default. Ferrocat still keys catalog messages by `(msgid, msgctxt)`.
+Good scope values are names already present in source code, such as
+`CheckoutButton`, `formatInvoiceStatus`, `SettingsPage`, or
+`InvoicePresenter`.
 
 ## Decision
 

--- a/docs/app/routes/guide/catalog-modes.mdx
+++ b/docs/app/routes/guide/catalog-modes.mdx
@@ -31,6 +31,15 @@ The painful failure with PO is not a crash. It is a finished translation that qu
 
 FCL removes that by construction. Every entry is one tab-separated line, sorted by `(id, ctxt)` behind a single `%FCL1` header. Independent edits land on distant lines and merge cleanly; an entry neither side touched stays byte-identical in all three versions, so ordinary git 3-way merges preserve it. No custom merge driver required, so it behaves the same in a hosted pull request or a web merge as it does locally.
 
+Those compact lines can still carry useful source context. An origin can be a
+file alone (`src/App.tsx`) or a file plus the nearest stable named container:
+`src/App.tsx#CheckoutButton`, `src/i18n.ts#formatInvoiceStatus`,
+`src/routes/settings.tsx#SettingsPage`, or
+`src/domain/invoice.ts#InvoiceStatus`. The part after `#` is the component,
+function, class, route handler, or similar authoring unit around the text. It
+helps reviewers understand where the message came from; it does not replace
+`msgctxt` and does not change message identity.
+
 Here is the part that usually involves a trade-off, except it doesn't: you do not pay for that safety with speed or size. Against the same catalog stored as PO, FCL parses about 45% faster and the file is roughly 12% smaller. Use it as the machine-owned format: generated, reviewed in diffs, handed to pipelines and external services, never hand-edited. Generate it through `CatalogMode::IcuFcl`; PO remains the right choice when translator tools need to read the file directly.
 
 Both PO and FCL can carry machine-translation metadata for AI-assisted workflows. Ferrocat keeps the storage compact, verifies the translation hash when writing, and drops stale metadata once the translated text has been edited.

--- a/docs/app/routes/guide/palamedes.mdx
+++ b/docs/app/routes/guide/palamedes.mdx
@@ -43,9 +43,12 @@ Keeping Ferrocat and Palamedes separate gives both projects cleaner boundaries.
 Ferrocat can focus on catalog correctness, performance, conformance, and storage contracts without becoming a JavaScript framework plugin. Palamedes can focus on application ergonomics, framework integrations, transforms, runtime wiring, and bundler behavior without duplicating PO parsing or catalog semantics.
 
 Semantic message metadata follows the same split. Palamedes can infer argument
-types, enum values, tags, component names, and source origins from JS/TS code;
-Ferrocat can normalize and validate those facts against `msgid + msgctxt`
-without owning the JS/TS parser.
+types, enum values, tags, component names, and source origins from JS/TS code.
+For origin scope, that usually means names already visible in application
+source: a component like `CheckoutButton`, a formatter function like
+`formatInvoiceStatus`, a route handler like `SettingsPage`, or a class such as
+`InvoicePresenter`. Ferrocat can normalize and validate those facts against
+`msgid + msgctxt` without owning the JS/TS parser.
 
 Catalog audit reports follow that boundary too. Palamedes can run audit in CI,
 editors, or release commands and enrich it with project context; Ferrocat owns

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -110,6 +110,24 @@ There is intentionally no FCL + gettext-plural mode; gettext plural behavior bel
 
 FCL (Ferrocat Catalog Lines) is the machine-owned, git-merge-optimized storage choice. Each entry is one tab-separated line, deterministically sorted by `(id, ctxt)`, behind a single `%FCL1` header line. It is useful when catalogs are maintained by larger teams, automation, or external systems that benefit from one entry per line: diffs stay focused, unchanged entries stay byte-identical across merge inputs for clean git 3-way merges, and hosted Git review workflows do not need custom merge-driver support to make routine catalog edits manageable. Against the same catalog stored as PO, FCL parses about 45% faster and is roughly 12% smaller on disk.
 
+### Origin file and scope
+
+Catalog origins keep a source `file` plus an optional `scope`. The serialized
+form is either `file` or `file#scope`, for example
+`src/App.tsx#CheckoutButton`, `src/i18n.ts#formatInvoiceStatus`, or
+`src/routes/settings.tsx#SettingsPage`.
+
+`file` identifies the source file. `scope` identifies the nearest stable named
+source container around the message, such as a component, function, class, or
+route handler. It is metadata for review and tooling, not message identity, and
+it is not a replacement for gettext context / `msgctxt`. Downstream extractors
+should not derive origin scope from `msgctxt` by default; Ferrocat still treats
+message identity as `msgid` plus optional `msgctxt`.
+
+Choose a scope that is stable enough to survive ordinary edits. Do not serialize
+line numbers as origin scope: line numbers move on unrelated edits and Ferrocat
+intentionally strips or omits them from catalog origins.
+
 ## Quick Choice
 
 | If you want to... | Use |

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -112,10 +112,16 @@ FCL (Ferrocat Catalog Lines) is the machine-owned, git-merge-optimized storage c
 
 ### Origin file and scope
 
-Catalog origins keep a source `file` plus an optional `scope`. The serialized
-form is either `file` or `file#scope`, for example
-`src/App.tsx#CheckoutButton`, `src/i18n.ts#formatInvoiceStatus`, or
-`src/routes/settings.tsx#SettingsPage`.
+Catalog origins answer "where did this message come from?" with a source `file`
+plus an optional `scope`. The serialized form is either `file` or `file#scope`.
+Use the scope for the name a developer would naturally point to in code:
+
+| Origin | Meaning |
+|---|---|
+| `src/App.tsx#CheckoutButton` | the text appears inside the `CheckoutButton` component |
+| `src/i18n.ts#formatInvoiceStatus` | the text is authored in the `formatInvoiceStatus` function |
+| `src/routes/settings.tsx#SettingsPage` | the text belongs to the `SettingsPage` route component |
+| `src/domain/invoice.ts#InvoiceStatus` | the text is grouped around the `InvoiceStatus` class, enum, or module-level authoring unit |
 
 `file` identifies the source file. `scope` identifies the nearest stable named
 source container around the message, such as a component, function, class, or
@@ -127,6 +133,10 @@ message identity as `msgid` plus optional `msgctxt`.
 Choose a scope that is stable enough to survive ordinary edits. Do not serialize
 line numbers as origin scope: line numbers move on unrelated edits and Ferrocat
 intentionally strips or omits them from catalog origins.
+
+For example, prefer `src/App.tsx#CheckoutButton` over
+`src/App.tsx#CheckoutButton:42` or `src/App.tsx#line42`. If the extractor cannot
+find a stable named container, emit the file alone and leave `scope` empty.
 
 ## Quick Choice
 

--- a/docs/fcl-format.md
+++ b/docs/fcl-format.md
@@ -79,12 +79,19 @@ A field containing no `\` is taken verbatim (zero-copy borrow on parse).
 Canonical tag order: `r` (sorted), `c`, `o`, `lock`, `ai`.
 
 `r` carries the file and an optional stable `#scope` anchor. The file identifies
-the source file; the scope identifies the nearest stable named source container,
-such as a component, function, class, or route handler. Example references are
-`src/App.tsx#CheckoutButton`, `src/i18n.ts#formatInvoiceStatus`, and
-`src/routes/settings.tsx#SettingsPage`. Scope is metadata for review and
-tooling, not message identity, and it is not a replacement for gettext context /
-`msgctxt`; downstream tools should not derive it from `msgctxt` by default. See
+the source file; the scope identifies the nearest stable named source container.
+Use names a developer would recognize in source code:
+
+| Origin | Typical scope |
+|---|---|
+| `src/App.tsx#CheckoutButton` | component name |
+| `src/i18n.ts#formatInvoiceStatus` | function name |
+| `src/routes/settings.tsx#SettingsPage` | route component or route handler |
+| `src/domain/invoice.ts#InvoiceStatus` | class, enum, or module-level authoring unit |
+
+Scope is metadata for review and tooling, not message identity, and it is not a
+replacement for gettext context / `msgctxt`; downstream tools should not derive
+it from `msgctxt` by default. See
 [ADR 0024](/architecture/adr/0024-origin-scope-anchor). `c` holds free-form
 notes: the gettext extracted (`#.`) and translator (`#`) comment kinds collapse
 into one list, and gettext flags (`fuzzy`, `*-format`) are not carried (see

--- a/docs/fcl-format.md
+++ b/docs/fcl-format.md
@@ -78,11 +78,17 @@ A field containing no `\` is taken verbatim (zero-copy borrow on parse).
 
 Canonical tag order: `r` (sorted), `c`, `o`, `lock`, `ai`.
 
-`r` carries the file and an optional stable `#scope` anchor (enclosing component
-or function); see [ADR 0024](/architecture/adr/0024-origin-scope-anchor). `c`
-holds free-form notes: the gettext extracted (`#.`) and translator (`#`) comment
-kinds collapse into one list, and gettext flags (`fuzzy`, `*-format`) are not
-carried (see [ADR 0023](/architecture/adr/0023-drop-gettext-flags-merge-comments)).
+`r` carries the file and an optional stable `#scope` anchor. The file identifies
+the source file; the scope identifies the nearest stable named source container,
+such as a component, function, class, or route handler. Example references are
+`src/App.tsx#CheckoutButton`, `src/i18n.ts#formatInvoiceStatus`, and
+`src/routes/settings.tsx#SettingsPage`. Scope is metadata for review and
+tooling, not message identity, and it is not a replacement for gettext context /
+`msgctxt`; downstream tools should not derive it from `msgctxt` by default. See
+[ADR 0024](/architecture/adr/0024-origin-scope-anchor). `c` holds free-form
+notes: the gettext extracted (`#.`) and translator (`#`) comment kinds collapse
+into one list, and gettext flags (`fuzzy`, `*-format`) are not carried (see
+[ADR 0023](/architecture/adr/0023-drop-gettext-flags-merge-comments)).
 
 `lock` is the fingerprint of the value when a machine (AI engine, TMS, script)
 set it; if `hash(current value) != lock`, a human edited it and high-level


### PR DESCRIPTION
Closes #176.

## Summary
- Document origin file and scope semantics in the API overview.
- Add earlier and more concrete scope examples in README, Catalog Modes, Palamedes, FCL format docs, ADR 0024, and CatalogOrigin Rustdocs.
- Clarify that scope is a component/function/class/route-style source container, metadata for review and tooling, and not msgctxt or message identity.

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- pnpm install --frozen-lockfile
- pnpm build