### PR TITLE
chore(deps): update benchmark adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -637,9 +637,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/benchmark/node/package-lock.json
+++ b/benchmark/node/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": "^3.5.11",
+        "@formatjs/icu-messageformat-parser": "^3.5.12",
         "@messageformat/parser": "^5.1.1",
         "gettext-parser": "^9.0.2",
         "pofile": "^1.1.4",
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.11.tgz",
-      "integrity": "sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.12.tgz",
+      "integrity": "sha512-YyzzxVgYJ8DELmmkhn0Yr0rUj0dTJFf9Jp628K3S0ysInBWxLVDOS8i3RP91cCp4DMK4WYb4cVMhWA9i4knSJg==",
       "license": "MIT",
       "dependencies": {
         "@formatjs/icu-skeleton-parser": "2.1.10"

--- a/benchmark/node/package.json
+++ b/benchmark/node/package.json
@@ -5,7 +5,7 @@
   "description": "External Node-based benchmark adapters for ferrocat comparison runs.",
   "license": "MIT",
   "dependencies": {
-    "@formatjs/icu-messageformat-parser": "^3.5.11",
+    "@formatjs/icu-messageformat-parser": "^3.5.12",
     "@messageformat/parser": "^5.1.1",
     "gettext-parser": "^9.0.2",
     "pofile": "^1.1.4",

--- a/docs/app/routes/performance/benchmarking.mdx
+++ b/docs/app/routes/performance/benchmarking.mdx
@@ -55,7 +55,7 @@ original.
 | [Babel](https://github.com/python-babel/babel) | Python | catalog update | 2.18.0 |
 | [gettext/gettext](https://github.com/php-gettext/Gettext) | PHP | PO parse, serialize | 5.7 |
 | [GNU gettext](https://www.gnu.org/software/gettext/) (`msgmerge`, `msgcat`) | C | merge, concat | system |
-| [@formatjs/icu-messageformat-parser](https://github.com/formatjs/formatjs) | Node | ICU parse | 3.5.11 |
+| [@formatjs/icu-messageformat-parser](https://github.com/formatjs/formatjs) | Node | ICU parse | 3.5.12 |
 | [@messageformat/parser](https://github.com/messageformat/messageformat) | Node | ICU parse | 5.1.1 |
 
 ## Scheduled Rust Reports


### PR DESCRIPTION
## Dependency group
- Packages: `@formatjs/icu-messageformat-parser` 3.5.11 -> 3.5.12, `time` 0.3.51 -> 0.3.53, `time-macros` 0.2.30 -> 0.2.31
- Why grouped: these are benchmark-only dependencies and share the benchmark validation surface.

## Upstream changes that matter here
- FormatJS parser 3.5.12 includes a parser fix to print plural/select branches in canonical order, plus release/package maintenance. The Node adapter uses `parse(message, { captureLocation: false })`, so the main local risk is benchmark digest behavior. Source: https://github.com/formatjs/formatjs/releases/tag/%40formatjs%2Ficu-messageformat-parser%403.5.12
- `time` 0.3.52 fixed macro parsing edge cases; 0.3.53 has no public API changes and restores an internal compatibility detail. The benchmark harness only uses `OffsetDateTime::now_utc().format(&Rfc3339)`. Source: https://github.com/time-rs/time/blob/main/CHANGELOG.md#0353-2026-07-01

## Local impact and code changes
- Updated the Node benchmark adapter manifest and lockfile.
- Refreshed the workspace lockfile for the benchmark-only `time` dependency.
- Updated the benchmark docs table to report the FormatJS parser version as 3.5.12.
- No benchmark harness source migration was required.

## Validation
- `cargo check -p ferrocat-bench --all-features --locked`: passed
- `npm ci --ignore-scripts`: passed
- `node benchmark/node/adapter.cjs --check`: passed
- `git diff --check`: passed

## Risk
- Risk is limited to benchmark reports and adapter metadata. Published Ferrocat crate APIs are not changed.