### PR TITLE
chore(deps): refresh fuzz lockfile

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "1.3.2"
+version = "2.0.0"
 dependencies = [
  "memchr",
  "serde",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-po"
-version = "1.3.2"
+version = "2.0.0"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",
@@ -160,8 +160,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -270,7 +281,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -348,6 +359,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rustix"
@@ -466,7 +483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",


### PR DESCRIPTION
## Dependency group
- Packages: fuzz lockfile path dependencies `ferrocat-icu` 1.3.2 -> 2.0.0 and `ferrocat-po` 1.3.2 -> 2.0.0
- Why grouped: the fuzz crate is excluded from the root workspace, so its lockfile must be refreshed separately from the published workspace crates.

## Upstream changes that matter here
- No external API migration is introduced here. This catches `fuzz/Cargo.lock` up to the current local workspace crate versions.
- The refreshed graph adds `getrandom` 0.4.3 and `r-efi` 6.0.0 through the current transitive dependency graph.

## Local impact and code changes
- Updated `fuzz/Cargo.lock` only.
- No fuzz target source changes were needed.

## Validation
- `cargo metadata --manifest-path fuzz/Cargo.toml --locked --format-version 1 --no-deps`: passed
- `git diff --check`: passed

## Risk
- Risk is limited to the excluded fuzz crate lockfile. Main workspace builds and published crate manifests are unchanged.