### PR TITLE
docs(changelog): backfill 2.0 breaking changes

### DIFF
--- a/crates/ferrocat-bench/CHANGELOG.md
+++ b/crates/ferrocat-bench/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ### ⚠ BREAKING CHANGES
 
-* **po:** `CatalogMessage::obsolete` is now `Option<ObsoleteInfo>` instead of `bool`, `ObsoleteStrategy` gains a non-`Copy` `DropObsoleteBefore(String)` variant, and `UpdateCatalogOptions` gains a `now` field. Lands in the 2.0.0 line.
-* **po:** `CatalogMessageExtra`, `CatalogMessage::extra`, `CatalogMessageStatus::Fuzzy`, `CatalogAuditChecks::fuzzy_flags`, the `catalog.fuzzy_flag` diagnostic, and `CatalogLocaleCoverage::fuzzy` are removed; `CatalogOrigin` gains a required `scope` field; the FCL `tc=` and `f=` tags are removed. PO/FCL output no longer carries `fuzzy`/format flags and renders origins as `file#scope`. Lands in the 2.0.0 line.
+* **po:** `CatalogMessage::obsolete` is now `Option<ObsoleteInfo>` instead of `bool`, `ObsoleteStrategy` gains a non-`Copy` `DropObsoleteBefore(String)` variant, and `UpdateCatalogOptions` gains a `now` field.
+* **po:** `CatalogMessageExtra`, `CatalogMessage::extra`, `CatalogMessageStatus::Fuzzy`, `CatalogAuditChecks::fuzzy_flags`, the `catalog.fuzzy_flag` diagnostic, and `CatalogLocaleCoverage::fuzzy` are removed; `CatalogOrigin` gains a required `scope` field; the FCL `tc=` and `f=` tags are removed. PO/FCL output no longer carries `fuzzy`/format flags and renders origins as `file#scope`.
 * **po:** `CatalogOrigin::line` and the `include_line_numbers` fields on `RenderOptions`, `CombineCatalogOptions`, and `CombineCatalogFilesOptions` are removed. Rendered references no longer include line numbers.
 * **po:** the NDJSON catalog storage format and its public types (NdjsonCatalogReader/Writer + options, CatalogStorageFormat::Ndjson, CatalogFileFormat::Ndjson, CatalogMode::IcuNdjson) are removed. Use FCL (CatalogMode::IcuFcl, .fcl files) instead.
 * **po:** `PoItem::references`, `comments`, `extracted_comments`, `flags`, and `metadata` are now `PoVec<T>` (`SmallVec<[T; 1]>`) instead of `Vec<T>`. Read-heavy code is unaffected (Deref to slice, iteration, indexing, serde), but constructing a field from a `Vec` now needs `.into()` and direct `PartialEq` against `Vec<_>` needs `.as_slice()` on both sides.

--- a/crates/ferrocat-po/CHANGELOG.md
+++ b/crates/ferrocat-po/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ### ⚠ BREAKING CHANGES
 
-* **po:** `CatalogMessage::obsolete` is now `Option<ObsoleteInfo>` instead of `bool`, `ObsoleteStrategy` gains a non-`Copy` `DropObsoleteBefore(String)` variant, and `UpdateCatalogOptions` gains a `now` field. Lands in the 2.0.0 line.
-* **po:** `CatalogMessageExtra`, `CatalogMessage::extra`, `CatalogMessageStatus::Fuzzy`, `CatalogAuditChecks::fuzzy_flags`, the `catalog.fuzzy_flag` diagnostic, and `CatalogLocaleCoverage::fuzzy` are removed; `CatalogOrigin` gains a required `scope` field; the FCL `tc=` and `f=` tags are removed. PO/FCL output no longer carries `fuzzy`/format flags and renders origins as `file#scope`. Lands in the 2.0.0 line.
+* **po:** `CatalogMessage::obsolete` is now `Option<ObsoleteInfo>` instead of `bool`, `ObsoleteStrategy` gains a non-`Copy` `DropObsoleteBefore(String)` variant, and `UpdateCatalogOptions` gains a `now` field.
+* **po:** `CatalogMessageExtra`, `CatalogMessage::extra`, `CatalogMessageStatus::Fuzzy`, `CatalogAuditChecks::fuzzy_flags`, the `catalog.fuzzy_flag` diagnostic, and `CatalogLocaleCoverage::fuzzy` are removed; `CatalogOrigin` gains a required `scope` field; the FCL `tc=` and `f=` tags are removed. PO/FCL output no longer carries `fuzzy`/format flags and renders origins as `file#scope`.
 * **po:** `MachineTranslationMetadata` (with `model`/`modified`/ `confidence: u8`/`hash`) is replaced by `MachineMetadata { lock, ai }` + `AiProvenance`; `CatalogMessage::machine_translation` is renamed to `machine`; `confidence` is now a `[0,1]` f32. PO machine metadata is written as `#@ lock:`/`#@ ai:` instead of `#@ ferrocat-mt`, and FCL as `lock=`/`ai=`.
 * **po:** `CatalogOrigin::line` and the `include_line_numbers` fields on `RenderOptions`, `CombineCatalogOptions`, and `CombineCatalogFilesOptions` are removed. Rendered references no longer include line numbers.
 * **po:** the NDJSON catalog storage format and its public types (NdjsonCatalogReader/Writer + options, CatalogStorageFormat::Ndjson, CatalogFileFormat::Ndjson, CatalogMode::IcuNdjson) are removed. Use FCL (CatalogMode::IcuFcl, .fcl files) instead.

--- a/crates/ferrocat/CHANGELOG.md
+++ b/crates/ferrocat/CHANGELOG.md
@@ -5,10 +5,14 @@
 
 ### ⚠ BREAKING CHANGES
 
-* **po:** `CatalogMessage::obsolete` is now `Option<ObsoleteInfo>` instead of `bool`, `ObsoleteStrategy` gains a non-`Copy` `DropObsoleteBefore(String)` variant, and `UpdateCatalogOptions` gains a `now` field. Lands in the 2.0.0 line.
-* **po:** `CatalogMessageExtra`, `CatalogMessage::extra`, `CatalogMessageStatus::Fuzzy`, `CatalogAuditChecks::fuzzy_flags`, the `catalog.fuzzy_flag` diagnostic, and `CatalogLocaleCoverage::fuzzy` are removed; `CatalogOrigin` gains a required `scope` field; the FCL `tc=` and `f=` tags are removed. PO/FCL output no longer carries `fuzzy`/format flags and renders origins as `file#scope`. Lands in the 2.0.0 line.
+* **po:** `CatalogMessage::obsolete` is now `Option<ObsoleteInfo>` instead of `bool`, `ObsoleteStrategy` gains a non-`Copy` `DropObsoleteBefore(String)` variant, and `UpdateCatalogOptions` gains a `now` field.
+* **po:** `CatalogMessageExtra`, `CatalogMessage::extra`, `CatalogMessageStatus::Fuzzy`, `CatalogAuditChecks::fuzzy_flags`, the `catalog.fuzzy_flag` diagnostic, and `CatalogLocaleCoverage::fuzzy` are removed; `CatalogOrigin` gains a required `scope` field; the FCL `tc=` and `f=` tags are removed. PO/FCL output no longer carries `fuzzy`/format flags and renders origins as `file#scope`.
 * **po:** `MachineTranslationMetadata` (with `model`/`modified`/ `confidence: u8`/`hash`) is replaced by `MachineMetadata { lock, ai }` + `AiProvenance`; `CatalogMessage::machine_translation` is renamed to `machine`; `confidence` is now a `[0,1]` f32. PO machine metadata is written as `#@ lock:`/`#@ ai:` instead of `#@ ferrocat-mt`, and FCL as `lock=`/`ai=`.
+* **po:** `CatalogOrigin::line` and the `include_line_numbers` fields on `RenderOptions`, `CombineCatalogOptions`, and `CombineCatalogFilesOptions` are removed. Rendered references no longer include line numbers.
 * **po:** the NDJSON catalog storage format and its public types (NdjsonCatalogReader/Writer + options, CatalogStorageFormat::Ndjson, CatalogFileFormat::Ndjson, CatalogMode::IcuNdjson) are removed. Use FCL (CatalogMode::IcuFcl, .fcl files) instead.
+* **po:** `CatalogMessage::origin` is now `PoVec<CatalogOrigin>` (`SmallVec<[CatalogOrigin; 1]>`) instead of `Vec<CatalogOrigin>`. Reads are unaffected; constructing from a `Vec` now needs `.into()`.
+* **po:** `BorrowedPoItem::{references, comments, extracted_comments, flags, metadata}` are now `PoVec<Cow<'_, str>>` (`SmallVec<[_; 1]>`) instead of `Vec<Cow<'_, str>>`.
+* **po:** `PoItem::{references, comments, extracted_comments, flags, metadata}` are now `PoVec<T>` (`SmallVec<[T; 1]>`) instead of `Vec<T>`. Reads are unaffected; constructing from a `Vec` now needs `.into()`.
 
 ### Features
 


### PR DESCRIPTION
## Summary

- Fixes #187.
- Backfills the umbrella `ferrocat` 2.0.0 changelog with breaking changes inherited through re-exported PO API types.
- Removes leftover `Lands in the 2.0.0 line.` prose from released 2.0.0 changelog entries.

## Verification

- [x] `rg -n "Lands in the 2\\.0\\.0 line\\." crates/*/CHANGELOG.md` returned no matches
- [x] `git diff --check`
- [x] `git diff --check HEAD~1..HEAD`
- [ ] `cargo fmt --all --check` not run; changelog-only markdown change
- [ ] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` not run; changelog-only markdown change
- [ ] `cargo test --workspace --locked` not run; changelog-only markdown change

## Notes

- No code or public API changes.