### PR TITLE
perf(po): reduce parser and serializer allocations

### DIFF
--- a/crates/ferrocat-icu/src/analysis.rs
+++ b/crates/ferrocat-icu/src/analysis.rs
@@ -466,36 +466,36 @@ fn unique_names<'a>(names: impl IntoIterator<Item = &'a String>) -> Vec<String> 
     let mut seen = BTreeSet::new();
     let mut out = Vec::new();
     for name in names {
-        if seen.insert(name.clone()) {
+        if seen.insert(name.as_str()) {
             out.push(name.clone());
         }
     }
     out
 }
 
-fn argument_map(analysis: &IcuAnalysis) -> BTreeMap<String, IcuArgumentKind> {
+fn argument_map(analysis: &IcuAnalysis) -> BTreeMap<&str, IcuArgumentKind> {
     analysis
         .arguments
         .iter()
-        .map(|argument| (argument.name.clone(), argument.kind))
+        .map(|argument| (argument.name.as_str(), argument.kind))
         .collect()
 }
 
-fn formatter_map(analysis: &IcuAnalysis) -> BTreeMap<(String, IcuArgumentKind), Option<String>> {
+fn formatter_map(analysis: &IcuAnalysis) -> BTreeMap<(&str, IcuArgumentKind), Option<&str>> {
     analysis
         .formatters
         .iter()
         .map(|formatter| {
             (
-                (formatter.name.clone(), formatter.kind),
-                formatter.style.clone().map(|style| style.trim().to_owned()),
+                (formatter.name.as_str(), formatter.kind),
+                formatter.style.as_deref().map(str::trim),
             )
         })
         .collect()
 }
 
-fn selector_set(selectors: &[String]) -> BTreeSet<String> {
-    selectors.iter().cloned().collect()
+fn selector_set(selectors: &[String]) -> BTreeSet<&str> {
+    selectors.iter().map(String::as_str).collect()
 }
 
 fn formatter_style_label(style: Option<&str>) -> &str {
@@ -520,7 +520,7 @@ fn compare_arguments(
                 IcuDiagnosticSeverity::Error,
                 diagnostic_codes::icu::MISSING_ARGUMENT,
                 format!("Translation is missing ICU argument `{name}`."),
-                Some(name.clone()),
+                Some((*name).to_owned()),
             ));
             continue;
         };
@@ -531,7 +531,7 @@ fn compare_arguments(
                 format!(
                     "Translation changes ICU argument `{name}` from {source_kind:?} to {translation_kind:?}."
                 ),
-                Some(name.clone()),
+                Some((*name).to_owned()),
             ));
         }
     }
@@ -545,7 +545,7 @@ fn compare_arguments(
                     format!(
                         "Translation adds ICU argument `{name}` that is not present in source."
                     ),
-                    Some(name.clone()),
+                    Some((*name).to_owned()),
                 ));
             }
         }
@@ -561,7 +561,7 @@ fn compare_formatter_styles(
     let translation_formatters = formatter_map(translation);
 
     for ((name, kind), source_style) in source_formatters {
-        let Some(translation_style) = translation_formatters.get(&(name.clone(), kind)) else {
+        let Some(translation_style) = translation_formatters.get(&(name, kind)) else {
             continue;
         };
         if source_style != *translation_style {
@@ -571,16 +571,16 @@ fn compare_formatter_styles(
                 format!(
                     "Translation changes ICU formatter style for `{name}` from {source_style:?} to {translation_style:?}."
                 ),
-                Some(name),
+                Some(name.to_owned()),
             ));
         }
     }
 }
 
-fn tag_counts(analysis: &IcuAnalysis) -> BTreeMap<String, usize> {
+fn tag_counts(analysis: &IcuAnalysis) -> BTreeMap<&str, usize> {
     let mut counts = BTreeMap::new();
     for tag in &analysis.tags {
-        *counts.entry(tag.name.clone()).or_insert(0) += 1;
+        *counts.entry(tag.name.as_str()).or_insert(0) += 1;
     }
     counts
 }
@@ -600,7 +600,7 @@ fn compare_tags(
                 IcuDiagnosticSeverity::Error,
                 diagnostic_codes::icu::MISSING_TAG,
                 format!("Translation is missing ICU tag `{name}`."),
-                Some(name.clone()),
+                Some((*name).to_owned()),
             ));
         }
     }
@@ -612,17 +612,17 @@ fn compare_tags(
                     IcuDiagnosticSeverity::Error,
                     diagnostic_codes::icu::EXTRA_TAG,
                     format!("Translation adds ICU tag `{name}` that is not present in source."),
-                    Some(name.clone()),
+                    Some((*name).to_owned()),
                 ));
             }
         }
     }
 }
 
-fn select_map(analysis: &IcuAnalysis) -> BTreeMap<String, BTreeSet<String>> {
-    let mut out = BTreeMap::<String, BTreeSet<String>>::new();
+fn select_map(analysis: &IcuAnalysis) -> BTreeMap<&str, BTreeSet<&str>> {
+    let mut out = BTreeMap::<&str, BTreeSet<&str>>::new();
     for select in &analysis.selects {
-        out.entry(select.name.clone())
+        out.entry(select.name.as_str())
             .or_default()
             .extend(selector_set(&select.selectors));
     }
@@ -641,7 +641,7 @@ fn compare_selects(
         let Some(translation_selectors) = translation_selects.get(name) else {
             continue;
         };
-        for selector in source_selectors {
+        for &selector in source_selectors {
             if !translation_selectors.contains(selector) {
                 report.diagnostics.push(IcuDiagnostic::new(
                     IcuDiagnosticSeverity::Error,
@@ -654,7 +654,7 @@ fn compare_selects(
             }
         }
         if options.report_extra_selectors {
-            for selector in translation_selectors {
+            for &selector in translation_selectors {
                 if !source_selectors.contains(selector) {
                     report.diagnostics.push(IcuDiagnostic::new(
                         IcuDiagnosticSeverity::Warning,
@@ -668,15 +668,15 @@ fn compare_selects(
     }
 }
 
-fn plural_key(plural: &IcuPluralSummary) -> (String, IcuPluralKind) {
-    (plural.name.clone(), plural.kind.clone())
+fn plural_key(plural: &IcuPluralSummary) -> (&str, IcuPluralKind) {
+    (plural.name.as_str(), plural.kind.clone())
 }
 
-fn plural_map(analysis: &IcuAnalysis) -> BTreeMap<(String, IcuPluralKind), IcuPluralSummary> {
+fn plural_map(analysis: &IcuAnalysis) -> BTreeMap<(&str, IcuPluralKind), &IcuPluralSummary> {
     analysis
         .plurals
         .iter()
-        .map(|plural| (plural_key(plural), plural.clone()))
+        .map(|plural| (plural_key(plural), plural))
         .collect()
 }
 
@@ -706,6 +706,7 @@ fn compare_plurals(
 
         let translation_selectors = selector_set(&translation_plural.selectors);
         for selector in &source_plural.selectors {
+            let selector = selector.as_str();
             if !translation_selectors.contains(selector) {
                 report.diagnostics.push(IcuDiagnostic::new(
                     IcuDiagnosticSeverity::Error,

--- a/crates/ferrocat-icu/src/parser.rs
+++ b/crates/ferrocat-icu/src/parser.rs
@@ -563,6 +563,8 @@ mod tests {
         validate_icu,
     };
 
+    use super::find_literal_stop;
+
     #[test]
     fn parses_simple_argument_message() {
         let message = parse_icu("Hello {name}!").expect("parse");
@@ -732,6 +734,14 @@ mod tests {
             message.nodes,
             vec![IcuNode::Literal("Total # items".to_owned())]
         );
+    }
+
+    #[test]
+    fn literal_stop_search_ignores_markers_after_structural_stop() {
+        assert_eq!(find_literal_stop(b"abc{later#'", true), Some(3));
+        assert_eq!(find_literal_stop(b"abc#later{", true), Some(3));
+        assert_eq!(find_literal_stop(b"abc#later{", false), Some(9));
+        assert_eq!(find_literal_stop(b"abc'later{", true), Some(3));
     }
 
     #[test]

--- a/crates/ferrocat-icu/src/parser.rs
+++ b/crates/ferrocat-icu/src/parser.rs
@@ -536,10 +536,12 @@ fn has_other_clause(options: &[IcuOption]) -> bool {
 #[inline]
 fn find_literal_stop(haystack: &[u8], in_plural: bool) -> Option<usize> {
     let structural = memchr::memchr3(b'{', b'}', b'<', haystack);
-    let quote = memchr::memchr(b'\'', haystack);
+    let search_end = structural.unwrap_or(haystack.len());
+    let literal_prefix = &haystack[..search_end];
+    let quote = memchr::memchr(b'\'', literal_prefix);
     let stop = min_option(structural, quote);
     if in_plural {
-        min_option(stop, memchr::memchr(b'#', haystack))
+        min_option(stop, memchr::memchr(b'#', literal_prefix))
     } else {
         stop
     }

--- a/crates/ferrocat-po/src/parse.rs
+++ b/crates/ferrocat-po/src/parse.rs
@@ -500,7 +500,7 @@ fn trimmed_string(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{declared_charset, parse_po, parse_po_bytes};
+    use super::{declared_charset, find_ascii_case, parse_po, parse_po_bytes};
 
     const MULTI_LINE: &str = r#"# French translation of Link (6.x-2.9)
 # Copyright (c) 2011 by the French translation team
@@ -747,6 +747,17 @@ msgstr "Datei"
         let input = b"msgid \"\"\nmsgstr \"\"\n\"Content-Type: text/plain; CHARSET=utf8\\n\"\n\n";
 
         assert_eq!(declared_charset(input), Some("utf8"));
+    }
+
+    #[test]
+    fn ascii_case_search_matches_alpha_and_non_alpha_anchors() {
+        assert_eq!(
+            find_ascii_case(b"xxCONTENT-TYPE: text/plain", b"content-type:"),
+            Some(2)
+        );
+        assert_eq!(find_ascii_case(b"name=value", b"=VALUE"), Some(4));
+        assert_eq!(find_ascii_case(b"anything", b""), Some(0));
+        assert_eq!(find_ascii_case(b"anything", b"missing"), None);
     }
 
     #[test]

--- a/crates/ferrocat-po/src/parse.rs
+++ b/crates/ferrocat-po/src/parse.rs
@@ -1,4 +1,4 @@
-use memchr::memchr_iter;
+use memchr::{memchr_iter, memchr2_iter};
 
 use crate::line_state::{PoLineContext, PoLineState};
 use crate::scan::{
@@ -218,9 +218,23 @@ fn declared_charset(input: &[u8]) -> Option<&str> {
 }
 
 fn find_ascii_case(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window.eq_ignore_ascii_case(needle))
+    let Some((&first, rest)) = needle.split_first() else {
+        return Some(0);
+    };
+
+    let matches_at = |index: usize| {
+        haystack
+            .get(index + 1..index + 1 + rest.len())
+            .is_some_and(|tail| tail.eq_ignore_ascii_case(rest))
+    };
+
+    if first.is_ascii_alphabetic() {
+        let lower = first.to_ascii_lowercase();
+        let upper = first.to_ascii_uppercase();
+        memchr2_iter(lower, upper, haystack).find(|&index| matches_at(index))
+    } else {
+        memchr_iter(first, haystack).find(|&index| matches_at(index))
+    }
 }
 
 fn parse_line(
@@ -414,7 +428,7 @@ fn finish_item(state: &mut ParserState, file: &mut PoFile, current_nplurals: &mu
         state.item.msgstr = MsgStr::Singular(String::new());
     }
     if state.item.msgid_plural.is_some() && state.item.msgstr.len() == 1 {
-        let mut values = state.item.msgstr.clone().into_vec();
+        let mut values = core::mem::take(&mut state.item.msgstr).into_vec();
         values.resize(state.item.nplurals.max(1), String::new());
         state.item.msgstr = MsgStr::Plural(values);
     }

--- a/crates/ferrocat-po/src/scan.rs
+++ b/crates/ferrocat-po/src/scan.rs
@@ -427,6 +427,7 @@ mod tests {
         assert_eq!(split_once_byte(b"a:b", b':'), Some((&b"a"[..], &b"b"[..])));
         assert_eq!(find_quoted_bounds(br#"msgid "abc""#), Some((7, 10)));
         assert_eq!(find_escapable_byte(b"plain\ttext"), Some(5));
+        assert_eq!(find_escapable_byte(b"plain\tbefore\\later"), Some(5));
         assert_eq!(find_escapable_byte(b"plain\\text"), Some(5));
         assert_eq!(find_escapable_byte(b"plain text"), None);
         assert_eq!(parse_plural_index(b"msgstr[12] \"x\""), Some(12));

--- a/crates/ferrocat-po/src/scan.rs
+++ b/crates/ferrocat-po/src/scan.rs
@@ -48,10 +48,14 @@ mod backend {
 
     #[inline]
     fn fallback_find_escapable_byte(haystack: &[u8]) -> Option<usize> {
+        let structural = memchr3(b'"', b'\\', b'\n', haystack);
+        let search_end = structural.unwrap_or(haystack.len());
+        let controls = &haystack[..search_end];
+
         min_option3(
-            memchr3(b'"', b'\\', b'\n', haystack),
-            memchr3(b'\t', b'\r', b'\x0b', haystack),
-            memchr3(b'\x07', b'\x08', b'\x0c', haystack),
+            structural,
+            memchr3(b'\t', b'\r', b'\x0b', controls),
+            memchr3(b'\x07', b'\x08', b'\x0c', controls),
         )
     }
 

--- a/crates/ferrocat-po/src/serialize.rs
+++ b/crates/ferrocat-po/src/serialize.rs
@@ -503,9 +503,9 @@ fn clamp_char_boundary(input: &str, start: usize, requested_end: usize) -> usize
 
 #[cfg(test)]
 mod tests {
-    use crate::{Header, MsgStr, PoFile, PoItem, SerializeOptions, parse_po};
+    use crate::{Header, MsgStr, PoFile, PoItem, SerializeOptions, escape_string, parse_po};
 
-    use super::stringify_po;
+    use super::{escaped_string_len, stringify_po};
 
     #[test]
     fn serializes_comments_headers_and_items() {
@@ -631,6 +631,14 @@ mod tests {
         let reparsed = parse_po(&output).expect("reparse folded utf8 output");
         assert_eq!(reparsed.items[0].msgid, "Grüße aus Köln");
         assert_eq!(reparsed.items[0].msgstr[0], "Übermäßig höflich");
+    }
+
+    #[test]
+    fn escaped_string_len_matches_rendered_escape_length() {
+        let input = "plain\tquote\"slash\\newline\ncarriage\r";
+
+        assert_eq!(escaped_string_len(input), escape_string(input).len());
+        assert_eq!(escaped_string_len("plain"), "plain".len());
     }
 
     #[test]

--- a/crates/ferrocat-po/src/serialize.rs
+++ b/crates/ferrocat-po/src/serialize.rs
@@ -328,10 +328,9 @@ fn write_complex_keyword(
     } else {
         options.fold_length.saturating_sub(2).max(1)
     };
-    let parts = parts_with_has_next(text).collect::<Vec<_>>();
     let requires_folding = options.fold_length > 0
-        && parts.iter().any(|(part, has_next)| {
-            let escaped_len = escaped_part_len(part, *has_next);
+        && parts_with_has_next(text).any(|(part, has_next)| {
+            let escaped_len = escaped_part_len(part, has_next);
             let limit = if has_multiple_lines {
                 other_line_max
             } else {
@@ -351,7 +350,7 @@ fn write_complex_keyword(
         true
     };
 
-    for (part, has_next) in parts {
+    for (part, has_next) in parts_with_has_next(text) {
         scratch.clear();
         escape_string_into(scratch, part);
         if has_next {
@@ -429,16 +428,23 @@ fn write_quoted_segment(
 }
 
 fn escaped_part_len(part: &str, has_next: bool) -> usize {
-    let escaped_len = match find_escapable_byte(part.as_bytes()) {
-        Some(_) => {
-            let mut escaped = String::new();
-            escape_string_into(&mut escaped, part);
-            escaped.len()
-        }
-        None => part.len(),
-    };
+    let escaped_len = escaped_string_len(part);
 
     escaped_len + if has_next { 2 } else { 0 }
+}
+
+fn escaped_string_len(input: &str) -> usize {
+    let bytes = input.as_bytes();
+    let Some(mut escape_index) = find_escapable_byte(bytes) else {
+        return input.len();
+    };
+
+    let mut escaped_len = input.len() + 1;
+    while let Some(relative) = find_escapable_byte(&bytes[escape_index + 1..]) {
+        escape_index += 1 + relative;
+        escaped_len += 1;
+    }
+    escaped_len
 }
 
 fn folded_split_point(input: &str, start: usize, max_len: usize) -> usize {


### PR DESCRIPTION
## Summary

- Refs #189.
- Moves the owned parser plural-finalization path instead of cloning `MsgStr` before overwriting it.
- Uses a memchr-backed candidate scan for case-insensitive charset lookup.
- Bounds follow-up searches in ICU literal scanning and the PO fallback escape scanner to the first structural stop.
- Avoids serializer throwaway allocations for escaped-length measurement and removes an intermediate multiline-part `Vec`.
- Uses borrowed keys in ICU compatibility maps and sets where diagnostics only need owned strings at emission time.

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo test -p ferrocat-icu --all-features --locked`
- [x] `cargo test -p ferrocat-po --all-features --locked`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `git diff --check`

## Notes

- No public API changes.
- Local validation did not include a full before/after timing run. The PR benchmark workflow should run `rust-scheduled-v1` against the base and current branch; keep #189 open until that report is reviewed.