### PR TITLE
docs(readme): restructure project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,111 +11,6 @@ The practical problem is simple: translations change constantly, and most projec
 
 You do not need to know PO files, ICU MessageFormat, or FCL to get started. What matters is that the catalog stays inspectable, testable, benchmarked, and portable across host-language adapters, instead of disappearing into format-specific tooling.
 
-Ferrocat is also part of the [Palamedes](https://github.com/sebastian-software/palamedes) ecosystem. Palamedes is the OSS i18n framework for JavaScript and TypeScript apps; Ferrocat supplies the shared catalog engine underneath it: exact updates, storage choices, release QA, runtime artifact compilation, and clear boundaries between catalog data and application integration. JavaScript and TypeScript access is a Palamedes concern, including the `palamedes-node` N-API bridge in that repository; this repository stays the pure-Rust catalog engine.
-
-## What Ferrocat Gives You
-
-- **One reliable catalog core.** Keep source text, contexts, translations, notes, source origins such as `src/App.tsx#CheckoutButton` or `src/i18n.ts#formatInvoiceStatus`, plural forms, and obsolete entries in a model that application code can reason about.
-- **Predictable updates.** Merge newly extracted messages into existing catalogs without fuzzy guessing, hidden identity changes, or silent conflict resolution.
-- **Release-ready QA.** Audit catalog sets for missing locales, missing translations, empty translations, stale target messages, ICU mistakes, metadata conflicts, and obsolete entries.
-- **Coverage and review reports.** Turn catalog state into completion counters, translator handoff diffs, and machine-managed value freshness checks instead of rebuilding those rules in every host tool.
-- **Safer rich messages.** Analyze placeholders, formatters, plural/select branches, and rich-text tags so a translation cannot accidentally drop a required runtime value. Runtime-specific formatter support and literal-apostrophe policy stay explicit.
-- **AI-native metadata.** Tag any machine-written value (AI model, TMS, or a script) with a top-level integrity lock plus optional model and confidence. Ship it as-is by default; when a human corrects one, the lock stops matching, so your next re-translation run won't silently overwrite their fix.
-- **Runtime artifacts you can explain.** Compile catalogs into host-neutral payloads with stable keys, fallback behavior, missing reports, optional ICU diagnostics, and provenance rows that show where each runtime string came from.
-- **Pseudo-locale QA.** Generate ICU-aware pseudolocalized messages and runtime artifacts without damaging placeholders, plural selectors, rich-text tags, or formatter syntax.
-- **Storage that survives a merge.** Use PO when translator tooling reads the file directly, or FCL when several people and jobs touch the same locale: one canonical entry per line keeps ordinary git merges from losing untouched translations, and the file still parses about 45% faster and stores roughly 12% smaller than the same catalog as PO.
-- **Room for host frameworks.** Palamedes can own JS/TS extraction, bindings, and framework integration while Ferrocat owns the catalog behavior that should stay consistent underneath.
-- **Measured behavior.** Parser, serializer, merge, combine, audit, and runtime paths are covered by fixtures, 60 upstream-derived conformance cases (454 assertions), coverage gates, and PR-visible benchmark regression checks.
-
-## Technical Foundation
-
-Ferrocat is a new catalog layer, but it is not invented in a vacuum. It keeps the useful parts of established translation workflows and makes them available through a Rust API:
-
-- **PO catalogs** for translator-friendly source, translation, context, comment, origin, plural, and obsolete-entry handling.
-- **ICU MessageFormat v1** for richer messages with arguments, formatting, plurals, selects, and rich-text tags.
-- **FCL catalogs** (Ferrocat Catalog Lines): one entry per line, deterministically sorted, so ordinary git merges preserve untouched entries and surface same-entry edits as normal conflicts, while parsing about 45% faster and storing roughly 12% smaller than the same catalog as PO. The machine-owned format for Git review, automation, and pipelines.
-- **Machine-managed value metadata** for AI-assisted workflows: a top-level integrity lock that detects later by-hand edits to any machine-set value, so a re-translation pass leaves human corrections intact, plus optional AI provenance (model and confidence).
-- **Structured diagnostics** instead of ad hoc text output, so CI, editors, and host frameworks can consume the same report.
-
-## Where Ferrocat Fits
-
-Ferrocat is not trying to replace every part of an i18n stack. If you already know the existing landscape, this is the gap it fills:
-
-| Common approach | What works well | Where Ferrocat helps |
-|---|---|---|
-| GNU gettext-style tooling | Mature PO conventions, translator metadata, broad ecosystem familiarity | Rust-native APIs, explicit conflict policy, structured diagnostics, ICU-native workflows, and app-ready runtime artifacts |
-| Framework-specific i18n packages | Great authoring ergonomics and runtime adapters inside one host ecosystem | Shared catalog semantics that can be reused by Palamedes or other adapters instead of reimplemented per framework |
-| Custom JSON catalogs | Easy loading and deployment | Stronger update semantics, reviewable FCL storage, source/translation QA, and a path back to translator-friendly PO workflows |
-| ICU-only message handling | Powerful plural, select, formatter, and rich-text syntax | Structural analysis and compatibility checks that catch missing arguments, formatter drift, tag mismatch, and branch changes before shipping |
-
-Ferrocat does not currently ship first-party WebAssembly, N-API, Python, Go, or
-other host-language bindings from this repository. Host integration is layered
-on top of the Rust API: JS/TS applications should look to Palamedes and its
-`palamedes-node` bridge, while other ecosystems can use the Rust crates
-directly, the `ferrocat` CLI audit gate, or host-specific bindings maintained
-at that layer.
-
-## Performance
-
-V8 is not a slow target. Node's JIT is one of the fastest dynamic runtimes ever shipped, which is why most JavaScript and TypeScript i18n tooling feels fine until you measure it against compiled Rust. Ferrocat is that compiled Rust: byte-oriented scanning, zero-copy parsing, and a merge that moves data instead of cloning it. On the same 10k-message gettext catalog, every tool reading the same files (Apple M1 Ultra, median of 10 runs):
-
-| Workload | Ferrocat | pofile-ts (Node) | gettext/gettext (PHP) | polib (Python) | GNU msgmerge |
-|---|---:|---:|---:|---:|---:|
-| Parse | **455 MiB/s** | 145 | 49 | 20 | — |
-| Update with new strings | **192 MiB/s** | 40 | 16 | 7 | 4 |
-
-The Node baseline here is [pofile-ts](https://github.com/sebastian-software/pofile-ts), our own speed-focused fork of the widely used `pofile`. So the fastest JS PO parser in this table is one we built ourselves, and native Rust is still ~3x ahead of it. The original `pofile`, which `pofile-ts` forks and optimizes, parses at about 2 MiB/s on this corpus -- roughly 220x behind Ferrocat -- and that gap is exactly why the fork exists. We compare against the harder JS target on purpose.
-
-None of this comes free with picking Rust. The hot path is written by hand: memchr scanning, NEON SIMD on Apple Silicon, borrowed parsing that never copies the source, and a merge that moves data instead of cloning it. Months of low-level work you inherit the moment you add the crate.
-
-Read the parse row carefully: it is the *smallest* lead in the table, and that is the honest part. Parsing is mostly raw scanning, and a warm JIT is genuinely good at raw scanning, so beating the quickest Node parser by roughly 3x is the hard-won number, not the flattering one. The release-time job is harder. Updating a catalog means parsing the existing file, parsing the freshly extracted strings, merging by exact identity, and serializing the result. Once allocation and output dominate, the JIT's edge fades and the zero-copy, move-not-clone hot path pulls away, so the same engine that is ~3x ahead on parse runs roughly 5x ahead on update and more than 40x ahead of GNU `msgmerge`. The PHP and Python stacks have no JIT that helps here, which is why they trail by close to an order of magnitude even on parse. That `msgmerge` figure is not a startup artifact: the benchmark records an empty-run baseline, the fixed process and I/O overhead is about 2% of the measured time on these 10k corpora, and the overhead-adjusted number ships in the report.
-
-The parse row uses borrowed, zero-copy parsing; reading into a fully owned model still reaches 362 MiB/s. Serialization runs at about 1.16 GiB/s on the same corpus. The catalog-update comparison is strictly file-to-file (parse existing, parse freshly extracted strings, merge, serialize), so the numbers stay apples-to-apples. See the [benchmark methodology](https://sebastian-software.github.io/ferrocat/performance/benchmarking) and the checked-in reports under [`benchmark/results/`](benchmark/results) for the full matrix and host details.
-
-## Core Workflows
-
-Ferrocat focuses on the work that happens around real translation catalogs:
-
-- Parse and serialize PO files.
-- Merge existing catalogs with templates or newer catalogs.
-- Combine several catalogs while preserving existing translations first.
-- Validate plural behavior and catalog structure.
-- Analyze ICU message structure and compare source/translation compatibility.
-- Validate runtime-specific ICU formatter support and literal-apostrophe syntax policy.
-- Normalize semantic message metadata around `msgid + msgctxt`.
-- Preserve AI translation provenance in PO and FCL catalogs, including stale-metadata cleanup when translations are edited.
-- Audit catalog sets before release with structured diagnostics.
-- Summarize per-locale catalog coverage for dashboards and CI thresholds.
-- Compare catalog states for translator review handoffs.
-- Compile catalogs into runtime artifacts for application delivery, with optional provenance reports.
-- Generate ICU-aware pseudolocalized messages and runtime artifacts for UI/layout QA.
-- Compare performance and conformance behavior across fixtures, including PR regression checks for Rust-only benchmark scenarios.
-
-See the [API overview](https://sebastian-software.github.io/ferrocat/reference/api-overview) when you want the Rust entry points. The [Gettext task landscape](https://sebastian-software.github.io/ferrocat/reference/gettext-task-landscape) is a deeper reference for readers mapping long-standing command-line workflows to Ferrocat APIs.
-
-## Catalog Modes
-
-At the high-level catalog layer, `ferrocat` supports three explicit combinations of storage format and message semantics. You do not need to choose every mode on day one; the point is that migrations stay visible in code.
-
-| Mode | Storage format | Message model | Use when you want to... |
-|---|---|---|---|
-| Classic Gettext catalog mode | Gettext PO | Gettext-compatible plurals | stay close to traditional gettext catalogs and `msgid_plural` / `msgstr[n]` workflows |
-| ICU-native Gettext PO mode | Gettext PO | ICU MessageFormat | keep Gettext PO files and tooling, but author richer ICU plural/select/formatting messages |
-| ICU-native FCL catalog mode | FCL catalog storage | ICU MessageFormat | move to one-entry-per-line, tab-separated records that are easier to diff, merge, batch, and hand to external systems |
-
-There is intentionally no FCL + gettext-plural mode; gettext plural behavior stays a PO concern, while FCL (Ferrocat Catalog Lines) is the ICU-native machine storage format for ICU-native catalogs. Its line-oriented shape is especially useful when large teams edit catalogs through normal Git review flows: unrelated entries stay on separate lines, conflicts are narrower, unchanged entries stay byte-identical across merge inputs for clean git 3-way merges, and the format does not depend on a custom merge handler being available. Generate FCL through the catalog layer by choosing `CatalogMode::IcuFcl` in `parse_catalog`, `update_catalog`, or file-based update flows; keep PO when external translator tools need gettext compatibility.
-
-The canonical documentation now lives on the docs site:
-
-- [Docs homepage](https://sebastian-software.github.io/ferrocat/)
-- [Getting started](https://sebastian-software.github.io/ferrocat/guide/getting-started)
-- [Catalog modes](https://sebastian-software.github.io/ferrocat/guide/catalog-modes)
-- [Ferrocat and Palamedes](https://sebastian-software.github.io/ferrocat/guide/palamedes)
-- [API overview](https://sebastian-software.github.io/ferrocat/reference/api-overview)
-- [Gettext task landscape](https://sebastian-software.github.io/ferrocat/reference/gettext-task-landscape)
-- [Performance docs](https://sebastian-software.github.io/ferrocat/performance)
-- [ADR index](https://sebastian-software.github.io/ferrocat/architecture/adr)
-
 ## Install
 
 ```bash
@@ -135,12 +30,7 @@ cargo install ferrocat-cli
 ferrocat audit --source-locale en --source locales/en.po --target de=locales/de.po
 ```
 
-The `ferrocat-cli` GitHub release also publishes a prebuilt Linux musl archive
-for `x86_64-unknown-linux-musl`. The archive is named
-`ferrocat-<version>-x86_64-unknown-linux-musl.tar.gz` and contains the
-`ferrocat` binary plus license and README metadata. CI builds and tests the
-workspace for that target and smoke-tests the CLI before uploading the release
-asset.
+The `ferrocat-cli` GitHub release also publishes a prebuilt Linux musl archive for `x86_64-unknown-linux-musl`. The archive is named `ferrocat-<version>-x86_64-unknown-linux-musl.tar.gz` and contains the `ferrocat` binary plus license and README metadata.
 
 ## Quick Start
 
@@ -164,23 +54,82 @@ msgstr "world"
 }
 ```
 
-For the common "merge fresh extracted messages into an existing catalog" workflow, `merge_catalog` is the lean Gettext-style entry point. For N-way catalog overlays and `msgcat`-style set operations, use `combine_catalogs`; when the catalogs already live on disk, `combine_catalog_files` adds format inference and atomic output replacement around the same semantics. For release checks across a source catalog and target catalogs, use `audit_catalogs`. For dashboards or translator handoffs, use `catalog_coverage` and `catalog_review`. For application delivery, compile requested-locale artifacts with fallback and ICU diagnostics; use `compile_catalog_artifact_report` when host tooling also needs per-message resolution provenance without changing the runtime artifact shape. For richer high-level flows across PO and FCL storage, the docs site's [API overview](https://sebastian-software.github.io/ferrocat/reference/api-overview) is the best next stop.
+For the common "merge fresh extracted messages into an existing catalog" workflow, `merge_catalog` is the lean Gettext-style entry point. For N-way catalog overlays and `msgcat`-style set operations, use `combine_catalogs`; when catalogs already live on disk, `combine_catalog_files` adds format inference and atomic output replacement around the same semantics. For release checks across a source catalog and target catalogs, use `audit_catalogs`. For dashboards or translator handoffs, use `catalog_coverage` and `catalog_review`. For application delivery, compile requested-locale artifacts with fallback and ICU diagnostics; use `compile_catalog_artifact_report` when host tooling also needs per-message resolution provenance without changing the runtime artifact shape.
 
-Beyond the basics, Ferrocat exposes byte-oriented and allocation-light borrowed parsers for hot paths, ICU analysis and source/translation compatibility checks (`analyze_icu`, `compare_icu_messages`, `validate_icu_formatter_support`), ICU-aware pseudolocalization, semantic metadata normalization around `msgid + msgctxt`, and AI-translation metadata that high-level writers clear automatically once a human edits the text. ICU scope is MessageFormat v1; MessageFormat 2 is tracked as a future standard but is not a near-term target. The [API overview](https://sebastian-software.github.io/ferrocat/reference/api-overview) documents each entry point in depth.
+Beyond the basics, Ferrocat exposes byte-oriented and allocation-light borrowed parsers for hot paths, ICU analysis and source/translation compatibility checks (`analyze_icu`, `compare_icu_messages`, `validate_icu_formatter_support`), ICU-aware pseudolocalization, semantic metadata normalization around `msgid + msgctxt`, and AI-translation metadata that high-level writers clear automatically once a human edits the text. ICU scope is MessageFormat v1; MessageFormat 2 is tracked as a future standard but is not a near-term target.
+
+## What Ferrocat Gives You
+
+- **One reliable catalog core.** Keep source text, contexts, translations, notes, source origins such as `src/App.tsx#CheckoutButton` or `src/i18n.ts#formatInvoiceStatus`, plural forms, and obsolete entries in a model that application code can reason about.
+- **Predictable updates.** Merge newly extracted messages into existing catalogs without fuzzy guessing, hidden identity changes, or silent conflict resolution.
+- **Release-ready QA.** Audit catalog sets for missing locales, missing translations, empty translations, stale target messages, ICU mistakes, metadata conflicts, and obsolete entries.
+- **Coverage and review reports.** Turn catalog state into completion counters, translator handoff diffs, and machine-managed value freshness checks instead of rebuilding those rules in every host tool.
+- **Safer rich messages.** Analyze placeholders, formatters, plural/select branches, and rich-text tags so a translation cannot accidentally drop a required runtime value.
+- **AI-native metadata.** Tag any machine-written value with a top-level integrity lock plus optional model and confidence. Ship it as-is by default; when a human corrects one, the lock stops matching, so the next re-translation run will not silently overwrite their fix.
+- **Runtime artifacts you can explain.** Compile catalogs into host-neutral payloads with stable keys, fallback behavior, missing reports, optional ICU diagnostics, and provenance rows that show where each runtime string came from.
+- **Pseudo-locale QA.** Generate ICU-aware pseudolocalized messages and runtime artifacts without damaging placeholders, plural selectors, rich-text tags, or formatter syntax.
+- **Storage that survives a merge.** Use PO when translator tooling reads the file directly, or FCL when several people and jobs touch the same locale: one canonical entry per line keeps ordinary git merges from losing untouched translations.
+- **Room for host frameworks.** Palamedes can own JS/TS extraction, bindings, and framework integration while Ferrocat owns the catalog behavior that should stay consistent underneath.
+- **Measured behavior.** Parser, serializer, merge, combine, audit, and runtime paths are covered by fixtures, upstream-derived conformance cases, coverage gates, and PR-visible benchmark regression checks.
+
+Ferrocat is part of the [Palamedes](https://github.com/sebastian-software/palamedes) ecosystem. Palamedes is the OSS i18n framework for JavaScript and TypeScript apps; Ferrocat supplies the shared catalog engine underneath it. JavaScript and TypeScript access is a Palamedes concern, including the `palamedes-node` N-API bridge in that repository; this repository stays the pure-Rust catalog engine.
+
+## Technical Foundation
+
+Ferrocat is a new catalog layer, but it is not invented in a vacuum. It keeps the useful parts of established translation workflows and makes them available through a Rust API:
+
+- **PO catalogs** for translator-friendly source, translation, context, comment, origin, plural, and obsolete-entry handling.
+- **ICU MessageFormat v1** for richer messages with arguments, formatting, plurals, selects, and rich-text tags.
+- **FCL catalogs** (Ferrocat Catalog Lines) for Git review, automation, and pipelines: one entry per line, deterministically sorted, and designed to preserve unrelated edits during ordinary 3-way merges.
+- **Machine-managed value metadata** for AI-assisted workflows: a top-level integrity lock that detects later by-hand edits to any machine-set value, plus optional AI provenance.
+- **Structured diagnostics** instead of ad hoc text output, so CI, editors, and host frameworks can consume the same report.
+
+## Where Ferrocat Fits
+
+Ferrocat is not trying to replace every part of an i18n stack. If you already know the existing landscape, this is the gap it fills:
+
+| Common approach | What works well | Where Ferrocat helps |
+|---|---|---|
+| GNU gettext-style tooling | Mature PO conventions, translator metadata, broad ecosystem familiarity | Rust-native APIs, explicit conflict policy, structured diagnostics, ICU-native workflows, and app-ready runtime artifacts |
+| Framework-specific i18n packages | Great authoring ergonomics and runtime adapters inside one host ecosystem | Shared catalog semantics that can be reused by Palamedes or other adapters instead of reimplemented per framework |
+| Custom JSON catalogs | Easy loading and deployment | Stronger update semantics, reviewable FCL storage, source/translation QA, and a path back to translator-friendly PO workflows |
+| ICU-only message handling | Powerful plural, select, formatter, and rich-text syntax | Structural analysis and compatibility checks that catch missing arguments, formatter drift, tag mismatch, and branch changes before shipping |
+
+Ferrocat does not currently ship first-party WebAssembly, N-API, Python, Go, or other host-language bindings from this repository. Host integration is layered on top of the Rust API: JS/TS applications should look to Palamedes and its `palamedes-node` bridge, while other ecosystems can use the Rust crates directly, the `ferrocat` CLI audit gate, or host-specific bindings maintained at that layer.
+
+## Performance
+
+Ferrocat's benchmark suite compares file-to-file catalog workloads against common PO libraries and tools on the same fixtures. The published table below uses the 10k-message gettext catalog from the checked-in benchmark reports (Apple M1 Ultra, median of 10 runs):
+
+| Workload | Ferrocat | pofile-ts (Node) | gettext/gettext (PHP) | polib (Python) | GNU msgmerge |
+|---|---:|---:|---:|---:|---:|
+| Parse | **455 MiB/s** | 145 | 49 | 20 | - |
+| Update with new strings | **192 MiB/s** | 40 | 16 | 7 | 4 |
+
+The Node baseline is [pofile-ts](https://github.com/sebastian-software/pofile-ts), a speed-focused fork of the widely used `pofile`, so the JavaScript comparison targets a fast implementation rather than an easy one. The update benchmark parses existing and freshly extracted files, merges by exact identity, and serializes the result, which is where Ferrocat's byte-oriented scanning and move-not-clone catalog paths matter most.
+
+See the [benchmark methodology](https://sebastian-software.github.io/ferrocat/performance/benchmarking) and the checked-in reports under [`benchmark/results/`](benchmark/results) for host details, fixture definitions, noise handling, and the full matrix.
+
+## Catalog Modes
+
+At the high-level catalog layer, `ferrocat` supports three explicit combinations of storage format and message semantics. You do not need to choose every mode on day one; the point is that migrations stay visible in code.
+
+| Mode | Storage format | Message model | Use when you want to... |
+|---|---|---|---|
+| Classic Gettext catalog mode | Gettext PO | Gettext-compatible plurals | stay close to traditional gettext catalogs and `msgid_plural` / `msgstr[n]` workflows |
+| ICU-native Gettext PO mode | Gettext PO | ICU MessageFormat | keep Gettext PO files and tooling, but author richer ICU plural/select/formatting messages |
+| ICU-native FCL catalog mode | FCL catalog storage | ICU MessageFormat | move to one-entry-per-line, tab-separated records that are easier to diff, merge, batch, and hand to external systems |
+
+There is intentionally no FCL + gettext-plural mode; gettext plural behavior stays a PO concern, while FCL is the ICU-native machine storage format for ICU-native catalogs. Generate FCL through the catalog layer by choosing `CatalogMode::IcuFcl` in `parse_catalog`, `update_catalog`, or file-based update flows; keep PO when external translator tools need gettext compatibility. The in-repo [FCL format specification](docs/fcl-format.md) documents the exact line format, escaping rules, and architecture decisions behind that storage mode.
 
 ## Compatibility Snapshot
 
 - **MSRV:** Rust `1.93.0`
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
-- **MSRV bumps:** raising the MSRV is treated as a minor-version change and
-  called out in the changelog; patch releases do not raise the MSRV.
-- **Prebuilt CLI target:** `x86_64-unknown-linux-musl` is validated in CI and
-  published as a smoke-tested GitHub Release archive for `ferrocat-cli`.
+- **MSRV bumps:** raising the MSRV is treated as a minor-version change and called out in the changelog; patch releases do not raise the MSRV
+- **Prebuilt CLI target:** `x86_64-unknown-linux-musl` is validated in CI and published as a smoke-tested GitHub Release archive for `ferrocat-cli`
 - **Semver:** the public API follows semantic versioning; breaking changes ship in a new major version and are documented in the changelog
-- **Error surface:** PO parse errors stay intentionally compact but expose
-  `message()` plus optional `position()` metadata. Positions include a
-  zero-based byte offset and one-based line/column when the parser can attach
-  source context.
+- **Error surface:** PO parse errors stay intentionally compact but expose `message()` plus optional `position()` metadata with zero-based byte offset and one-based line/column when source context is available
 - **Documentation surface:** README examples, rustdoc examples, and the docs site aim to stay aligned
 
 ## Docs Paths
@@ -188,6 +137,8 @@ Beyond the basics, Ferrocat exposes byte-oriented and allocation-light borrowed 
 If you already know what kind of question you have, these are the fastest entry points:
 
 - [Getting started](https://sebastian-software.github.io/ferrocat/guide/getting-started) for installation, quick start, and the main next steps
+- [Catalog modes](https://sebastian-software.github.io/ferrocat/guide/catalog-modes) for choosing PO or FCL storage with gettext or ICU message semantics
+- [FCL format specification](docs/fcl-format.md) for the repository-local line format and escaping reference
 - [Ferrocat and Palamedes](https://sebastian-software.github.io/ferrocat/guide/palamedes) for the relationship between the catalog engine and the JS/TS i18n framework
 - [Releases and upgrading](https://sebastian-software.github.io/ferrocat/guide/upgrading) for changelogs, lockstep versions, and safe upgrades
 - [API overview](https://sebastian-software.github.io/ferrocat/reference/api-overview) for choosing between PO core, catalog workflows, and ICU helpers

--- a/crates/ferrocat-po/README.md
+++ b/crates/ferrocat-po/README.md
@@ -20,6 +20,8 @@ At the catalog layer, it supports three explicit modes:
 
 `FCL + gettext-compatible plurals` is intentionally unsupported.
 
+See the repository's [FCL format specification](../../docs/fcl-format.md) for the line format and escaping rules behind ICU-native FCL storage.
+
 Use this crate when you want that surface directly:
 
 - `parse_po` / `parse_po_borrowed` for raw PO parsing

--- a/crates/ferrocat/README.md
+++ b/crates/ferrocat/README.md
@@ -7,8 +7,6 @@ Public umbrella crate for the `ferrocat` workspace.
 
 Ferrocat is a Rust-native translation catalog engine. It gives applications and host-language adapters one place to parse, update, audit, validate, and compile translation catalogs into runtime-ready data.
 
-Patch releases may also carry workspace dependency and release-maintenance refreshes that keep the published crate set reproducible.
-
 Add it with:
 
 ```bash
@@ -33,6 +31,8 @@ At the catalog layer, `ferrocat` supports three explicit modes:
 - ICU-native FCL catalog mode: FCL (Ferrocat Catalog Lines) storage + ICU MessageFormat
 
 `FCL + gettext-compatible plurals` is intentionally unsupported.
+
+See the repository's [FCL format specification](../../docs/fcl-format.md) for the line format and escaping rules behind ICU-native FCL storage.
 
 Repository, docs, and contribution guidelines:
 


### PR DESCRIPTION
## Summary

- Fixes #194.
- Refs #195 for README-level FCL spec discoverability.
- Moves install and quick start directly after the opening context.
- Collapses repeated docs link lists and removes duplicated FCL/performance claims.
- Tightens the performance section to the benchmark table, concise context, and methodology links.
- Removes fast-aging exact prose numbers where generated reports are the better source.
- Links the in-repo FCL format specification from the root and crate READMEs.

## Verification

- [x] `git diff --check`
- [x] relative FCL spec links resolve from `crates/ferrocat/README.md` and `crates/ferrocat-po/README.md`
- [x] `cargo test -p ferrocat --doc --all-features --locked`
- [x] `cargo package -p ferrocat -p ferrocat-po --locked`

## Notes

- This PR intentionally keeps rustdoc examples and `docs/fcl-format.md` ADR link fixes out of scope; those are handled separately for #195.