### PR TITLE
docs(api): expand rustdoc examples and fcl links

### DIFF
--- a/crates/ferrocat-icu/src/analysis.rs
+++ b/crates/ferrocat-icu/src/analysis.rs
@@ -236,6 +236,33 @@ impl IcuCompatibilityReport {
 }
 
 /// Produces a structural summary of a parsed ICU message.
+///
+/// The summary preserves first-seen occurrences for data arguments, formatter
+/// arguments, plural/select expressions, and rich-text tags. Use it when a tool
+/// needs to inspect authoring structure without rendering or normalizing the
+/// original message text.
+///
+/// # Examples
+///
+/// ```rust
+/// use ferrocat_icu::{IcuArgumentKind, IcuStyleKind, analyze_icu, parse_icu};
+///
+/// let message = parse_icu(
+///     "Hi <bold>{name}</bold>, {count, plural, one {# file} other {# files}} \
+///      due {due, date, ::yMMMd}",
+/// )?;
+/// let analysis = analyze_icu(&message);
+///
+/// assert!(analysis.arguments.iter().any(|arg| arg.name == "name"));
+/// assert!(analysis.plurals.iter().any(|plural| plural.name == "count"));
+/// assert!(analysis.tags.iter().any(|tag| tag.name == "bold"));
+/// assert!(analysis.formatters.iter().any(|formatter| {
+///     formatter.name == "due"
+///         && formatter.kind == IcuArgumentKind::Date
+///         && formatter.style_kind == IcuStyleKind::Skeleton
+/// }));
+/// # Ok::<(), ferrocat_icu::IcuParseError>(())
+/// ```
 #[must_use]
 pub fn analyze_icu(message: &IcuMessage) -> IcuAnalysis {
     let mut analysis = IcuAnalysis::default();
@@ -317,6 +344,29 @@ pub fn validate_icu_formatter_support_from_analysis(
 }
 
 /// Compares source and translation ICU messages for authoring compatibility.
+///
+/// The comparison checks whether the translation keeps source-required data
+/// arguments, rich-text tags, formatter roles and styles, select selectors, and
+/// plural structure. Optional settings control whether translation-only
+/// arguments, tags, selectors, and opaque pattern styles are reported.
+///
+/// # Examples
+///
+/// ```rust
+/// use ferrocat_icu::{IcuCompatibilityOptions, compare_icu_messages, parse_icu};
+///
+/// let source = parse_icu("Hello {name}, you have <strong>{count}</strong> files")?;
+/// let translation = parse_icu("Hallo {name}, du hast {count} Dateien")?;
+///
+/// let report = compare_icu_messages(&source, &translation, &IcuCompatibilityOptions::default());
+///
+/// assert!(report.has_errors());
+/// assert!(report
+///     .diagnostics
+///     .iter()
+///     .any(|diagnostic| diagnostic.name.as_deref() == Some("strong")));
+/// # Ok::<(), ferrocat_icu::IcuParseError>(())
+/// ```
 #[must_use]
 pub fn compare_icu_messages(
     source: &IcuMessage,

--- a/crates/ferrocat-po/src/api/coverage.rs
+++ b/crates/ferrocat-po/src/api/coverage.rs
@@ -116,6 +116,35 @@ pub struct CatalogCoverageMessage {
 /// Active target-only messages are counted as `extra` and do not affect the
 /// completion denominator.
 ///
+/// # Examples
+///
+/// ```rust
+/// use ferrocat_po::{
+///     CatalogCoverageOptions, CatalogMessageStatus, ParseCatalogOptions, catalog_coverage,
+///     parse_catalog,
+/// };
+///
+/// let source = parse_catalog(ParseCatalogOptions {
+///     locale: Some("en"),
+///     ..ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"\"\n", "en")
+/// })?
+/// .into_normalized_view()?;
+/// let target = parse_catalog(ParseCatalogOptions {
+///     locale: Some("de"),
+///     ..ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"Speichern\"\n", "en")
+/// })?
+/// .into_normalized_view()?;
+///
+/// let options = CatalogCoverageOptions::new("en").with_details(true);
+/// let report = catalog_coverage(&[&source, &target], &options)?;
+///
+/// assert_eq!(report.source_messages, 1);
+/// assert_eq!(report.locales[0].locale, "de");
+/// assert_eq!(report.locales[0].translated, 1);
+/// assert_eq!(report.locales[0].details[0].status, CatalogMessageStatus::Translated);
+/// # Ok::<(), ferrocat_po::ApiError>(())
+/// ```
+///
 /// # Errors
 ///
 /// Returns [`ApiError::InvalidArguments`] when locales are missing, empty,

--- a/crates/ferrocat-po/src/api/review.rs
+++ b/crates/ferrocat-po/src/api/review.rs
@@ -224,6 +224,52 @@ pub enum CatalogMachineTranslationStatus {
 /// target status is [`CatalogMessageStatus::Translated`]; missing, empty, and
 /// obsolete current entries are surfaced by the coverage counters.
 ///
+/// # Examples
+///
+/// ```rust
+/// use ferrocat_po::{CatalogReviewOptions, ParseCatalogOptions, catalog_review, parse_catalog};
+///
+/// let previous_source = parse_catalog(ParseCatalogOptions {
+///     locale: Some("en"),
+///     ..ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"\"\n", "en")
+/// })?
+/// .into_normalized_view()?;
+/// let previous_target = parse_catalog(ParseCatalogOptions {
+///     locale: Some("de"),
+///     ..ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"Speichern\"\n", "en")
+/// })?
+/// .into_normalized_view()?;
+///
+/// let current_source = parse_catalog(ParseCatalogOptions {
+///     locale: Some("en"),
+///     ..ParseCatalogOptions::new(
+///         "msgid \"Save\"\nmsgstr \"\"\n\nmsgid \"Cancel\"\nmsgstr \"\"\n",
+///         "en",
+///     )
+/// })?
+/// .into_normalized_view()?;
+/// let current_target = parse_catalog(ParseCatalogOptions {
+///     locale: Some("de"),
+///     ..ParseCatalogOptions::new(
+///         "msgid \"Save\"\nmsgstr \"Sichern\"\n\nmsgid \"Cancel\"\nmsgstr \"\"\n",
+///         "en",
+///     )
+/// })?
+/// .into_normalized_view()?;
+///
+/// let options = CatalogReviewOptions::new("en").with_details(true);
+/// let report = catalog_review(
+///     &[&previous_source, &previous_target],
+///     &[&current_source, &current_target],
+///     &options,
+/// )?;
+///
+/// assert_eq!(report.summary.source_added, 1);
+/// assert_eq!(report.summary.translation_changed, 1);
+/// assert_eq!(report.locales[0].coverage.empty, 1);
+/// # Ok::<(), ferrocat_po::ApiError>(())
+/// ```
+///
 /// # Errors
 ///
 /// Returns [`ApiError::InvalidArguments`] when either catalog state is missing

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -190,7 +190,13 @@ pub struct PoItem {
     pub comments: PoVec<String>,
     /// Extracted comments attached to the item.
     pub extracted_comments: PoVec<String>,
-    /// Flags such as `fuzzy`.
+    /// Raw gettext flags such as `fuzzy`.
+    ///
+    /// The low-level PO parser and serializer preserve this field for faithful
+    /// PO round trips. Since Ferrocat 2.0, the high-level catalog layer drops
+    /// gettext flags, including `fuzzy`, when parsing or writing catalog data;
+    /// fuzzy/discard decisions are modeled by catalog-layer behavior instead
+    /// of being carried through this raw PO field.
     pub flags: PoVec<String>,
     /// Raw metadata lines that do not fit the dedicated fields.
     pub metadata: PoVec<(String, String)>,

--- a/docs/fcl-format.md
+++ b/docs/fcl-format.md
@@ -92,17 +92,17 @@ Use names a developer would recognize in source code:
 Scope is metadata for review and tooling, not message identity, and it is not a
 replacement for gettext context / `msgctxt`; downstream tools should not derive
 it from `msgctxt` by default. See
-[ADR 0024](/architecture/adr/0024-origin-scope-anchor). `c` holds free-form
+[ADR 0024](app/routes/architecture/adr/0024-origin-scope-anchor.mdx). `c` holds free-form
 notes: the gettext extracted (`#.`) and translator (`#`) comment kinds collapse
 into one list, and gettext flags (`fuzzy`, `*-format`) are not carried (see
-[ADR 0023](/architecture/adr/0023-drop-gettext-flags-merge-comments)).
+[ADR 0023](app/routes/architecture/adr/0023-drop-gettext-flags-merge-comments.mdx)).
 
 `lock` is the fingerprint of the value when a machine (AI engine, TMS, script)
 set it; if `hash(current value) != lock`, a human edited it and high-level
 writers drop the block. `ai` is optional provenance: an opaque `model` id, then
 an optional `:confidence` decimal in `[0, 1]`. The model id is free-form and may
 contain `/` or `:`; only a trailing `[0, 1]` suffix after the last `:` is read as
-confidence (see [ADR 0022](/architecture/adr/0022-machine-managed-value-integrity-and-ai-provenance)).
+confidence (see [ADR 0022](app/routes/architecture/adr/0022-machine-managed-value-integrity-and-ai-provenance.mdx)).
 
 **Deliberately omitted:** a machine-translation timestamp. Timestamps churn every
 line on regeneration and poison merges; staleness is detected by the `lock` hash


### PR DESCRIPTION
## Summary

- Refs #195.
- Fixes broken ADR links in `docs/fcl-format.md` with repository-relative MDX paths.
- Adds rustdoc examples for `catalog_coverage` and `catalog_review`.
- Expands `analyze_icu` and `compare_icu_messages` docs with usage examples.
- Clarifies that `PoItem::flags` is preserved by the low-level PO layer while the high-level catalog layer drops gettext flags since 2.0.

## Verification

- [x] `cargo fmt --all --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p ferrocat-po -p ferrocat-icu --all-features --no-deps --locked`
- [x] `cargo test -p ferrocat-po -p ferrocat-icu --doc --all-features --locked`
- [x] `git diff --check`

## Notes

- README-level FCL spec discoverability is handled in #199 to avoid conflicting README edits.
- This PR intentionally does not change `missing_docs` policy.