### PR TITLE
docs(features): clarify current feature profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ At the high-level catalog layer, `ferrocat` supports three explicit combinations
 
 There is intentionally no FCL + gettext-plural mode; gettext plural behavior stays a PO concern, while FCL is the ICU-native machine storage format for ICU-native catalogs. Generate FCL through the catalog layer by choosing `CatalogMode::IcuFcl` in `parse_catalog`, `update_catalog`, or file-based update flows; keep PO when external translator tools need gettext compatibility. The in-repo [FCL format specification](docs/fcl-format.md) documents the exact line format, escaping rules, and architecture decisions behind that storage mode.
 
+## Feature Profiles
+
+The published crates default to the full current API surface. Use
+`default-features = false` when you want the low-level PO and ICU parsers without
+the catalog workflow layer.
+
+- `catalog` enables high-level catalog parsing, updates, combining, audits,
+  machine-translation metadata, plural handling, FCL storage, and runtime
+  artifact compilation.
+- `serde` enables serialization support for tooling, cache, schema, report, and
+  runtime artifact shapes.
+- `compile`, `mt`, and `plurals` are reserved subsystem aliases that currently
+  imply `catalog`; they do not reduce or split the catalog API surface yet.
+
+See the [API overview](https://sebastian-software.github.io/ferrocat/reference/api-overview#feature-profiles)
+for the crate-by-crate feature profile details.
+
 ## Compatibility Snapshot
 
 - **MSRV:** Rust `1.93.0`

--- a/crates/ferrocat-po/Cargo.toml
+++ b/crates/ferrocat-po/Cargo.toml
@@ -46,6 +46,7 @@ tempfile = { version = "3.23.0", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
 ferrocat-conformance = { path = "../ferrocat-conformance" }

--- a/crates/ferrocat-po/README.md
+++ b/crates/ferrocat-po/README.md
@@ -12,6 +12,24 @@ cargo add ferrocat-po
 
 This crate covers both the low-level PO surface and the higher-level catalog layer. For PO-only dependency profiles, disable default features.
 
+## Feature flags
+
+`ferrocat-po` enables `full` by default. `full` currently means `catalog`, so the
+default build exposes the complete current PO and catalog API surface.
+
+- `catalog`: high-level catalog parse, update, combine, audit, metadata, FCL,
+  plural, and runtime compile APIs, plus their hashing, tempfile, serde JSON,
+  ICU, and CLDR plural-data dependencies
+- `serde`: serde support for low-level PO document types; `catalog` also enables
+  it for catalog-layer JSON/report shapes
+- `compile`, `mt`, and `plurals`: reserved subsystem aliases that currently
+  imply `catalog`; they do not reduce or split the catalog API surface yet
+
+Use `default-features = false` for the low-level PO parser, borrowed parser,
+serializer, string helpers, and lightweight `merge_catalog` helper without
+catalog-layer dependencies. Enabling `compile`, `mt`, or `plurals` currently has
+the same dependency effect as enabling `catalog`.
+
 At the catalog layer, it supports three explicit modes:
 
 - classic Gettext catalog mode: Gettext PO + gettext-compatible plurals

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -1,9 +1,30 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rustdoc::broken_intra_doc_links)]
 //! Performance-first PO parsing and serialization.
 //!
 //! The crate exposes both owned and borrowed parsers for gettext PO files,
 //! a byte-oriented UTF-8 parser entry point, plus helpers for serialization
 //! and higher-level catalog update workflows.
+//!
+//! # Feature flags
+//!
+//! The default feature set is `full`, which currently enables the `catalog`
+//! workflow layer.
+//!
+//! - `catalog` exposes high-level catalog parsing, updates, combining, audits,
+//!   machine-translation metadata, plural handling, FCL storage, and runtime
+//!   artifact compilation. It also enables the catalog-layer dependencies used
+//!   for hashing, atomic file updates, serde JSON output, ICU diagnostics, and
+//!   CLDR plural data.
+//! - `serde` enables serde implementations for low-level PO document types and
+//!   is also enabled by `catalog` for catalog-layer JSON/report shapes.
+//! - `compile`, `mt`, and `plurals` are reserved subsystem aliases. Today they
+//!   imply `catalog`; they do not reduce or split the catalog API surface.
+//!
+//! Use `default-features = false` for the low-level PO parser, borrowed parser,
+//! serializer, string helpers, and lightweight `merge_catalog` helper without
+//! catalog-layer dependencies. Enabling `compile`, `mt`, or `plurals` currently
+//! has the same dependency effect as enabling `catalog`.
 //!
 //! # Examples
 //!
@@ -77,6 +98,7 @@
 //! ```
 
 #[cfg(feature = "catalog")]
+#[cfg_attr(docsrs, doc(cfg(feature = "catalog")))]
 mod api;
 mod borrowed;
 pub mod diagnostic_codes;
@@ -89,6 +111,7 @@ mod text;
 mod utf8;
 
 #[cfg(feature = "catalog")]
+#[cfg_attr(docsrs, doc(cfg(feature = "catalog")))]
 pub use api::{
     AiProvenance, ApiError, COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION, CatalogAuditChecks,
     CatalogAuditDiagnostic, CatalogAuditIcuOptions, CatalogAuditMessageRef, CatalogAuditOptions,

--- a/crates/ferrocat/Cargo.toml
+++ b/crates/ferrocat/Cargo.toml
@@ -30,6 +30,7 @@ ferrocat-po = { version = "2.0.0", path = "../ferrocat-po", default-features = f
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/crates/ferrocat/README.md
+++ b/crates/ferrocat/README.md
@@ -15,6 +15,22 @@ cargo add ferrocat
 
 It re-exports the stable Rust API from `ferrocat-po` and `ferrocat-icu`.
 
+## Feature flags
+
+`ferrocat` enables `full` by default. `full` currently means `catalog` plus
+`serde`, so the default build exposes the complete current API surface.
+
+- `catalog`: high-level catalog parse, update, combine, audit, metadata, FCL,
+  plural, and runtime compile APIs
+- `serde`: serde support in the re-exported `ferrocat-po` and `ferrocat-icu`
+  types
+- `compile`, `mt`, and `plurals`: reserved subsystem aliases that currently
+  imply `catalog`; they do not reduce or split the catalog API surface yet
+
+Use `default-features = false` for low-level PO and ICU parsing without the
+catalog layer. Enabling `compile`, `mt`, or `plurals` currently has the same
+dependency effect as enabling `catalog`.
+
 Use the umbrella crate when you want one dependency for the full catalog workflow:
 
 - translator-friendly catalog parsing and serialization

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -1,9 +1,27 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rustdoc::broken_intra_doc_links)]
 //! Public Rust entry point for the `ferrocat` workspace.
 //!
 //! This crate re-exports the primary API surface from the lower-level
 //! `ferrocat-po` and `ferrocat-icu` crates so application code can depend on a
 //! single package.
+//!
+//! # Feature flags
+//!
+//! The default feature set is `full`, which enables the complete current API
+//! surface through `catalog` and `serde`.
+//!
+//! - `catalog` exposes high-level catalog parsing, updates, combining, audits,
+//!   machine-translation metadata, plural handling, FCL storage, and runtime
+//!   artifact compilation.
+//! - `serde` enables serde support in the re-exported `ferrocat-po` and
+//!   `ferrocat-icu` types.
+//! - `compile`, `mt`, and `plurals` are reserved subsystem aliases. Today they
+//!   imply `catalog`; they do not reduce or split the catalog API surface.
+//!
+//! Use `default-features = false` for low-level PO and ICU parsing without the
+//! catalog layer. Enabling `compile`, `mt`, or `plurals` currently has the same
+//! dependency effect as enabling `catalog`.
 //!
 //! # Examples
 //!
@@ -69,6 +87,7 @@
 
 /// High-level catalog maintenance, audit, and runtime artifact APIs.
 #[cfg(feature = "catalog")]
+#[cfg_attr(docsrs, doc(cfg(feature = "catalog")))]
 pub mod catalog {
     pub use ferrocat_po::diagnostic_codes;
     pub use ferrocat_po::{
@@ -166,6 +185,7 @@ pub use ferrocat_icu::{
 };
 
 #[cfg(feature = "catalog")]
+#[cfg_attr(docsrs, doc(cfg(feature = "catalog")))]
 /// JSON schema version emitted by [`CompiledCatalogArtifact`] serialization.
 pub const COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION: u16 =
     ferrocat_po::COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION;
@@ -176,6 +196,7 @@ pub const COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION: u16 =
 )]
 pub use ferrocat_po::MergeExtractedMessage;
 #[cfg(feature = "catalog")]
+#[cfg_attr(docsrs, doc(cfg(feature = "catalog")))]
 pub use ferrocat_po::{
     AiProvenance, ApiError, CatalogAuditChecks, CatalogAuditDiagnostic, CatalogAuditIcuOptions,
     CatalogAuditMessageRef, CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary,

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -37,14 +37,18 @@ profiles instead of moving it to a separate crate.
 
 The named feature profiles are:
 
-- `full`: the default profile with the complete current API surface
+- `default`: enables `full` on `ferrocat` and `ferrocat-po`
+- `full`: the default profile with the complete current API surface; on
+  `ferrocat`, this means `catalog` plus `serde`, while on `ferrocat-po` it means
+  `catalog`
 - `catalog`: high-level catalog update, parse, combine, audit, metadata, FCL,
   plural, and runtime compile support
 - `serde`: serde implementations used by schema, cache, and tooling-oriented
   consumers; it can be enabled without the full catalog profile for low-level PO
   document types
-- `compile`, `mt`, `fcl`, and `plurals`: named subsystem profiles reserved for
-  callers that want to declare intent explicitly
+- `compile`, `mt`, and `plurals`: reserved subsystem aliases that currently imply
+  `catalog`; they let callers declare intent explicitly, but they do not reduce
+  or split the catalog API surface yet
 
 `docs.rs` builds with all features enabled so the rendered reference shows the
 full API surface.


### PR DESCRIPTION
## Summary

- document the current feature profiles in the root README, crate READMEs, and crate-level rustdoc
- add docs.rs metadata plus `doc(cfg)` annotations for catalog-gated exports
- clarify that `compile`, `mt`, and `plurals` are reserved aliases that currently imply `catalog`, not reduced build profiles

Refs #193.

## Validation

- `cargo fmt --all --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p ferrocat -p ferrocat-po --all-features --no-deps --locked`
- `cargo test -p ferrocat -p ferrocat-po --doc --all-features --locked`
- `git diff --check`
- `pnpm build` from `docs/`

## Notes

This intentionally does not make `compile`, `mt`, or `plurals` real gates and does not add feature-matrix CI. Those remain separate packaging/CI decisions.
