### PR TITLE
perf(po): avoid helper and combine clone churn

### DIFF
--- a/crates/ferrocat-po/src/api/combine.rs
+++ b/crates/ferrocat-po/src/api/combine.rs
@@ -78,7 +78,7 @@ struct CombineState {
     file_extracted_comments: Vec<String>,
     inferred_locale: Option<String>,
     entries: Vec<CombineEntry>,
-    index: BTreeMap<(String, Option<String>), usize>,
+    index: BTreeMap<String, BTreeMap<Option<String>, usize>>,
     stats: CatalogCombineStats,
     labels: Vec<String>,
 }
@@ -146,9 +146,8 @@ impl CombineState {
         label_index: usize,
         conflict_strategy: CatalogConflictStrategy,
     ) -> Result<(), ApiError> {
-        let key = (message.msgid.clone(), message.msgctxt.clone());
-        let Some(existing_index) = self.index.get(&key).copied() else {
-            self.index.insert(key, self.entries.len());
+        let Some(existing_index) = self.message_index(&message) else {
+            self.insert_message_index(&message);
             self.entries.push(CombineEntry {
                 message,
                 definitions: 1,
@@ -168,6 +167,25 @@ impl CombineState {
             &mut self.stats,
             &mut self.diagnostics,
         )
+    }
+
+    fn message_index(&self, message: &CanonicalMessage) -> Option<usize> {
+        self.index
+            .get(message.msgid.as_str())
+            .and_then(|by_context| by_context.get(&message.msgctxt))
+            .copied()
+    }
+
+    fn insert_message_index(&mut self, message: &CanonicalMessage) {
+        let entry_index = self.entries.len();
+        if let Some(by_context) = self.index.get_mut(message.msgid.as_str()) {
+            by_context.insert(message.msgctxt.clone(), entry_index);
+        } else {
+            self.index.insert(
+                message.msgid.clone(),
+                BTreeMap::from([(message.msgctxt.clone(), entry_index)]),
+            );
+        }
     }
 
     fn finish(mut self, config: CombineConfig<'_>) -> Result<CatalogCombineResult, ApiError> {

--- a/crates/ferrocat-po/src/api/helpers.rs
+++ b/crates/ferrocat-po/src/api/helpers.rs
@@ -12,10 +12,41 @@ use crate::PoVec;
 
 /// Deduplicates strings while preserving first-seen order.
 pub(super) fn dedupe_strings(values: Vec<String>) -> Vec<String> {
+    if values.len() < 8 {
+        return dedupe_strings_linear(values);
+    }
+
+    dedupe_strings_with_seen(values)
+}
+
+fn dedupe_strings_linear(values: Vec<String>) -> Vec<String> {
     let mut out = Vec::new();
     for value in values {
         if !push_unique_string(&out, &value) {
             out.push(value);
+        }
+    }
+    out
+}
+
+fn dedupe_strings_with_seen(values: Vec<String>) -> Vec<String> {
+    let mut selected_indexes = Vec::new();
+    {
+        let mut seen = BTreeSet::new();
+        for (index, value) in values.iter().enumerate() {
+            if seen.insert(value.as_str()) {
+                selected_indexes.push(index);
+            }
+        }
+    }
+
+    let mut out = Vec::with_capacity(selected_indexes.len());
+    let mut selected_indexes = selected_indexes.into_iter();
+    let mut next_selected = selected_indexes.next();
+    for (index, value) in values.into_iter().enumerate() {
+        if next_selected == Some(index) {
+            out.push(value);
+            next_selected = selected_indexes.next();
         }
     }
     out
@@ -129,6 +160,31 @@ mod tests {
                 "gamma".to_owned(),
             ]),
             vec!["alpha".to_owned(), "beta".to_owned(), "gamma".to_owned(),]
+        );
+        assert_eq!(
+            dedupe_strings(vec![
+                "a".to_owned(),
+                "b".to_owned(),
+                "c".to_owned(),
+                "d".to_owned(),
+                "e".to_owned(),
+                "f".to_owned(),
+                "g".to_owned(),
+                "h".to_owned(),
+                "a".to_owned(),
+                "i".to_owned(),
+            ]),
+            vec![
+                "a".to_owned(),
+                "b".to_owned(),
+                "c".to_owned(),
+                "d".to_owned(),
+                "e".to_owned(),
+                "f".to_owned(),
+                "g".to_owned(),
+                "h".to_owned(),
+                "i".to_owned(),
+            ]
         );
 
         let mut small = vec!["alpha".to_owned()];


### PR DESCRIPTION
## Summary

- dedupe larger string lists with one borrowed membership set instead of rebuilding a cloned set per check
- keep first-seen order while moving selected strings into the result
- avoid cloning combine message identity keys on existing-key hits

Refs #188. This covers the helper dedupe and combine-index follow-ups; export/provenance/type-index work remains tracked there.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p ferrocat-po --all-targets --all-features --locked -- -D warnings`
- `cargo test -p ferrocat-po --all-features --locked`
- `git diff --check HEAD~1..HEAD`

## Notes

No public API change. This is intentionally limited to the helper/combine layer.
