### PR TITLE
ci(features): check documented feature profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,16 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
-      - name: Check umbrella crate without default features
-        run: cargo check -p ferrocat --no-default-features --locked
+      - name: Check documented feature profiles
+        run: |
+          cargo check -p ferrocat-po --no-default-features --locked
+          cargo check -p ferrocat-po --no-default-features --features serde --locked
+          cargo check -p ferrocat-po --no-default-features --features catalog --locked
+          cargo check -p ferrocat-po --no-default-features --features compile,mt,plurals --locked
+          cargo check -p ferrocat --no-default-features --locked
+          cargo check -p ferrocat --no-default-features --features serde --locked
+          cargo check -p ferrocat --no-default-features --features catalog --locked
+          cargo check -p ferrocat --no-default-features --features compile,mt,plurals --locked
 
   rustdoc:
     name: Rustdoc warnings


### PR DESCRIPTION
## Summary

- replace the single umbrella no-default check with documented feature-profile checks
- cover `ferrocat-po` under no-default, `serde`, `catalog`, and reserved alias profiles
- cover the umbrella `ferrocat` crate under no-default, `serde`, `catalog`, and reserved alias profiles

Refs #193.

## Validation

Local validation passed for all added `cargo check` commands:

- `cargo check -p ferrocat-po --no-default-features --locked`
- `cargo check -p ferrocat-po --no-default-features --features serde --locked`
- `cargo check -p ferrocat-po --no-default-features --features catalog --locked`
- `cargo check -p ferrocat-po --no-default-features --features compile,mt,plurals --locked`
- `cargo check -p ferrocat --no-default-features --locked`
- `cargo check -p ferrocat --no-default-features --features serde --locked`
- `cargo check -p ferrocat --no-default-features --features catalog --locked`
- `cargo check -p ferrocat --no-default-features --features compile,mt,plurals --locked`
- `git diff --check HEAD~1..HEAD`

## Notes

This intentionally preserves the current documented feature semantics. It does not make `compile`, `mt`, or `plurals` real gates; that remains a separate semver-sensitive decision.
