### PR TITLE
docs(api): de-emphasize smallvec re-export

### DIFF
--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -160,12 +160,16 @@ use core::{fmt, ops::Index};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[doc(hidden)]
 pub use smallvec::SmallVec;
 
 /// Inline-capable vector for the small per-item collections (references, flags,
 /// comments, metadata) that hold a single element in the overwhelmingly common
-/// case, avoiding a heap allocation for the backing buffer. Re-exported via
-/// [`SmallVec`] so callers need not depend on `smallvec` directly.
+/// case, avoiding a heap allocation for the backing buffer.
+///
+/// Name this type as `PoVec<T>` in public signatures and examples. The inline
+/// capacity and backing collection remain implementation details for the 2.x
+/// compatibility line.
 pub type PoVec<T> = SmallVec<[T; 1]>;
 
 /// An owned PO document.

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -89,6 +89,8 @@
 #[cfg(feature = "catalog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "catalog")))]
 pub mod catalog {
+    #[doc(hidden)]
+    pub use ferrocat_po::SmallVec;
     pub use ferrocat_po::diagnostic_codes;
     pub use ferrocat_po::{
         AiProvenance, ApiError, COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION, CatalogAuditChecks,
@@ -116,7 +118,7 @@ pub mod catalog {
         ExtractedPluralMessage, ExtractedSingularMessage, IcuFormatterSupportPolicy,
         IcuPseudolocalizationOptions, IcuSyntaxPolicy, MachineMetadata, NormalizedParsedCatalog,
         ObsoleteInfo, ObsoleteStrategy, OrderBy, ParseCatalogOptions, ParsedCatalog,
-        PlaceholderCommentMode, PluralEncoding, PluralSource, PoVec, RenderOptions, SmallVec,
+        PlaceholderCommentMode, PluralEncoding, PluralSource, PoVec, RenderOptions,
         SourceExtractedMessage, TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions,
         audit_catalogs, audit_catalogs_with_icu_options, catalog_coverage, catalog_review,
         combine_catalog_files, combine_catalogs, compile_catalog_artifact,
@@ -154,12 +156,14 @@ pub mod icu {
 /// Low-level PO parsing, serialization, and text merge APIs.
 pub mod po {
     pub use ferrocat_po::MergeExtractedMessage as MergeMessageInput;
+    #[doc(hidden)]
+    pub use ferrocat_po::SmallVec;
     pub use ferrocat_po::diagnostic_codes;
     pub use ferrocat_po::{
         BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, Header, MsgStr, MsgStrIter,
-        ParseError, ParsePosition, PoFile, PoItem, PoVec, SerializeOptions, SmallVec,
-        escape_string, extract_quoted, extract_quoted_cow, merge_catalog, parse_po,
-        parse_po_borrowed, parse_po_bytes, stringify_po, unescape_string,
+        ParseError, ParsePosition, PoFile, PoItem, PoVec, SerializeOptions, escape_string,
+        extract_quoted, extract_quoted_cow, merge_catalog, parse_po, parse_po_borrowed,
+        parse_po_bytes, stringify_po, unescape_string,
     };
 }
 
@@ -195,6 +199,8 @@ pub const COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION: u16 =
     note = "use ferrocat::po::MergeMessageInput for the PO merge helper input"
 )]
 pub use ferrocat_po::MergeExtractedMessage;
+#[doc(hidden)]
+pub use ferrocat_po::SmallVec;
 #[cfg(feature = "catalog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "catalog")))]
 pub use ferrocat_po::{
@@ -233,7 +239,7 @@ pub use ferrocat_po::{
 };
 pub use ferrocat_po::{
     BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, Header, MsgStr, MsgStrIter,
-    ParseError, ParsePosition, PoFile, PoItem, PoVec, SerializeOptions, SmallVec, escape_string,
+    ParseError, ParsePosition, PoFile, PoItem, PoVec, SerializeOptions, escape_string,
     extract_quoted, extract_quoted_cow, merge_catalog, parse_po, parse_po_borrowed, parse_po_bytes,
     stringify_po, unescape_string,
 };

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -798,12 +798,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 > **Field type note.** `CatalogMessage::origin` — and the per-item collections
 > on the lower-level `PoItem`/`BorrowedPoItem` (`references`, `comments`,
-> `extracted_comments`, `flags`, `metadata`) — are `PoVec<T>`, a re-exported
-> `SmallVec` that stores the common single-element case inline. Reading is
+> `extracted_comments`, `flags`, `metadata`) — are `PoVec<T>`. Reading is
 > unchanged (it dereferences to a slice and iterates like a `Vec`); to construct
-> one, use `PoVec::new()`, `Default::default()`, or `vec![…].into()`. `PoVec`
-> and `SmallVec` are re-exported through `ferrocat::catalog`, `ferrocat::po`, and
-> the crate root, so you never need to depend on `smallvec` directly.
+> one, use `PoVec::new()`, `Default::default()`, or `vec![…].into()`. Prefer
+> naming `PoVec<T>` in public signatures and examples. Its inline capacity and
+> backing collection are implementation details for the 2.x compatibility line.
 
 ### Machine-managed value metadata
 


### PR DESCRIPTION
Refs #191.

## Summary

- keep the existing `SmallVec` re-exports public for 2.x compatibility, but hide them from generated docs
- document `PoVec<T>` as the intended public name for PO/catalog collection fields
- update the API overview so the backing collection and inline capacity are described as implementation details

## Validation

- `cargo fmt --all --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p ferrocat-po -p ferrocat --all-features --no-deps --locked`
- `cargo test -p ferrocat-po -p ferrocat --doc --all-features --locked`
- `git diff --check HEAD~1..HEAD`
