### PR TITLE
feat(api): add option builder setters

### DIFF
--- a/crates/ferrocat-icu/src/analysis.rs
+++ b/crates/ferrocat-icu/src/analysis.rs
@@ -189,6 +189,36 @@ impl Default for IcuCompatibilityOptions {
     }
 }
 
+impl IcuCompatibilityOptions {
+    /// Returns options that enable or disable translation-only argument diagnostics.
+    #[must_use]
+    pub fn with_report_extra_arguments(mut self, report_extra_arguments: bool) -> Self {
+        self.report_extra_arguments = report_extra_arguments;
+        self
+    }
+
+    /// Returns options that enable or disable translation-only rich-text tag diagnostics.
+    #[must_use]
+    pub fn with_report_extra_tags(mut self, report_extra_tags: bool) -> Self {
+        self.report_extra_tags = report_extra_tags;
+        self
+    }
+
+    /// Returns options that enable or disable translation-only select selector diagnostics.
+    #[must_use]
+    pub fn with_report_extra_selectors(mut self, report_extra_selectors: bool) -> Self {
+        self.report_extra_selectors = report_extra_selectors;
+        self
+    }
+
+    /// Returns options that enable or disable opaque number/date/time pattern diagnostics.
+    #[must_use]
+    pub fn with_report_pattern_styles(mut self, report_pattern_styles: bool) -> Self {
+        self.report_pattern_styles = report_pattern_styles;
+        self
+    }
+}
+
 /// One diagnostic emitted by an ICU compatibility check.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IcuDiagnostic {
@@ -1102,5 +1132,19 @@ mod tests {
 
         assert!(report.diagnostics.is_empty());
         assert_eq!(visited, vec![("created".to_owned(), IcuArgumentKind::Date)]);
+    }
+
+    #[test]
+    fn compatibility_option_builders_set_fields() {
+        let options = IcuCompatibilityOptions::default()
+            .with_report_extra_arguments(false)
+            .with_report_extra_tags(false)
+            .with_report_extra_selectors(false)
+            .with_report_pattern_styles(false);
+
+        assert!(!options.report_extra_arguments);
+        assert!(!options.report_extra_tags);
+        assert!(!options.report_extra_selectors);
+        assert!(!options.report_pattern_styles);
     }
 }

--- a/crates/ferrocat-icu/src/parser.rs
+++ b/crates/ferrocat-icu/src/parser.rs
@@ -19,6 +19,22 @@ impl Default for IcuParserOptions {
     }
 }
 
+impl IcuParserOptions {
+    /// Returns options that enable or disable rich-text tag parsing.
+    #[must_use]
+    pub fn with_ignore_tag(mut self, ignore_tag: bool) -> Self {
+        self.ignore_tag = ignore_tag;
+        self
+    }
+
+    /// Returns options that enable or disable required `other` clauses.
+    #[must_use]
+    pub fn with_requires_other_clause(mut self, requires_other_clause: bool) -> Self {
+        self.requires_other_clause = requires_other_clause;
+        self
+    }
+}
+
 /// Parses ICU `MessageFormat` input with the default parser options.
 ///
 /// # Errors
@@ -656,10 +672,7 @@ mod tests {
     fn ignore_tag_treats_tags_as_literal_text() {
         let message = parse_icu_with_options(
             "<b>Hello</b>",
-            &IcuParserOptions {
-                ignore_tag: true,
-                ..IcuParserOptions::default()
-            },
+            &IcuParserOptions::default().with_ignore_tag(true),
         )
         .expect("parse");
         assert_eq!(
@@ -693,10 +706,7 @@ mod tests {
     fn missing_other_clause_can_be_disabled() {
         parse_icu_with_options(
             "{count, plural, one {item}}",
-            &IcuParserOptions {
-                requires_other_clause: false,
-                ..IcuParserOptions::default()
-            },
+            &IcuParserOptions::default().with_requires_other_clause(false),
         )
         .expect("parse");
     }

--- a/crates/ferrocat-po/src/api/audit.rs
+++ b/crates/ferrocat-po/src/api/audit.rs
@@ -40,6 +40,27 @@ impl<'a> CatalogAuditOptions<'a> {
             ..Self::default()
         }
     }
+
+    /// Returns options that audit only the given target locales.
+    #[must_use]
+    pub fn with_locales(mut self, locales: &'a [&'a str]) -> Self {
+        self.locales = locales;
+        self
+    }
+
+    /// Returns options that validate the given source-side metadata records.
+    #[must_use]
+    pub fn with_metadata(mut self, metadata: &'a [MessageMetadataInput]) -> Self {
+        self.metadata = metadata;
+        self
+    }
+
+    /// Returns options that run the given audit check set.
+    #[must_use]
+    pub fn with_checks(mut self, checks: CatalogAuditChecks) -> Self {
+        self.checks = checks;
+        self
+    }
 }
 
 /// ICU-specific options used by catalog audit checks.
@@ -92,6 +113,50 @@ impl Default for CatalogAuditChecks {
             semantic_metadata: true,
             obsolete_entries: true,
         }
+    }
+}
+
+impl CatalogAuditChecks {
+    /// Returns checks with completeness validation enabled or disabled.
+    #[must_use]
+    pub fn with_completeness(mut self, completeness: bool) -> Self {
+        self.completeness = completeness;
+        self
+    }
+
+    /// Returns checks with extra-message validation enabled or disabled.
+    #[must_use]
+    pub fn with_extra_messages(mut self, extra_messages: bool) -> Self {
+        self.extra_messages = extra_messages;
+        self
+    }
+
+    /// Returns checks with ICU syntax validation enabled or disabled.
+    #[must_use]
+    pub fn with_icu_syntax(mut self, icu_syntax: bool) -> Self {
+        self.icu_syntax = icu_syntax;
+        self
+    }
+
+    /// Returns checks with ICU compatibility validation enabled or disabled.
+    #[must_use]
+    pub fn with_icu_compatibility(mut self, icu_compatibility: bool) -> Self {
+        self.icu_compatibility = icu_compatibility;
+        self
+    }
+
+    /// Returns checks with semantic metadata validation enabled or disabled.
+    #[must_use]
+    pub fn with_semantic_metadata(mut self, semantic_metadata: bool) -> Self {
+        self.semantic_metadata = semantic_metadata;
+        self
+    }
+
+    /// Returns checks with obsolete-entry reporting enabled or disabled.
+    #[must_use]
+    pub fn with_obsolete_entries(mut self, obsolete_entries: bool) -> Self {
+        self.obsolete_entries = obsolete_entries;
+        self
     }
 }
 
@@ -209,15 +274,13 @@ impl CatalogAuditReport {
 /// ```rust
 /// use ferrocat_po::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog};
 ///
-/// let source = parse_catalog(ParseCatalogOptions {
-///     locale: Some("en"),
-///     ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
-/// })?
+/// let source = parse_catalog(
+///     ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en").with_locale("en"),
+/// )?
 /// .into_normalized_view()?;
-/// let target = parse_catalog(ParseCatalogOptions {
-///     locale: Some("de"),
-///     ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"\"\n", "en")
-/// })?
+/// let target = parse_catalog(
+///     ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"\"\n", "en").with_locale("de"),
+/// )?
 /// .into_normalized_view()?;
 ///
 /// let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
@@ -597,6 +660,43 @@ fn message_strings(message: &CatalogMessage, include_msgid: bool) -> Vec<&str> {
 fn push_unique<'a>(values: &mut Vec<&'a str>, value: &'a str) {
     if !values.contains(&value) {
         values.push(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ferrocat_icu::MessageMetadataInput;
+
+    use super::{CatalogAuditChecks, CatalogAuditOptions};
+
+    #[test]
+    fn audit_option_builders_set_fields() {
+        let metadata = [MessageMetadataInput::new("Checkout")];
+        let locales = ["de", "fr"];
+        let checks = CatalogAuditChecks::default()
+            .with_completeness(false)
+            .with_extra_messages(false)
+            .with_icu_syntax(false)
+            .with_icu_compatibility(false)
+            .with_semantic_metadata(false)
+            .with_obsolete_entries(false);
+
+        assert!(!checks.completeness);
+        assert!(!checks.extra_messages);
+        assert!(!checks.icu_syntax);
+        assert!(!checks.icu_compatibility);
+        assert!(!checks.semantic_metadata);
+        assert!(!checks.obsolete_entries);
+
+        let options = CatalogAuditOptions::new("en")
+            .with_locales(&locales)
+            .with_metadata(&metadata)
+            .with_checks(checks);
+
+        assert_eq!(options.source_locale, "en");
+        assert_eq!(options.locales, &locales);
+        assert_eq!(options.metadata, &metadata);
+        assert_eq!(options.checks, checks);
     }
 }
 

--- a/crates/ferrocat-po/src/api/catalog.rs
+++ b/crates/ferrocat-po/src/api/catalog.rs
@@ -115,14 +115,16 @@ struct MergeCatalogContext<'a> {
 ///     CatalogMode, CatalogUpdateInput, SourceExtractedMessage, UpdateCatalogOptions, update_catalog,
 /// };
 ///
-/// let result = update_catalog(UpdateCatalogOptions {
-///     locale: Some("de"),
-///     input: CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
-///         msgid: "Checkout".to_owned(),
-///         ..SourceExtractedMessage::default()
-///     }]),
-///     ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
-/// })?;
+/// let result = update_catalog(
+///     UpdateCatalogOptions::new(
+///         "en",
+///         CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
+///             msgid: "Checkout".to_owned(),
+///             ..SourceExtractedMessage::default()
+///         }]),
+///     )
+///     .with_locale("de"),
+/// )?;
 ///
 /// assert!(result.created);
 /// assert!(result.content.contains("msgid \"Checkout\""));
@@ -234,10 +236,10 @@ pub fn update_catalog_file(
 /// ```rust
 /// use ferrocat_po::{ParseCatalogOptions, parse_catalog};
 ///
-/// let catalog = parse_catalog(ParseCatalogOptions {
-///     locale: Some("de"),
-///     ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
-/// })?;
+/// let catalog = parse_catalog(
+///     ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
+///         .with_locale("de"),
+/// )?;
 ///
 /// assert_eq!(catalog.locale.as_deref(), Some("de"));
 /// assert_eq!(catalog.messages.len(), 1);

--- a/crates/ferrocat-po/src/api/compile.rs
+++ b/crates/ferrocat-po/src/api/compile.rs
@@ -45,10 +45,10 @@ impl NormalizedParsedCatalog {
     /// ```rust
     /// use ferrocat_po::{CompileCatalogOptions, ParseCatalogOptions, parse_catalog};
     ///
-    /// let parsed = parse_catalog(ParseCatalogOptions {
-    ///     locale: Some("de"),
-    ///     ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
-    /// })?;
+    /// let parsed = parse_catalog(
+    ///     ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
+    ///         .with_locale("de"),
+    /// )?;
     /// let normalized = parsed.into_normalized_view()?;
     /// let compiled = normalized.compile(&CompileCatalogOptions::default())?;
     ///

--- a/crates/ferrocat-po/src/api/compile_types.rs
+++ b/crates/ferrocat-po/src/api/compile_types.rs
@@ -80,11 +80,39 @@ impl Default for CompileCatalogOptions<'_> {
     }
 }
 
-impl CompileCatalogOptions<'_> {
+impl<'a> CompileCatalogOptions<'a> {
     /// Creates runtime catalog compile options with default behavior.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Returns options that derive runtime keys with the given strategy.
+    #[must_use]
+    pub fn with_key_strategy(mut self, key_strategy: CompiledKeyStrategy) -> Self {
+        self.key_strategy = key_strategy;
+        self
+    }
+
+    /// Returns options that enable or disable source-locale fallback.
+    #[must_use]
+    pub fn with_source_fallback(mut self, source_fallback: bool) -> Self {
+        self.source_fallback = source_fallback;
+        self
+    }
+
+    /// Returns options that use the given source locale for source fallback.
+    #[must_use]
+    pub fn with_source_locale(mut self, source_locale: &'a str) -> Self {
+        self.source_locale = Some(source_locale);
+        self
+    }
+
+    /// Returns options that interpret input catalogs with the given semantics.
+    #[must_use]
+    pub fn with_semantics(mut self, semantics: CatalogSemantics) -> Self {
+        self.semantics = semantics;
+        self
     }
 }
 
@@ -127,6 +155,62 @@ impl<'a> CompileCatalogArtifactOptions<'a> {
             icu_compatibility: false,
             semantics: CatalogSemantics::IcuNative,
         }
+    }
+
+    /// Returns options that compile the given requested locale.
+    #[must_use]
+    pub fn with_requested_locale(mut self, requested_locale: &'a str) -> Self {
+        self.requested_locale = requested_locale;
+        self
+    }
+
+    /// Returns options that use the given source locale.
+    #[must_use]
+    pub fn with_source_locale(mut self, source_locale: &'a str) -> Self {
+        self.source_locale = source_locale;
+        self
+    }
+
+    /// Returns options that consult the given ordered fallback locales.
+    #[must_use]
+    pub fn with_fallback_chain(mut self, fallback_chain: &'a [String]) -> Self {
+        self.fallback_chain = fallback_chain;
+        self
+    }
+
+    /// Returns options that derive runtime keys with the given strategy.
+    #[must_use]
+    pub fn with_key_strategy(mut self, key_strategy: CompiledKeyStrategy) -> Self {
+        self.key_strategy = key_strategy;
+        self
+    }
+
+    /// Returns options that enable or disable source-text fallback.
+    #[must_use]
+    pub fn with_source_fallback(mut self, source_fallback: bool) -> Self {
+        self.source_fallback = source_fallback;
+        self
+    }
+
+    /// Returns options that enable or disable hard errors for invalid final ICU messages.
+    #[must_use]
+    pub fn with_strict_icu(mut self, strict_icu: bool) -> Self {
+        self.strict_icu = strict_icu;
+        self
+    }
+
+    /// Returns options that enable or disable final ICU compatibility checks.
+    #[must_use]
+    pub fn with_icu_compatibility(mut self, icu_compatibility: bool) -> Self {
+        self.icu_compatibility = icu_compatibility;
+        self
+    }
+
+    /// Returns options that interpret input catalogs with the given semantics.
+    #[must_use]
+    pub fn with_semantics(mut self, semantics: CatalogSemantics) -> Self {
+        self.semantics = semantics;
+        self
     }
 }
 
@@ -187,6 +271,20 @@ impl<'a> CompileSelectedCatalogArtifactOptions<'a> {
             options: CompileCatalogArtifactOptions::new(requested_locale, source_locale),
         }
     }
+
+    /// Returns options that include the given compiled runtime IDs.
+    #[must_use]
+    pub fn with_compiled_ids(mut self, compiled_ids: &'a [String]) -> Self {
+        self.compiled_ids = compiled_ids;
+        self
+    }
+
+    /// Returns options that use the given shared artifact compile options.
+    #[must_use]
+    pub fn with_options(mut self, options: CompileCatalogArtifactOptions<'a>) -> Self {
+        self.options = options;
+        self
+    }
 }
 
 /// Message selection for [`super::compile_catalog_artifact_report`].
@@ -241,6 +339,27 @@ impl<'a> CompileCatalogArtifactReportOptions<'a> {
                 compiled_ids,
             },
         }
+    }
+
+    /// Returns report options that use the given shared artifact compile options.
+    #[must_use]
+    pub fn with_options(mut self, options: CompileCatalogArtifactOptions<'a>) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Returns report options that use the given ICU validation options.
+    #[must_use]
+    pub fn with_icu_options(mut self, icu_options: CompileCatalogArtifactIcuOptions) -> Self {
+        self.icu_options = icu_options;
+        self
+    }
+
+    /// Returns report options that use the given source identity selection.
+    #[must_use]
+    pub fn with_selection(mut self, selection: CompileCatalogArtifactReportSelection<'a>) -> Self {
+        self.selection = selection;
+        self
     }
 }
 
@@ -686,12 +805,13 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::{
-        COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION, CompileCatalogArtifactOptions,
-        CompileCatalogArtifactReportOptions, CompileCatalogArtifactReportSelection,
-        CompileCatalogOptions, CompileSelectedCatalogArtifactOptions, CompiledCatalogArtifact,
-        CompiledCatalogDiagnostic, CompiledCatalogMissingMessage, CompiledKeyStrategy,
+        COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION, CompileCatalogArtifactIcuOptions,
+        CompileCatalogArtifactOptions, CompileCatalogArtifactReportOptions,
+        CompileCatalogArtifactReportSelection, CompileCatalogOptions,
+        CompileSelectedCatalogArtifactOptions, CompiledCatalogArtifact, CompiledCatalogDiagnostic,
+        CompiledCatalogIdIndex, CompiledCatalogMissingMessage, CompiledKeyStrategy,
     };
-    use crate::api::{CatalogMessageKey, CatalogSemantics, DiagnosticSeverity};
+    use crate::api::{CatalogMessageKey, CatalogSemantics, DiagnosticSeverity, IcuSyntaxPolicy};
 
     #[test]
     fn compile_option_constructors_set_required_fields_and_keep_defaults() {
@@ -721,6 +841,72 @@ mod tests {
         assert!(matches!(
             report.selection,
             CompileCatalogArtifactReportSelection::All
+        ));
+    }
+
+    #[test]
+    fn compile_option_builders_set_fields() {
+        let compile = CompileCatalogOptions::new()
+            .with_key_strategy(CompiledKeyStrategy::FerrocatV1)
+            .with_source_fallback(true)
+            .with_source_locale("en")
+            .with_semantics(CatalogSemantics::GettextCompat);
+
+        assert_eq!(compile.key_strategy, CompiledKeyStrategy::FerrocatV1);
+        assert!(compile.source_fallback);
+        assert_eq!(compile.source_locale, Some("en"));
+        assert_eq!(compile.semantics, CatalogSemantics::GettextCompat);
+
+        let fallback_chain = vec!["fr".to_owned(), "en".to_owned()];
+        let artifact = CompileCatalogArtifactOptions::new("de", "en")
+            .with_requested_locale("fr")
+            .with_source_locale("en-US")
+            .with_fallback_chain(&fallback_chain)
+            .with_key_strategy(CompiledKeyStrategy::FerrocatV1)
+            .with_source_fallback(true)
+            .with_strict_icu(true)
+            .with_icu_compatibility(true)
+            .with_semantics(CatalogSemantics::GettextCompat);
+
+        assert_eq!(artifact.requested_locale, "fr");
+        assert_eq!(artifact.source_locale, "en-US");
+        assert_eq!(artifact.fallback_chain, fallback_chain.as_slice());
+        assert!(artifact.source_fallback);
+        assert!(artifact.strict_icu);
+        assert!(artifact.icu_compatibility);
+        assert_eq!(artifact.semantics, CatalogSemantics::GettextCompat);
+
+        let selected_ids = vec!["id-1".to_owned()];
+        let other_ids = vec!["id-2".to_owned()];
+        let selected = CompileSelectedCatalogArtifactOptions::new("de", "en", &selected_ids)
+            .with_compiled_ids(&other_ids)
+            .with_options(artifact.clone());
+
+        assert_eq!(selected.compiled_ids, other_ids.as_slice());
+        assert_eq!(selected.options, artifact);
+
+        let index = CompiledCatalogIdIndex::default();
+        let selection = CompileCatalogArtifactReportSelection::Selected {
+            index: &index,
+            compiled_ids: &other_ids,
+        };
+        let report = CompileCatalogArtifactReportOptions::new("de", "en")
+            .with_options(artifact.clone())
+            .with_icu_options(
+                CompileCatalogArtifactIcuOptions::new()
+                    .with_syntax_policy(IcuSyntaxPolicy::RuntimeLiteralApostrophes),
+            )
+            .with_selection(selection);
+
+        assert_eq!(report.options, artifact);
+        assert_eq!(
+            report.icu_options.syntax_policy,
+            IcuSyntaxPolicy::RuntimeLiteralApostrophes
+        );
+        assert!(matches!(
+            report.selection,
+            CompileCatalogArtifactReportSelection::Selected { compiled_ids, .. }
+                if compiled_ids == other_ids.as_slice()
         ));
     }
 

--- a/crates/ferrocat-po/src/api/coverage.rs
+++ b/crates/ferrocat-po/src/api/coverage.rs
@@ -124,15 +124,14 @@ pub struct CatalogCoverageMessage {
 ///     parse_catalog,
 /// };
 ///
-/// let source = parse_catalog(ParseCatalogOptions {
-///     locale: Some("en"),
-///     ..ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"\"\n", "en")
-/// })?
+/// let source = parse_catalog(
+///     ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"\"\n", "en").with_locale("en"),
+/// )?
 /// .into_normalized_view()?;
-/// let target = parse_catalog(ParseCatalogOptions {
-///     locale: Some("de"),
-///     ..ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"Speichern\"\n", "en")
-/// })?
+/// let target = parse_catalog(
+///     ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"Speichern\"\n", "en")
+///         .with_locale("de"),
+/// )?
 /// .into_normalized_view()?;
 ///
 /// let options = CatalogCoverageOptions::new("en").with_details(true);

--- a/crates/ferrocat-po/src/api/review.rs
+++ b/crates/ferrocat-po/src/api/review.rs
@@ -229,32 +229,31 @@ pub enum CatalogMachineTranslationStatus {
 /// ```rust
 /// use ferrocat_po::{CatalogReviewOptions, ParseCatalogOptions, catalog_review, parse_catalog};
 ///
-/// let previous_source = parse_catalog(ParseCatalogOptions {
-///     locale: Some("en"),
-///     ..ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"\"\n", "en")
-/// })?
+/// let previous_source = parse_catalog(
+///     ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"\"\n", "en").with_locale("en"),
+/// )?
 /// .into_normalized_view()?;
-/// let previous_target = parse_catalog(ParseCatalogOptions {
-///     locale: Some("de"),
-///     ..ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"Speichern\"\n", "en")
-/// })?
+/// let previous_target = parse_catalog(
+///     ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"Speichern\"\n", "en")
+///         .with_locale("de"),
+/// )?
 /// .into_normalized_view()?;
 ///
-/// let current_source = parse_catalog(ParseCatalogOptions {
-///     locale: Some("en"),
-///     ..ParseCatalogOptions::new(
+/// let current_source = parse_catalog(
+///     ParseCatalogOptions::new(
 ///         "msgid \"Save\"\nmsgstr \"\"\n\nmsgid \"Cancel\"\nmsgstr \"\"\n",
 ///         "en",
 ///     )
-/// })?
+///     .with_locale("en"),
+/// )?
 /// .into_normalized_view()?;
-/// let current_target = parse_catalog(ParseCatalogOptions {
-///     locale: Some("de"),
-///     ..ParseCatalogOptions::new(
+/// let current_target = parse_catalog(
+///     ParseCatalogOptions::new(
 ///         "msgid \"Save\"\nmsgstr \"Sichern\"\n\nmsgid \"Cancel\"\nmsgstr \"\"\n",
 ///         "en",
 ///     )
-/// })?
+///     .with_locale("de"),
+/// )?
 /// .into_normalized_view()?;
 ///
 /// let options = CatalogReviewOptions::new("en").with_details(true);

--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -960,6 +960,42 @@ impl Default for RenderOptions<'_> {
     }
 }
 
+impl<'a> RenderOptions<'a> {
+    /// Returns options that render messages with the given sort order.
+    #[must_use]
+    pub fn with_order_by(mut self, order_by: OrderBy) -> Self {
+        self.order_by = order_by;
+        self
+    }
+
+    /// Returns options that enable or disable rendered source origins.
+    #[must_use]
+    pub fn with_include_origins(mut self, include_origins: bool) -> Self {
+        self.include_origins = include_origins;
+        self
+    }
+
+    /// Returns options that use the given placeholder comment mode.
+    #[must_use]
+    pub fn with_placeholder_comments(
+        mut self,
+        print_placeholders_in_comments: PlaceholderCommentMode,
+    ) -> Self {
+        self.print_placeholders_in_comments = print_placeholders_in_comments;
+        self
+    }
+
+    /// Returns options that inject or override the given header attributes.
+    #[must_use]
+    pub fn with_custom_header_attributes(
+        mut self,
+        custom_header_attributes: &'a BTreeMap<String, String>,
+    ) -> Self {
+        self.custom_header_attributes = Some(custom_header_attributes);
+        self
+    }
+}
+
 /// Options for in-memory catalog updates.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdateCatalogOptions<'a> {
@@ -1005,6 +1041,58 @@ impl<'a> UpdateCatalogOptions<'a> {
             now: None,
             render: RenderOptions::default(),
         }
+    }
+
+    /// Returns options that use the given catalog locale.
+    #[must_use]
+    pub fn with_locale(mut self, locale: &'a str) -> Self {
+        self.locale = Some(locale);
+        self
+    }
+
+    /// Returns options that update the given existing catalog content.
+    #[must_use]
+    pub fn with_existing(mut self, existing: &'a str) -> Self {
+        self.existing = Some(existing);
+        self
+    }
+
+    /// Returns options that parse, merge, and render with the given catalog mode.
+    #[must_use]
+    pub fn with_mode(mut self, mode: CatalogMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Returns options that render the updated catalog with the given options.
+    #[must_use]
+    pub fn with_render(mut self, render: RenderOptions<'a>) -> Self {
+        self.render = render;
+        self
+    }
+
+    /// Returns options that handle missing extracted messages with the given strategy.
+    #[must_use]
+    pub fn with_obsolete_strategy(mut self, obsolete_strategy: ObsoleteStrategy) -> Self {
+        self.obsolete_strategy = obsolete_strategy;
+        self
+    }
+
+    /// Returns options that enable or disable source-locale translation refreshes.
+    #[must_use]
+    pub fn with_overwrite_source_translations(
+        mut self,
+        overwrite_source_translations: bool,
+    ) -> Self {
+        self.overwrite_source_translations = overwrite_source_translations;
+        self
+    }
+
+    /// Returns options that stamp newly obsolete entries with the given ISO date.
+    #[must_use]
+    pub fn with_now(mut self, now: &'a str) -> Self {
+        self.now = Some(now);
+        self
     }
 }
 
@@ -1110,6 +1198,27 @@ impl<'a> ParseCatalogOptions<'a> {
             mode: CatalogMode::default(),
             strict: false,
         }
+    }
+
+    /// Returns options that use the given explicit catalog locale.
+    #[must_use]
+    pub fn with_locale(mut self, locale: &'a str) -> Self {
+        self.locale = Some(locale);
+        self
+    }
+
+    /// Returns options that interpret catalog content with the given mode.
+    #[must_use]
+    pub fn with_mode(mut self, mode: CatalogMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Returns options that enable or disable strict plural projection.
+    #[must_use]
+    pub fn with_strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
     }
 }
 
@@ -1233,7 +1342,7 @@ mod tests {
         CombineCatalogOptions, Diagnostic, DiagnosticSeverity, EffectiveTranslation,
         EffectiveTranslationRef, NormalizedParsedCatalog, ObsoleteStrategy, OrderBy,
         ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode, PluralEncoding, PluralSource,
-        TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions,
+        RenderOptions, TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions,
     };
     use crate::ParseError;
 
@@ -1453,6 +1562,50 @@ mod tests {
     }
 
     #[test]
+    fn catalog_option_builders_set_fields() {
+        let headers = BTreeMap::from([("X-Generator".to_owned(), "ferrocat".to_owned())]);
+        let render = RenderOptions::default()
+            .with_order_by(OrderBy::Origin)
+            .with_include_origins(false)
+            .with_placeholder_comments(PlaceholderCommentMode::Disabled)
+            .with_custom_header_attributes(&headers);
+
+        assert_eq!(render.order_by, OrderBy::Origin);
+        assert!(!render.include_origins);
+        assert_eq!(
+            render.print_placeholders_in_comments,
+            PlaceholderCommentMode::Disabled
+        );
+        assert_eq!(render.custom_header_attributes, Some(&headers));
+
+        let update = UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
+            .with_locale("de")
+            .with_existing("msgid \"Hello\"\nmsgstr \"Hallo\"\n")
+            .with_mode(CatalogMode::GettextPo)
+            .with_render(render.clone())
+            .with_obsolete_strategy(ObsoleteStrategy::Delete)
+            .with_overwrite_source_translations(true)
+            .with_now("2026-07-02");
+
+        assert_eq!(update.locale, Some("de"));
+        assert_eq!(update.existing, Some("msgid \"Hello\"\nmsgstr \"Hallo\"\n"));
+        assert_eq!(update.mode, CatalogMode::GettextPo);
+        assert_eq!(update.render, render);
+        assert_eq!(update.obsolete_strategy, ObsoleteStrategy::Delete);
+        assert!(update.overwrite_source_translations);
+        assert_eq!(update.now, Some("2026-07-02"));
+
+        let parse = ParseCatalogOptions::new("content", "en")
+            .with_locale("fr")
+            .with_mode(CatalogMode::IcuFcl)
+            .with_strict(true);
+
+        assert_eq!(parse.locale, Some("fr"));
+        assert_eq!(parse.mode, CatalogMode::IcuFcl);
+        assert!(parse.strict);
+    }
+
+    #[test]
     fn catalog_file_format_infers_supported_suffixes() {
         assert_eq!(
             CatalogFileFormat::infer_from_path(Path::new("locale/de.po")).expect("po"),
@@ -1514,10 +1667,8 @@ mod tests {
             ),
             Some(CatalogMode::IcuPo)
         );
-        let update = UpdateCatalogOptions {
-            mode: CatalogMode::GettextPo,
-            ..UpdateCatalogOptions::new("en", Vec::<super::SourceExtractedMessage>::new())
-        };
+        let update = UpdateCatalogOptions::new("en", Vec::<super::SourceExtractedMessage>::new())
+            .with_mode(CatalogMode::GettextPo);
         assert_eq!(update.mode, CatalogMode::GettextPo);
     }
 

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -56,15 +56,13 @@
 //!     parse_catalog,
 //! };
 //!
-//! let source = parse_catalog(ParseCatalogOptions {
-//!     locale: Some("en"),
-//!     ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en")
-//! })?
+//! let source = parse_catalog(
+//!     ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en").with_locale("en"),
+//! )?
 //! .into_normalized_view()?;
-//! let requested = parse_catalog(ParseCatalogOptions {
-//!     locale: Some("de"),
-//!     ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
-//! })?
+//! let requested = parse_catalog(
+//!     ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en").with_locale("de"),
+//! )?
 //! .into_normalized_view()?;
 //! let index = CompiledCatalogIdIndex::new(&[&requested, &source], ferrocat_po::CompiledKeyStrategy::FerrocatV1)?;
 //! let compiled_ids = index.iter().map(|(id, _)| id.to_owned()).collect::<Vec<_>>();
@@ -81,15 +79,15 @@
 //! ```rust
 //! use ferrocat_po::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog};
 //!
-//! let source = parse_catalog(ParseCatalogOptions {
-//!     locale: Some("en"),
-//!     ..ParseCatalogOptions::new("msgid \"Hello {name}\"\nmsgstr \"Hello {name}\"\n", "en")
-//! })?
+//! let source = parse_catalog(
+//!     ParseCatalogOptions::new("msgid \"Hello {name}\"\nmsgstr \"Hello {name}\"\n", "en")
+//!         .with_locale("en"),
+//! )?
 //! .into_normalized_view()?;
-//! let target = parse_catalog(ParseCatalogOptions {
-//!     locale: Some("de"),
-//!     ..ParseCatalogOptions::new("msgid \"Hello {name}\"\nmsgstr \"Hallo\"\n", "en")
-//! })?
+//! let target = parse_catalog(
+//!     ParseCatalogOptions::new("msgid \"Hello {name}\"\nmsgstr \"Hallo\"\n", "en")
+//!         .with_locale("de"),
+//! )?
 //! .into_normalized_view()?;
 //! let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
 //!
@@ -438,6 +436,22 @@ impl Default for SerializeOptions {
     }
 }
 
+impl SerializeOptions {
+    /// Returns options that wrap string literals at the given soft limit.
+    #[must_use]
+    pub fn with_fold_length(mut self, fold_length: usize) -> Self {
+        self.fold_length = fold_length;
+        self
+    }
+
+    /// Returns options that keep one-line values compact when possible.
+    #[must_use]
+    pub fn with_compact_multiline(mut self, compact_multiline: bool) -> Self {
+        self.compact_multiline = compact_multiline;
+        self
+    }
+}
+
 /// One-based line/column context plus the byte offset for a parse error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ParsePosition {
@@ -533,7 +547,7 @@ impl std::error::Error for ParseError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{MsgStr, ParseError, ParsePosition};
+    use super::{MsgStr, ParseError, ParsePosition, SerializeOptions};
 
     #[cfg(feature = "serde")]
     use super::{Header, PoFile, PoItem};
@@ -604,6 +618,16 @@ mod tests {
         assert_eq!(plural.iter().collect::<Vec<_>>(), vec!["eins", "viele"]);
         assert_eq!(plural[1], "viele");
         assert_eq!(plural.into_vec(), vec!["eins", "viele"]);
+    }
+
+    #[test]
+    fn serialize_option_builders_set_fields() {
+        let options = SerializeOptions::default()
+            .with_fold_length(120)
+            .with_compact_multiline(false);
+
+        assert_eq!(options.fold_length, 120);
+        assert!(!options.compact_multiline);
     }
 
     #[cfg(feature = "serde")]

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -42,15 +42,13 @@
 //!     ParseCatalogOptions, compile_catalog_artifact_selected, parse_catalog,
 //! };
 //!
-//! let source = parse_catalog(ParseCatalogOptions {
-//!     locale: Some("en"),
-//!     ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en")
-//! })?
+//! let source = parse_catalog(
+//!     ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en").with_locale("en"),
+//! )?
 //! .into_normalized_view()?;
-//! let requested = parse_catalog(ParseCatalogOptions {
-//!     locale: Some("de"),
-//!     ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
-//! })?
+//! let requested = parse_catalog(
+//!     ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en").with_locale("de"),
+//! )?
 //! .into_normalized_view()?;
 //! let index = CompiledCatalogIdIndex::new(&[&requested, &source], CompiledKeyStrategy::FerrocatV1)?;
 //! let compiled_ids = index.iter().map(|(id, _)| id.to_owned()).collect::<Vec<_>>();
@@ -69,15 +67,11 @@
 //!     CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog,
 //! };
 //!
-//! let source = parse_catalog(ParseCatalogOptions {
-//!     locale: Some("en"),
-//!     ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
-//! })?
+//! let source = parse_catalog(
+//!     ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en").with_locale("en"),
+//! )?
 //! .into_normalized_view()?;
-//! let target = parse_catalog(ParseCatalogOptions {
-//!     locale: Some("de"),
-//!     ..ParseCatalogOptions::new("", "en")
-//! })?
+//! let target = parse_catalog(ParseCatalogOptions::new("", "en").with_locale("de"))?
 //! .into_normalized_view()?;
 //! let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
 //!

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -354,10 +354,10 @@ The normalized view supports both owned-key lookup with `CatalogMessageKey` and 
 use ferrocat::{ParseCatalogOptions, parse_catalog};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let catalog = parse_catalog(ParseCatalogOptions {
-        locale: Some("de"),
-        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
-    })?;
+    let catalog = parse_catalog(
+        ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
+            .with_locale("de"),
+    )?;
 
     let view = catalog.into_normalized_view()?;
     assert!(view.contains_parts("Checkout", None));
@@ -415,15 +415,14 @@ Diagnostics are machine-readable. Examples include:
 use ferrocat::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let source = parse_catalog(ParseCatalogOptions {
-        locale: Some("en"),
-        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
-    })?
+    let source = parse_catalog(
+        ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
+            .with_locale("en"),
+    )?
     .into_normalized_view()?;
-    let target = parse_catalog(ParseCatalogOptions {
-        locale: Some("de"),
-        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"\"\n", "en")
-    })?
+    let target = parse_catalog(
+        ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"\"\n", "en").with_locale("de"),
+    )?
     .into_normalized_view()?;
 
     let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
@@ -517,15 +516,15 @@ use ferrocat::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let source = parse_catalog(ParseCatalogOptions {
-        locale: Some("en"),
-        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
-    })?
+    let source = parse_catalog(
+        ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
+            .with_locale("en"),
+    )?
     .into_normalized_view()?;
-    let target = parse_catalog(ParseCatalogOptions {
-        locale: Some("de"),
-        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
-    })?
+    let target = parse_catalog(
+        ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
+            .with_locale("de"),
+    )?
     .into_normalized_view()?;
 
     let report = catalog_coverage(&[&source, &target], &CatalogCoverageOptions::new("en"))?;
@@ -560,28 +559,28 @@ use ferrocat::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let previous_source = parse_catalog(ParseCatalogOptions {
-        locale: Some("en"),
-        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
-    })?
+    let previous_source = parse_catalog(
+        ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
+            .with_locale("en"),
+    )?
     .into_normalized_view()?;
-    let current_source = parse_catalog(ParseCatalogOptions {
-        locale: Some("en"),
-        ..ParseCatalogOptions::new(
+    let current_source = parse_catalog(
+        ParseCatalogOptions::new(
             "msgid \"Checkout\"\nmsgstr \"Checkout\"\n\nmsgid \"Cancel\"\nmsgstr \"Cancel\"\n",
             "en",
         )
-    })?
+        .with_locale("en"),
+    )?
     .into_normalized_view()?;
-    let previous_de = parse_catalog(ParseCatalogOptions {
-        locale: Some("de"),
-        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
-    })?
+    let previous_de = parse_catalog(
+        ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
+            .with_locale("de"),
+    )?
     .into_normalized_view()?;
-    let current_de = parse_catalog(ParseCatalogOptions {
-        locale: Some("de"),
-        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
-    })?
+    let current_de = parse_catalog(
+        ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
+            .with_locale("de"),
+    )?
     .into_normalized_view()?;
 
     let report = catalog_review(
@@ -633,24 +632,21 @@ use ferrocat::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let source = parse_catalog(ParseCatalogOptions {
-        locale: Some("en"),
-        ..ParseCatalogOptions::new(
+    let source = parse_catalog(
+        ParseCatalogOptions::new(
             "msgid \"Checkout\"\nmsgstr \"Checkout\"\n\nmsgid \"Cart\"\nmsgstr \"Cart\"\n",
             "en",
         )
-    })?
+        .with_locale("en"),
+    )?
     .into_normalized_view()?;
-    let german = parse_catalog(ParseCatalogOptions {
-        locale: Some("de"),
-        ..ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
-    })?
+    let german = parse_catalog(
+        ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
+            .with_locale("de"),
+    )?
     .into_normalized_view()?;
 
-    let options = CompileCatalogArtifactOptions {
-        source_fallback: true,
-        ..CompileCatalogArtifactOptions::new("de", "en")
-    };
+    let options = CompileCatalogArtifactOptions::new("de", "en").with_source_fallback(true);
     let artifact = compile_catalog_artifact(&[&source, &german], &options)?;
     assert_eq!(artifact.messages.len(), 2);
     assert_eq!(artifact.missing.len(), 1);
@@ -780,15 +776,17 @@ use ferrocat_po::{
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let result = update_catalog(UpdateCatalogOptions {
-        locale: Some("de"),
-        mode: CatalogMode::IcuFcl,
-        input: CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
-            msgid: "Checkout".to_owned(),
-            ..SourceExtractedMessage::default()
-        }]),
-        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
-    })?;
+    let result = update_catalog(
+        UpdateCatalogOptions::new(
+            "en",
+            CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
+                msgid: "Checkout".to_owned(),
+                ..SourceExtractedMessage::default()
+            }]),
+        )
+        .with_locale("de")
+        .with_mode(CatalogMode::IcuFcl),
+    )?;
 
     assert!(result.content.starts_with("%FCL1\t"));
     assert!(result.content.contains("Checkout"));


### PR DESCRIPTION
Refs #190.

## Summary

- add additive `with_*` setters for the public option structs that previously required field mutation or FRU for common customization
- migrate public crate docs, rustdoc examples, and the API overview away from functional-record-update examples for option structs
- keep the semver-sensitive parts out of this PR: no `#[non_exhaustive]`, no field privacy changes, and no `_with_*` API removal/deprecation

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p ferrocat-po -p ferrocat-icu -p ferrocat --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p ferrocat-po -p ferrocat-icu -p ferrocat --all-features --no-deps --locked`
- `cargo test -p ferrocat-po -p ferrocat-icu -p ferrocat --doc --all-features --locked`
- `git diff --check HEAD~1..HEAD`
- public rustdoc FRU scan for the listed option types
- `pnpm build` from `docs/`
