### PR TITLE
perf(po): compact normalized catalog lookups

### DIFF
--- a/crates/ferrocat-po/src/api/compile.rs
+++ b/crates/ferrocat-po/src/api/compile.rs
@@ -88,10 +88,7 @@ impl NormalizedParsedCatalog {
         for (source_key, message) in self.iter() {
             let effective = source_locale.map_or_else(
                 || message.effective_translation_owned(),
-                |source_locale| {
-                    self.effective_translation_with_source_fallback(source_key, source_locale)
-                        .expect("normalized catalog lookup")
-                },
+                |source_locale| self.effective_translation_for_message(message, source_locale),
             );
             let translation = compiled_translation_for_message(
                 message,
@@ -839,21 +836,24 @@ fn resolve_compiled_catalog_artifact_message(
     source_key: &CatalogMessageKey,
     options: &CompileCatalogArtifactOptions<'_>,
 ) -> Option<ResolvedArtifactMessage> {
+    let msgid = source_key.msgid.as_str();
+    let msgctxt = source_key.msgctxt.as_deref();
+
     for locale in std::iter::once(options.requested_locale)
         .chain(options.fallback_chain.iter().map(String::as_str))
     {
         let Some(catalog) = catalogs.get(locale) else {
             continue;
         };
-        let Some(message) = catalog.get(source_key) else {
+        let Some(message) = catalog.get_by_parts(msgid, msgctxt) else {
             continue;
         };
         if message.obsolete.is_some() || !message_has_runtime_translation(message) {
             continue;
         }
-        return rendered_compiled_catalog_artifact_message(
+        return rendered_compiled_catalog_artifact_message_for_message(
             catalog,
-            source_key,
+            message,
             options.source_locale,
             false,
         )
@@ -870,16 +870,21 @@ fn resolve_compiled_catalog_artifact_message(
     }
 
     let catalog = catalogs.get(options.source_locale)?;
-    let message = catalog.get(source_key)?;
+    let message = catalog.get_by_parts(msgid, msgctxt)?;
     if message.obsolete.is_some() {
         return None;
     }
 
-    rendered_compiled_catalog_artifact_message(catalog, source_key, options.source_locale, true)
-        .map(|message| ResolvedArtifactMessage {
-            locale: options.source_locale.to_owned(),
-            message,
-        })
+    rendered_compiled_catalog_artifact_message_for_message(
+        catalog,
+        message,
+        options.source_locale,
+        true,
+    )
+    .map(|message| ResolvedArtifactMessage {
+        locale: options.source_locale.to_owned(),
+        message,
+    })
 }
 
 /// Renders the final runtime string for one message after translation fallback
@@ -893,9 +898,23 @@ fn rendered_compiled_catalog_artifact_message(
     source_locale: &str,
     use_source_fallback: bool,
 ) -> Option<String> {
-    let message = catalog.get(source_key)?;
+    let message = catalog.get_by_parts(source_key.msgid.as_str(), source_key.msgctxt.as_deref())?;
+    rendered_compiled_catalog_artifact_message_for_message(
+        catalog,
+        message,
+        source_locale,
+        use_source_fallback,
+    )
+}
+
+fn rendered_compiled_catalog_artifact_message_for_message(
+    catalog: &NormalizedParsedCatalog,
+    message: &CatalogMessage,
+    source_locale: &str,
+    use_source_fallback: bool,
+) -> Option<String> {
     let effective = if use_source_fallback {
-        catalog.effective_translation_with_source_fallback(source_key, source_locale)?
+        catalog.effective_translation_for_message(message, source_locale)
     } else {
         message.effective_translation_owned()
     };

--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -1,5 +1,7 @@
-use std::collections::BTreeMap;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{BTreeMap, HashMap, btree_map};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 use crate::{ParseError, PoVec};
@@ -617,28 +619,38 @@ impl ParsedCatalog {
 pub struct NormalizedParsedCatalog {
     pub(super) catalog: ParsedCatalog,
     pub(super) key_index: BTreeMap<CatalogMessageKey, usize>,
-    msgid_index: BTreeMap<String, Vec<usize>>,
+    msgid_hash_index: HashMap<u64, Vec<usize>>,
 }
 
 impl NormalizedParsedCatalog {
     /// Builds the lookup index once and rejects duplicate gettext identities up front.
     pub(super) fn new(catalog: ParsedCatalog) -> Result<Self, ApiError> {
         let mut key_index = BTreeMap::new();
-        let mut msgid_index = BTreeMap::<String, Vec<usize>>::new();
+        let mut msgid_hash_index =
+            HashMap::<u64, Vec<usize>>::with_capacity(catalog.messages.len());
         for (index, message) in catalog.messages.iter().enumerate() {
             let key = message.key();
-            if key_index.insert(key.clone(), index).is_some() {
-                return Err(ApiError::Conflict(format!(
-                    "duplicate parsed catalog message for msgid {:?} and context {:?}",
-                    key.msgid, key.msgctxt
-                )));
+            match key_index.entry(key) {
+                btree_map::Entry::Vacant(entry) => {
+                    entry.insert(index);
+                }
+                btree_map::Entry::Occupied(entry) => {
+                    let key = entry.key();
+                    return Err(ApiError::Conflict(format!(
+                        "duplicate parsed catalog message for msgid {:?} and context {:?}",
+                        key.msgid, key.msgctxt
+                    )));
+                }
             }
-            msgid_index.entry(key.msgid).or_default().push(index);
+            msgid_hash_index
+                .entry(message_id_hash(&message.msgid))
+                .or_default()
+                .push(index);
         }
         Ok(Self {
             catalog,
             key_index,
-            msgid_index,
+            msgid_hash_index,
         })
     }
 
@@ -668,10 +680,14 @@ impl NormalizedParsedCatalog {
     /// already have borrowed source identity fields.
     #[must_use]
     pub fn get_by_parts(&self, msgid: &str, msgctxt: Option<&str>) -> Option<&CatalogMessage> {
-        self.msgid_index.get(msgid)?.iter().find_map(|index| {
-            let message = &self.catalog.messages[*index];
-            (message.msgctxt.as_deref() == msgctxt).then_some(message)
-        })
+        self.msgid_hash_index
+            .get(&message_id_hash(msgid))?
+            .iter()
+            .find_map(|index| {
+                let message = &self.catalog.messages[*index];
+                (message.msgid.as_str() == msgid && message.msgctxt.as_deref() == msgctxt)
+                    .then_some(message)
+            })
     }
 
     /// Returns `true` if a message for `key` exists.
@@ -742,7 +758,7 @@ impl NormalizedParsedCatalog {
         Some(self.effective_translation_for_message(message, source_locale))
     }
 
-    fn effective_translation_for_message(
+    pub(super) fn effective_translation_for_message(
         &self,
         message: &CatalogMessage,
         source_locale: &str,
@@ -758,6 +774,12 @@ impl NormalizedParsedCatalog {
             message.effective_translation_owned()
         }
     }
+}
+
+fn message_id_hash(msgid: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    msgid.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// Encoding used for plural messages in PO files.


### PR DESCRIPTION
## Summary

Part of #188.

This PR reduces allocation in the normalized parsed-catalog lookup layer:

- replaces the owned msgid index with a compact hash-bucket index while keeping collision-safe msgid/msgctxt verification against the original message
- builds the ordered key index via BTreeMap entry insertion so duplicate detection no longer clones the key before insert
- avoids redundant normalized-catalog lookups in compile/artifact resolution when the caller already has the message reference

Public API behavior stays unchanged.

## Validation

- cargo fmt --all --check
- cargo clippy -p ferrocat-po --all-targets --all-features --locked -- -D warnings
- cargo test -p ferrocat-po --all-features --locked
- RUSTDOCFLAGS="-D warnings" cargo doc -p ferrocat-po --all-features --no-deps --locked
- git diff --check HEAD~1..HEAD
