### PR TITLE
perf(po): avoid fcl update allocation leftovers

### DIFF
--- a/crates/ferrocat-po/src/api/catalog.rs
+++ b/crates/ferrocat-po/src/api/catalog.rs
@@ -138,7 +138,7 @@ pub fn update_catalog(
     let input = mem::take(&mut options.input);
     let created = options.existing.is_none();
     let original = options.existing.unwrap_or("");
-    let existing = match options.existing {
+    let mut existing = match options.existing {
         Some(content) if !content.is_empty() => parse_catalog_to_internal(
             content,
             options.locale,
@@ -163,7 +163,7 @@ pub fn update_catalog(
         .map(str::to_owned)
         .or_else(|| existing.locale.clone())
         .or_else(|| existing.headers.get("Language").cloned());
-    let mut diagnostics = existing.diagnostics.clone();
+    let mut diagnostics = mem::take(&mut existing.diagnostics);
     let normalized = normalize_update_input(input)?;
     let merge_context = MergeCatalogContext {
         locale: locale.as_deref(),
@@ -947,7 +947,7 @@ pub(super) fn split_placeholder_comments(
     (comments, dedupe_placeholders(placeholders))
 }
 
-/// Parses the internal placeholder comment format emitted by `append_placeholder_comments`.
+/// Parses the internal placeholder comment format emitted by the export helpers.
 fn parse_placeholder_comment(comment: &str) -> Option<(String, String)> {
     let rest = comment.strip_prefix("placeholder {")?;
     let end = rest.find("}: ")?;

--- a/crates/ferrocat-po/src/api/export.rs
+++ b/crates/ferrocat-po/src/api/export.rs
@@ -323,32 +323,9 @@ fn write_placeholder_comments(
     placeholders: &BTreeMap<String, Vec<String>>,
     mode: &PlaceholderCommentMode,
 ) {
-    let limit = match mode {
-        PlaceholderCommentMode::Disabled => return,
-        PlaceholderCommentMode::Enabled { limit } => *limit,
-    };
-
-    let mut generated_comments = Vec::<String>::new();
-    for (name, values) in placeholders {
-        if !name.chars().all(|ch| ch.is_ascii_digit()) {
-            continue;
-        }
-        for value in values.iter().take(limit) {
-            let comment = format!(
-                "placeholder {{{name}}}: {}",
-                normalize_placeholder_value(value)
-            );
-            if comments.iter().any(|existing| existing == &comment)
-                || generated_comments
-                    .iter()
-                    .any(|existing| existing == &comment)
-            {
-                continue;
-            }
-            write_prefixed_line(out, obsolete_prefix, "#.", &comment);
-            generated_comments.push(comment);
-        }
-    }
+    for_each_placeholder_comment(comments, placeholders, mode, |comment| {
+        write_prefixed_line(out, obsolete_prefix, "#.", comment);
+    });
 }
 
 fn write_plural_msgstr(
@@ -424,10 +401,11 @@ pub(super) fn plural_source_branches(source: &PluralSource) -> BTreeMap<String, 
     map
 }
 
-pub(super) fn append_placeholder_comments(
-    comments: &mut Vec<String>,
+pub(super) fn for_each_placeholder_comment(
+    comments: &[String],
     placeholders: &BTreeMap<String, Vec<String>>,
     mode: &PlaceholderCommentMode,
+    mut visit: impl FnMut(&str),
 ) {
     let limit = match mode {
         PlaceholderCommentMode::Disabled => return,
@@ -446,7 +424,7 @@ pub(super) fn append_placeholder_comments(
                 normalize_placeholder_value(value)
             );
             if seen.insert(comment.clone()) {
-                comments.push(comment);
+                visit(&comment);
             }
         }
     }
@@ -698,7 +676,7 @@ mod tests {
     }
 
     #[test]
-    fn append_placeholder_comments_respects_mode_limit_and_duplicates() {
+    fn placeholder_comment_generator_respects_mode_limit_and_duplicates() {
         let mut comments = vec!["placeholder {0}: known value".to_owned()];
         let placeholders = BTreeMap::from([
             (
@@ -708,11 +686,24 @@ mod tests {
             ("name".to_owned(), vec!["ignored".to_owned()]),
         ]);
 
-        append_placeholder_comments(
-            &mut comments,
-            &placeholders,
-            &PlaceholderCommentMode::Enabled { limit: 2 },
-        );
+        let mut generated = Vec::new();
+        {
+            let mut collect = |comment: &str| generated.push(comment.to_owned());
+            for_each_placeholder_comment(
+                &comments,
+                &placeholders,
+                &PlaceholderCommentMode::Enabled { limit: 2 },
+                &mut collect,
+            );
+
+            for_each_placeholder_comment(
+                &comments,
+                &placeholders,
+                &PlaceholderCommentMode::Disabled,
+                &mut collect,
+            );
+        }
+        comments.extend(generated);
 
         assert_eq!(
             comments,
@@ -720,12 +711,6 @@ mod tests {
                 "placeholder {0}: known value".to_owned(),
                 "placeholder {0}: next value".to_owned(),
             ]
-        );
-
-        append_placeholder_comments(
-            &mut comments,
-            &placeholders,
-            &PlaceholderCommentMode::Disabled,
         );
 
         assert_eq!(

--- a/crates/ferrocat-po/src/api/fcl.rs
+++ b/crates/ferrocat-po/src/api/fcl.rs
@@ -8,13 +8,12 @@
 
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::catalog::{
-    CanonicalMessage, CanonicalTranslation, Catalog, format_origin, parse_origin_owned,
-    split_placeholder_comments,
+    CanonicalMessage, CanonicalTranslation, Catalog, parse_origin_owned, split_placeholder_comments,
 };
-use super::export::{append_placeholder_comments, plural_source_branches};
+use super::export::{for_each_placeholder_comment, plural_source_branches};
 use super::mt::{
     MachineMetadata, format_ai_descriptor, machine_translation_hash, parse_ai_descriptor,
     validate_machine_metadata,
@@ -146,29 +145,36 @@ fn write_entry(out: &mut String, message: &CanonicalMessage, render: &RenderOpti
     if render.include_origins {
         // References are file-only; sort for determinism and drop duplicates that
         // distinct origins can now collapse to.
-        let mut refs = message
+        let refs = message
             .origins
             .iter()
-            .map(format_origin)
-            .collect::<Vec<_>>();
-        refs.sort_unstable();
-        refs.dedup();
-        for reference in &refs {
-            write_tag(out, "r", reference);
+            .map(|origin| (origin.file.as_str(), origin.scope.as_deref()))
+            .collect::<BTreeSet<_>>();
+        let mut reference = String::new();
+        for (file, scope) in refs {
+            reference.clear();
+            reference.push_str(file);
+            if let Some(scope) = scope {
+                reference.push('#');
+                reference.push_str(scope);
+            }
+            write_tag(out, "r", &reference);
         }
     }
 
     // Extracted comments plus the placeholder comments folded back in, matching
     // the catalog's comment round-trip.
-    let mut comments = message.comments.clone();
-    append_placeholder_comments(
-        &mut comments,
-        &message.placeholders,
-        &render.print_placeholders_in_comments,
-    );
-    for comment in &comments {
+    for comment in &message.comments {
         write_tag(out, "c", comment);
     }
+    for_each_placeholder_comment(
+        &message.comments,
+        &message.placeholders,
+        &render.print_placeholders_in_comments,
+        |comment| {
+            write_tag(out, "c", comment);
+        },
+    );
 
     if let Some(info) = &message.obsolete {
         match &info.since {
@@ -619,6 +625,49 @@ mod tests {
         let text = format!("{FCL_MAGIC}\tsource=en\nid\t\tv\tr=src/a.rs\tr=src/a.rs\n");
         let rendered = roundtrip(&text);
         assert_eq!(rendered.matches("\tr=src/a.rs").count(), 1);
+    }
+
+    #[test]
+    fn serializes_scoped_references_and_generated_placeholder_comments() {
+        let message = super::CanonicalMessage {
+            msgid: "Hello {0}".to_owned(),
+            msgctxt: None,
+            translation: super::CanonicalTranslation::Singular {
+                value: "Hallo {0}".to_owned(),
+            },
+            comments: vec!["Translator note".to_owned()],
+            origins: vec![
+                super::CatalogOrigin {
+                    file: "src/app.rs".to_owned(),
+                    scope: Some("Greeting".to_owned()),
+                },
+                super::CatalogOrigin {
+                    file: "src/app.rs".to_owned(),
+                    scope: Some("Greeting".to_owned()),
+                },
+            ]
+            .into(),
+            placeholders: std::collections::BTreeMap::from([(
+                "0".to_owned(),
+                vec!["user\nname".to_owned()],
+            )]),
+            obsolete: None,
+            machine: None,
+        };
+        let catalog = super::Catalog {
+            locale: Some("de".to_owned()),
+            headers: std::collections::BTreeMap::new(),
+            file_comments: Vec::new(),
+            file_extracted_comments: Vec::new(),
+            messages: vec![message],
+            diagnostics: Vec::new(),
+        };
+
+        let text = stringify_catalog_fcl(&catalog, Some("de"), "en", &RenderOptions::default());
+
+        assert_eq!(text.matches("\tr=src/app.rs#Greeting").count(), 1);
+        assert!(text.contains("\tc=Translator note"));
+        assert!(text.contains("\tc=placeholder {0}: user name"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Part of #188.

This PR handles the remaining small allocation cleanups from the catalog API layer:

- move existing parse diagnostics into the update diagnostics buffer instead of cloning them
- write FCL comments without cloning the message comment vector
- sort/dedupe FCL origin references using borrowed origin parts and one scratch string
- share placeholder-comment generation between PO and FCL rendering

Public API behavior stays unchanged.

## Validation

- cargo fmt --all --check
- cargo clippy -p ferrocat-po --all-targets --all-features --locked -- -D warnings
- cargo test -p ferrocat-po --all-features --locked
- RUSTDOCFLAGS="-D warnings" cargo doc -p ferrocat-po --all-features --no-deps --locked
- git diff --check HEAD~1..HEAD
