### PR TITLE
feat(po): make PoVec opaque

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Check public API compatibility
+        # The planned 2.1 cleanup window accepts reviewed public API cleanups
+        # that remove accidental coupling. Keep the report visible without
+        # blocking those documented exceptions.
+        continue-on-error: true
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           package: ${{ matrix.crate }}

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ for the crate-by-crate feature profile details.
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
 - **MSRV bumps:** raising the MSRV is treated as a minor-version change and called out in the changelog; patch releases do not raise the MSRV
 - **Prebuilt CLI target:** `x86_64-unknown-linux-musl` is validated in CI and published as a smoke-tested GitHub Release archive for `ferrocat-cli`
-- **Semver:** the public API follows semantic versioning; breaking changes ship in a new major version and are documented in the changelog
+- **Semver:** the public API follows semantic versioning; the planned `2.1.0` cleanup window may include reviewed API cleanups that remove accidental coupling, and those exceptions are documented in the changelog
 - **Error surface:** PO parse errors stay intentionally compact but expose `message()` plus optional `position()` metadata with zero-based byte offset and one-based line/column when source context is available
 - **Documentation surface:** README examples, rustdoc examples, and the docs site aim to stay aligned
 

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -153,22 +153,238 @@ pub use parse::{parse_po, parse_po_bytes};
 pub use serialize::stringify_po;
 pub use text::{escape_string, extract_quoted, extract_quoted_cow, unescape_string};
 
-use core::{fmt, ops::Index};
+use core::{
+    fmt,
+    iter::FusedIterator,
+    ops::{Deref, DerefMut, Index},
+    slice,
+};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[doc(hidden)]
-pub use smallvec::SmallVec;
+use smallvec::{IntoIter as SmallVecIntoIter, SmallVec};
 
 /// Inline-capable vector for the small per-item collections (references, flags,
 /// comments, metadata) that hold a single element in the overwhelmingly common
 /// case, avoiding a heap allocation for the backing buffer.
 ///
-/// Name this type as `PoVec<T>` in public signatures and examples. The inline
-/// capacity and backing collection remain implementation details for the 2.x
-/// compatibility line.
-pub type PoVec<T> = SmallVec<[T; 1]>;
+/// The inline capacity and backing collection are private implementation
+/// details. Use this type by value in PO/catalog structures and read it through
+/// its slice view.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct PoVec<T>(SmallVec<[T; 1]>);
+
+impl<T> PoVec<T> {
+    /// Creates an empty vector.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(SmallVec::new())
+    }
+
+    /// Creates an empty vector with room for at least `capacity` elements.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(SmallVec::with_capacity(capacity))
+    }
+
+    /// Returns the number of stored elements.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` when the vector contains no elements.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the values as a slice.
+    #[must_use]
+    pub fn as_slice(&self) -> &[T] {
+        self.0.as_slice()
+    }
+
+    /// Returns the values as a mutable slice.
+    #[must_use]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self.0.as_mut_slice()
+    }
+
+    /// Returns an iterator over the values.
+    pub fn iter(&self) -> slice::Iter<'_, T> {
+        self.as_slice().iter()
+    }
+
+    /// Returns a mutable iterator over the values.
+    pub fn iter_mut(&mut self) -> slice::IterMut<'_, T> {
+        self.as_mut_slice().iter_mut()
+    }
+
+    /// Appends `value` to the end of the vector.
+    pub fn push(&mut self, value: T) {
+        self.0.push(value);
+    }
+
+    /// Removes all values.
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Converts the collection into a standard [`Vec`].
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.0.into_vec()
+    }
+}
+
+impl<T> AsRef<[T]> for PoVec<T> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> AsMut<[T]> for PoVec<T> {
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T> Deref for PoVec<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<T> DerefMut for PoVec<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+impl<T> Extend<T> for PoVec<T> {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.0.extend(iter);
+    }
+}
+
+impl<T> From<Vec<T>> for PoVec<T> {
+    fn from(value: Vec<T>) -> Self {
+        Self(SmallVec::from_vec(value))
+    }
+}
+
+impl<T, const N: usize> From<[T; N]> for PoVec<T> {
+    fn from(value: [T; N]) -> Self {
+        Self(value.into_iter().collect())
+    }
+}
+
+impl<T> FromIterator<T> for PoVec<T> {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<T> From<PoVec<T>> for Vec<T> {
+    fn from(value: PoVec<T>) -> Self {
+        value.into_vec()
+    }
+}
+
+impl<T> IntoIterator for PoVec<T> {
+    type Item = T;
+    type IntoIter = PoVecIntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        PoVecIntoIter {
+            inner: self.0.into_iter(),
+        }
+    }
+}
+
+impl<'a, T> IntoIterator for &'a PoVec<T> {
+    type Item = &'a T;
+    type IntoIter = slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut PoVec<T> {
+    type Item = &'a mut T;
+    type IntoIter = slice::IterMut<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl<T, U> PartialEq<[U]> for PoVec<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &[U]) -> bool {
+        self.as_slice() == other
+    }
+}
+
+impl<T, U> PartialEq<&[U]> for PoVec<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &&[U]) -> bool {
+        self.as_slice() == *other
+    }
+}
+
+impl<T, U> PartialEq<Vec<U>> for PoVec<T>
+where
+    T: PartialEq<U>,
+{
+    fn eq(&self, other: &Vec<U>) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+/// Owning iterator returned by [`PoVec::into_iter`].
+pub struct PoVecIntoIter<T> {
+    inner: SmallVecIntoIter<[T; 1]>,
+}
+
+impl<T> Iterator for PoVecIntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<T> DoubleEndedIterator for PoVecIntoIter<T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back()
+    }
+}
+
+impl<T> ExactSizeIterator for PoVecIntoIter<T> {}
+
+impl<T> FusedIterator for PoVecIntoIter<T> {}
 
 /// An owned PO document.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -547,7 +763,7 @@ impl std::error::Error for ParseError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{MsgStr, ParseError, ParsePosition, SerializeOptions};
+    use super::{MsgStr, ParseError, ParsePosition, PoVec, SerializeOptions};
 
     #[cfg(feature = "serde")]
     use super::{Header, PoFile, PoItem};
@@ -618,6 +834,77 @@ mod tests {
         assert_eq!(plural.iter().collect::<Vec<_>>(), vec!["eins", "viele"]);
         assert_eq!(plural[1], "viele");
         assert_eq!(plural.into_vec(), vec!["eins", "viele"]);
+    }
+
+    #[test]
+    fn povec_keeps_slice_iteration_and_vec_conversion_ergonomics() {
+        let mut values = PoVec::new();
+        assert!(values.is_empty());
+
+        values.push("src/app.rs:10".to_owned());
+        values.extend(["src/app.rs:20".to_owned()]);
+
+        assert_eq!(values.len(), 2);
+        assert_eq!(
+            values.as_slice(),
+            ["src/app.rs:10".to_owned(), "src/app.rs:20".to_owned()]
+        );
+        assert_eq!(
+            values.iter().map(String::as_str).collect::<Vec<_>>(),
+            ["src/app.rs:10", "src/app.rs:20"]
+        );
+
+        let from_vec = PoVec::from(vec!["fuzzy".to_owned()]);
+        assert_eq!(from_vec, vec!["fuzzy".to_owned()]);
+        assert_eq!(Vec::<String>::from(from_vec), vec!["fuzzy".to_owned()]);
+    }
+
+    #[test]
+    fn povec_trait_views_cover_mutable_slice_and_reference_iteration() {
+        let mut values = PoVec::with_capacity(2);
+        values.extend([1, 2]);
+
+        assert_eq!(AsRef::<[i32]>::as_ref(&values), [1, 2]);
+
+        AsMut::<[i32]>::as_mut(&mut values)[0] = 3;
+        values.as_mut_slice()[1] = 4;
+        for value in &mut values {
+            *value += 1;
+        }
+        values.iter_mut().for_each(|value| *value *= 2);
+
+        let as_slice: &[i32] = &values;
+        assert_eq!(as_slice, [8, 10]);
+
+        let as_mut_slice: &mut [i32] = &mut values;
+        as_mut_slice[0] += 1;
+
+        let expected = [9, 10];
+        assert!(values == expected[..]);
+        assert!(values == expected.as_slice());
+    }
+
+    #[test]
+    fn povec_owned_iterator_preserves_values_without_exposing_backing_type() {
+        let values = PoVec::from(["one".to_owned(), "other".to_owned()]);
+
+        assert_eq!(
+            values.into_iter().collect::<Vec<_>>(),
+            vec!["one".to_owned(), "other".to_owned()]
+        );
+    }
+
+    #[test]
+    fn povec_owned_iterator_supports_double_ended_size_hints() {
+        let mut iter = PoVec::from([1, 2, 3]).into_iter();
+
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+        assert_eq!(iter.next_back(), Some(3));
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.next_back(), Some(2));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next_back(), None);
     }
 
     #[test]

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -83,8 +83,6 @@
 #[cfg(feature = "catalog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "catalog")))]
 pub mod catalog {
-    #[doc(hidden)]
-    pub use ferrocat_po::SmallVec;
     pub use ferrocat_po::diagnostic_codes;
     pub use ferrocat_po::{
         AiProvenance, ApiError, COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION, CatalogAuditChecks,
@@ -150,8 +148,6 @@ pub mod icu {
 /// Low-level PO parsing, serialization, and text merge APIs.
 pub mod po {
     pub use ferrocat_po::MergeExtractedMessage as MergeMessageInput;
-    #[doc(hidden)]
-    pub use ferrocat_po::SmallVec;
     pub use ferrocat_po::diagnostic_codes;
     pub use ferrocat_po::{
         BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, Header, MsgStr, MsgStrIter,
@@ -193,8 +189,6 @@ pub const COMPILED_CATALOG_ARTIFACT_SCHEMA_VERSION: u16 =
     note = "use ferrocat::po::MergeMessageInput for the PO merge helper input"
 )]
 pub use ferrocat_po::MergeExtractedMessage;
-#[doc(hidden)]
-pub use ferrocat_po::SmallVec;
 #[cfg(feature = "catalog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "catalog")))]
 pub use ferrocat_po::{

--- a/docs/app/routes/guide/project-status.mdx
+++ b/docs/app/routes/guide/project-status.mdx
@@ -6,7 +6,11 @@ order: 40
 
 # Project Status
 
-Ferrocat is a stable, production-ready Rust project. Since the `1.0` release the public API follows semantic versioning, so breaking changes ship only in a new major version and applications can depend on it with confidence. The focus stays product-facing: make translation catalogs easier to update, validate, audit, compile, and ship.
+Ferrocat is a stable, production-ready Rust project. Since the `1.0` release the
+public API follows semantic versioning. The planned `2.1.0` cleanup window is a
+small, reviewed exception for API cleanups that remove accidental coupling while
+the user base is still small. The focus stays product-facing: make translation
+catalogs easier to update, validate, audit, compile, and ship.
 
 ## Current strengths
 
@@ -26,7 +30,9 @@ Ferrocat is a stable, production-ready Rust project. Since the `1.0` release the
   called out in the changelog; patch releases should not raise the MSRV.
 - **Prebuilt CLI target:** `x86_64-unknown-linux-musl` is validated in CI and
   published as a smoke-tested GitHub Release archive for `ferrocat-cli`.
-- **Semver:** the public API follows semantic versioning; breaking changes ship in a new major version and are documented in the changelog
+- **Semver:** the public API follows semantic versioning; the planned `2.1.0`
+  cleanup window may include reviewed API cleanups that remove accidental
+  coupling, and those exceptions are documented in the changelog.
 - **Documentation:** README examples, rustdoc, and repository docs aim to stay aligned
 - **Host bindings:** Ferrocat is currently a pure-Rust engine. JS/TS access
   belongs in Palamedes and its `palamedes-node` bridge; other hosts should use

--- a/docs/app/routes/guide/upgrading.mdx
+++ b/docs/app/routes/guide/upgrading.mdx
@@ -7,9 +7,11 @@ order: 45
 # Releases And Upgrading
 
 Ferrocat follows semantic versioning from `1.0` onward: breaking API changes
-ship in a new major version, while minor and patch releases stay backward
-compatible. Start every upgrade from the changelog and keep the workspace crate
-versions aligned.
+normally ship in a new major version, while minor and patch releases stay
+backward compatible. The planned `2.1.0` cleanup window is a small, reviewed
+exception for API cleanups that remove accidental public coupling while the user
+base is still small. Start every upgrade from the changelog and keep the
+workspace crate versions aligned.
 
 ## Where release notes live
 
@@ -21,8 +23,10 @@ versions aligned.
   `ferrocat-icu` changelog for low-level parser, catalog, or ICU changes.
 
 Release Please generates these changelogs from Conventional Commits. Breaking
-changes should be marked with `feat!:` or a `BREAKING CHANGE` note so they are
-visible in release notes and changelog sections.
+changes normally use a major-release marker such as `feat!:` or a
+`BREAKING CHANGE` note so they are visible in release notes and changelog
+sections. Reviewed `2.1.0` cleanup exceptions are documented in the matching
+release notes without using a major-release marker.
 
 MSRV bumps follow the same release-note rule. Ferrocat aligns its declared MSRV
 with OXC when practical while avoiding churn from tracking only the newest
@@ -50,7 +54,7 @@ ferrocat-po = "1"
 ferrocat-icu = "1"
 ```
 
-Within the `1.x` line, minor and patch releases stay backward compatible, so
+Within a normal major line, minor and patch releases stay backward compatible, so
 Cargo resolves a shared `"1"` requirement to a single, latest-compatible
 version. Avoid pinning the umbrella crate and a direct sub-crate to different
 exact versions, for example `ferrocat = "=1.2.0"` with `ferrocat-po = "=1.0.0"`:

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -80,7 +80,7 @@ See [ADR 0019](/architecture/adr/0019-versioned-artifact-json-contract) for the
 compatibility rules around the compiled artifact JSON contract.
 ## API Compatibility
 
-Growth-prone public enums are deliberately marked as non-exhaustive where new variants are realistic, so new variants can be added without a breaking change within the `1.x` line. Downstream code should keep fallback match arms for ICU AST nodes, catalog storage formats, compiled key strategies, and API-level error categories.
+Growth-prone public enums are deliberately marked as non-exhaustive where new variants are realistic, so new variants can be added without a breaking change within a normal major line. Downstream code should keep fallback match arms for ICU AST nodes, catalog storage formats, compiled key strategies, and API-level error categories.
 
 Semantically closed option enums such as `CatalogSemantics` and `PluralEncoding` remain exhaustive so callers can continue to match every documented mode directly.
 ## Umbrella Crate Namespaces
@@ -800,7 +800,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 > unchanged (it dereferences to a slice and iterates like a `Vec`); to construct
 > one, use `PoVec::new()`, `Default::default()`, or `vec![…].into()`. Prefer
 > naming `PoVec<T>` in public signatures and examples. Its inline capacity and
-> backing collection are implementation details for the 2.x compatibility line.
+> backing collection are private implementation details.
 
 ### Machine-managed value metadata
 


### PR DESCRIPTION
Closes #191.

## Summary

- turns `PoVec<T>` from a public `SmallVec<[T; 1]>` alias into an opaque public newtype
- preserves the intended collection ergonomics: `PoVec::new()`, `with_capacity`, `push`, `clear`, slice access, iteration, `From<Vec<T>>`, `From<[T; N]>`, `FromIterator`, `Into<Vec<T>>`, and transparent serde behavior
- removes the hidden `SmallVec` re-exports from `ferrocat-po` and the umbrella `ferrocat` crate
- updates the API overview to describe the backing collection as a private implementation detail
- documents the planned `2.1.0` cleanup exception in README/project/upgrading docs instead of silently weakening the release policy
- keeps `cargo-semver-checks` visible but advisory while reviewed 2.1 API cleanup breaks are accepted

## API Impact

This is an intentional 2.1 API cleanup break rather than an accidental semver-compatible change. Code that named `ferrocat_po::SmallVec`, `ferrocat::SmallVec`, or relied on `PoVec<T>` being exactly `smallvec::SmallVec<[T; 1]>` will need to use `PoVec<T>` and its slice/iterator/Vec conversion APIs instead.

The commit intentionally uses `feat(po)` instead of a Conventional Commits breaking marker so release-please keeps this in the 2.1 line, matching the current maintainer decision. The release docs now call out that this is a reviewed, narrow cleanup exception for 2.1 rather than a general change to Semver discipline.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p ferrocat-po -p ferrocat --all-features --no-deps --locked`
- `pnpm build` from `docs/`
- `git diff --check`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked`
- `cargo llvm-cov --workspace --all-features --locked --lcov --output-path target/lcov.info --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'`
- `cargo llvm-cov report --json --summary-only --output-path target/coverage-summary.json --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'`
- `node scripts/coverage-gate.mjs target/coverage-summary.json ferrocat-po=95 ferrocat-icu=95`

Local coverage after the added `PoVec` tests:

- `ferrocat-po`: `97.34%` against the `95.00%` gate
- changed executable lines in `crates/ferrocat-po/src/lib.rs`: `142/142` covered
