### PR TITLE
feat(api): make options extensible

### DIFF
--- a/conformance/harness.rs
+++ b/conformance/harness.rs
@@ -148,10 +148,9 @@ fn evaluate_po_roundtrip(case: &ConformanceCase) -> Result<String, String> {
         .ok_or_else(|| format!("roundtrip case {} is missing expected fixture", case.id))?;
     let expected = read_fixture_text(expected_path).map_err(|error| error.to_string())?;
     let parsed = parse_po(&input).map_err(|error| format!("parse failed unexpectedly: {error}"))?;
-    let options = SerializeOptions {
-        fold_length: case.fold_length.unwrap_or(80),
-        compact_multiline: case.compact_multiline.unwrap_or(true),
-    };
+    let options = SerializeOptions::default()
+        .with_fold_length(case.fold_length.unwrap_or(80))
+        .with_compact_multiline(case.compact_multiline.unwrap_or(true));
     let rendered = stringify_po(&parsed, &options);
     if equivalent_text(&rendered, &expected) {
         Ok(String::new())
@@ -285,13 +284,11 @@ fn evaluate_po_plural_header(case: &ConformanceCase) -> Result<String, String> {
             .source_locale
             .clone()
             .unwrap_or_else(|| "en".to_owned());
-        parse_catalog(ParseCatalogOptions {
-            content: &input,
-            locale: Some(locale),
-            source_locale: &source_locale,
-            mode: ferrocat_po::CatalogMode::GettextPo,
-            strict: false,
-        })
+        parse_catalog(
+            ParseCatalogOptions::new(&input, &source_locale)
+                .with_locale(locale)
+                .with_mode(ferrocat_po::CatalogMode::GettextPo),
+        )
         .map_err(|error| format!("parse_catalog failed unexpectedly: {error:?}"))?;
     }
 

--- a/crates/ferrocat-bench/src/compare.rs
+++ b/crates/ferrocat-bench/src/compare.rs
@@ -848,14 +848,14 @@ impl PreparedScenario {
                 let po_content = fixture.content().to_owned();
                 // Render an equivalent FCL catalog so the storage-format comparison
                 // can parse the same logical catalog as both PO and FCL.
-                let parsed = parse_catalog(ParseCatalogOptions {
-                    content: &po_content,
-                    locale: fixture_locale(&first.fixture).as_deref(),
-                    source_locale: "en",
-                    mode: CatalogMode::IcuPo,
-                    strict: false,
-                })
-                .map_err(|error| format!("failed to parse catalog fixture: {error}"))?;
+                let mut options =
+                    ParseCatalogOptions::new(&po_content, "en").with_mode(CatalogMode::IcuPo);
+                let fixture_locale = fixture_locale(&first.fixture);
+                if let Some(locale) = fixture_locale.as_deref() {
+                    options = options.with_locale(locale);
+                }
+                let parsed = parse_catalog(options)
+                    .map_err(|error| format!("failed to parse catalog fixture: {error}"))?;
                 let fcl_content = crate::render_fcl_catalog(&parsed);
                 Ok(Self {
                     operation: first.operation.clone(),
@@ -1165,15 +1165,12 @@ impl PreparedScenario {
         let mut last_parsed = None;
         let start = Instant::now();
         for _ in 0..iterations {
+            let mut options = ParseCatalogOptions::new(content, "en").with_mode(mode);
+            if let Some(locale) = locale.as_deref() {
+                options = options.with_locale(locale);
+            }
             last_parsed = Some(
-                parse_catalog(ParseCatalogOptions {
-                    content,
-                    locale: locale.as_deref(),
-                    source_locale: "en",
-                    mode,
-                    strict: false,
-                })
-                .map_err(|error| format!("parse_catalog failed: {error}"))?,
+                parse_catalog(options).map_err(|error| format!("parse_catalog failed: {error}"))?,
             );
         }
         let elapsed = start.elapsed();
@@ -1323,13 +1320,14 @@ impl PreparedScenario {
         let locale = fixture_locale(&self.fixture);
         let mode = fixture_catalog_mode(&self.fixture);
         for _ in 0..iterations {
-            let updated = update_catalog(UpdateCatalogOptions {
-                locale: locale.as_deref(),
-                mode,
-                existing: Some(fixture.existing_po.as_str()),
-                ..UpdateCatalogOptions::new("en", fixture.api_messages.clone())
-            })
-            .map_err(|error| format!("update_catalog failed: {error}"))?;
+            let mut options = UpdateCatalogOptions::new("en", fixture.api_messages.clone())
+                .with_mode(mode)
+                .with_existing(fixture.existing_po.as_str());
+            if let Some(locale) = locale.as_deref() {
+                options = options.with_locale(locale);
+            }
+            let updated = update_catalog(options)
+                .map_err(|error| format!("update_catalog failed: {error}"))?;
             bytes_processed += updated.content.len();
             last_rendered = Some(updated.content);
         }

--- a/crates/ferrocat-bench/src/fixtures.rs
+++ b/crates/ferrocat-bench/src/fixtures.rs
@@ -1908,13 +1908,11 @@ mod tests {
     #[test]
     fn catalog_modern_fixture_is_parseable_as_icu_catalog() {
         let fixture = fixture_by_name("catalog-modern-de-1000").expect("fixture exists");
-        let parsed = parse_catalog(ParseCatalogOptions {
-            content: fixture.content(),
-            locale: Some("de"),
-            source_locale: "en",
-            mode: CatalogMode::IcuPo,
-            strict: false,
-        })
+        let parsed = parse_catalog(
+            ParseCatalogOptions::new(fixture.content(), "en")
+                .with_locale("de")
+                .with_mode(CatalogMode::IcuPo),
+        )
         .expect("parse catalog");
 
         assert_eq!(parsed.messages.len(), 1000);
@@ -1939,11 +1937,11 @@ mod tests {
     #[test]
     fn update_catalog_accepts_projectable_icu_fixture() {
         let fixture = merge_fixture_by_name("catalog-icu-projectable").expect("fixture exists");
-        let result = update_catalog(UpdateCatalogOptions {
-            locale: Some("de"),
-            existing: Some(fixture.existing_po()),
-            ..UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
-        })
+        let result = update_catalog(
+            UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
+                .with_locale("de")
+                .with_existing(fixture.existing_po()),
+        )
         .expect("update catalog");
 
         assert!(result.content.contains("plural"));
@@ -1953,11 +1951,11 @@ mod tests {
     #[test]
     fn update_catalog_keeps_unsupported_icu_fixture_raw_in_native_mode() {
         let fixture = merge_fixture_by_name("catalog-icu-unsupported").expect("fixture exists");
-        let result = update_catalog(UpdateCatalogOptions {
-            locale: Some("de"),
-            existing: Some(fixture.existing_po()),
-            ..UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
-        })
+        let result = update_catalog(
+            UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
+                .with_locale("de")
+                .with_existing(fixture.existing_po()),
+        )
         .expect("update catalog");
 
         assert!(result.diagnostics.is_empty());

--- a/crates/ferrocat-bench/src/main.rs
+++ b/crates/ferrocat-bench/src/main.rs
@@ -346,14 +346,11 @@ fn run_alloc_stats(fixture: &Fixture) -> Result<(), String> {
 
     ALLOCS.store(0, Ordering::SeqCst);
     BYTES.store(0, Ordering::SeqCst);
-    let catalog = parse_catalog(ParseCatalogOptions {
-        content,
-        locale: inferred_fixture_locale(fixture.name()),
-        source_locale: "en",
-        mode: CatalogMode::IcuPo,
-        strict: false,
-    })
-    .map_err(|error| error.to_string())?;
+    let mut catalog_options = ParseCatalogOptions::new(content, "en").with_mode(CatalogMode::IcuPo);
+    if let Some(locale) = inferred_fixture_locale(fixture.name()) {
+        catalog_options = catalog_options.with_locale(locale);
+    }
+    let catalog = parse_catalog(catalog_options).map_err(|error| error.to_string())?;
     let catalog_allocs = ALLOCS.load(Ordering::SeqCst);
     let catalog_bytes = BYTES.load(Ordering::SeqCst);
     let catalog_items = catalog.messages.len();
@@ -363,26 +360,21 @@ fn run_alloc_stats(fixture: &Fixture) -> Result<(), String> {
     // Render the same catalog as FCL once outside the measured window, then
     // measure the FCL parse so its allocation profile is comparable to PO.
     let fcl_content = {
-        let parsed = parse_catalog(ParseCatalogOptions {
-            content,
-            locale: inferred_fixture_locale(fixture.name()),
-            source_locale: "en",
-            mode: CatalogMode::IcuPo,
-            strict: false,
-        })
-        .map_err(|error| error.to_string())?;
+        let mut options = ParseCatalogOptions::new(content, "en").with_mode(CatalogMode::IcuPo);
+        if let Some(locale) = inferred_fixture_locale(fixture.name()) {
+            options = options.with_locale(locale);
+        }
+        let parsed = parse_catalog(options).map_err(|error| error.to_string())?;
         render_fcl_catalog(&parsed)
     };
     ALLOCS.store(0, Ordering::SeqCst);
     BYTES.store(0, Ordering::SeqCst);
-    let fcl_catalog = parse_catalog(ParseCatalogOptions {
-        content: &fcl_content,
-        locale: inferred_fixture_locale(fixture.name()),
-        source_locale: "en",
-        mode: CatalogMode::IcuFcl,
-        strict: false,
-    })
-    .map_err(|error| error.to_string())?;
+    let mut fcl_options =
+        ParseCatalogOptions::new(&fcl_content, "en").with_mode(CatalogMode::IcuFcl);
+    if let Some(locale) = inferred_fixture_locale(fixture.name()) {
+        fcl_options = fcl_options.with_locale(locale);
+    }
+    let fcl_catalog = parse_catalog(fcl_options).map_err(|error| error.to_string())?;
     let fcl_allocs = ALLOCS.load(Ordering::SeqCst);
     let fcl_bytes = BYTES.load(Ordering::SeqCst);
     let fcl_items = fcl_catalog.messages.len();
@@ -561,14 +553,12 @@ fn bench_parse_catalog_po(fixture: &Fixture, config: BenchConfig) -> Result<(), 
     let samples = run_bench(config, || {
         let start = Instant::now();
         for _ in 0..config.iterations {
-            let parsed = parse_catalog(ParseCatalogOptions {
-                content: fixture.content(),
-                locale: inferred_fixture_locale(fixture.name()),
-                source_locale: "en",
-                mode: CatalogMode::IcuPo,
-                strict: false,
-            })
-            .map_err(|error| error.to_string())?;
+            let mut options =
+                ParseCatalogOptions::new(fixture.content(), "en").with_mode(CatalogMode::IcuPo);
+            if let Some(locale) = inferred_fixture_locale(fixture.name()) {
+                options = options.with_locale(locale);
+            }
+            let parsed = parse_catalog(options).map_err(|error| error.to_string())?;
             parsed_items = parsed.messages.len();
             std::hint::black_box(parsed);
         }
@@ -594,14 +584,12 @@ fn bench_parse_catalog_fcl(fixture: &Fixture, config: BenchConfig) -> Result<(),
     let samples = run_bench(config, || {
         let start = Instant::now();
         for _ in 0..config.iterations {
-            let parsed = parse_catalog(ParseCatalogOptions {
-                content: &content,
-                locale,
-                source_locale: "en",
-                mode: CatalogMode::IcuFcl,
-                strict: false,
-            })
-            .map_err(|error| error.to_string())?;
+            let mut options =
+                ParseCatalogOptions::new(&content, "en").with_mode(CatalogMode::IcuFcl);
+            if let Some(locale) = locale {
+                options = options.with_locale(locale);
+            }
+            let parsed = parse_catalog(options).map_err(|error| error.to_string())?;
             parsed_items = parsed.messages.len();
             std::hint::black_box(parsed);
         }
@@ -747,13 +735,11 @@ fn bench_update_catalog_fcl(fixture: &MergeFixture, config: BenchConfig) -> Resu
     // Convert the fixture's existing PO catalog to FCL once so the timed loop runs
     // the FCL write path (parse + merge + `stringify_catalog_fcl`) — the only
     // public way to exercise the library's FCL serializer.
-    let parsed = parse_catalog(ParseCatalogOptions {
-        content: fixture.existing_po(),
-        locale: Some("de"),
-        source_locale: "en",
-        mode: CatalogMode::IcuPo,
-        strict: false,
-    })
+    let parsed = parse_catalog(
+        ParseCatalogOptions::new(fixture.existing_po(), "en")
+            .with_locale("de")
+            .with_mode(CatalogMode::IcuPo),
+    )
     .map_err(|error| error.to_string())?;
     let existing_fcl = render_fcl_catalog(&parsed);
 
@@ -762,12 +748,12 @@ fn bench_update_catalog_fcl(fixture: &MergeFixture, config: BenchConfig) -> Resu
         let start = Instant::now();
         let mut bytes = 0usize;
         for _ in 0..config.iterations {
-            let rendered = update_catalog(UpdateCatalogOptions {
-                locale: Some("de"),
-                mode: CatalogMode::IcuFcl,
-                existing: Some(&existing_fcl),
-                ..UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
-            })
+            let rendered = update_catalog(
+                UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
+                    .with_locale("de")
+                    .with_mode(CatalogMode::IcuFcl)
+                    .with_existing(&existing_fcl),
+            )
             .map_err(|error| error.to_string())?;
             bytes += rendered.content.len();
             std::hint::black_box(rendered);
@@ -817,11 +803,11 @@ fn bench_update_catalog(fixture: &MergeFixture, config: BenchConfig) -> Result<(
         let start = Instant::now();
         let mut bytes = 0usize;
         for _ in 0..config.iterations {
-            let rendered = update_catalog(UpdateCatalogOptions {
-                locale: Some("de"),
-                existing: Some(fixture.existing_po()),
-                ..UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
-            })
+            let rendered = update_catalog(
+                UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
+                    .with_locale("de")
+                    .with_existing(fixture.existing_po()),
+            )
             .map_err(|error| error.to_string())?;
             bytes += rendered.content.len();
             std::hint::black_box(rendered);
@@ -857,13 +843,17 @@ fn bench_update_catalog_file(fixture: &MergeFixture, config: BenchConfig) -> Res
         let mut bytes = 0usize;
         for _ in 0..config.iterations {
             fs::write(&path, fixture.existing_po()).map_err(|error| error.to_string())?;
-            let rendered = update_catalog_file(UpdateCatalogFileOptions {
-                target_path: &path,
-                options: UpdateCatalogOptions {
-                    locale: Some("de"),
-                    ..UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
-                },
-            })
+            let options =
+                UpdateCatalogOptions::new("en", fixture.api_extracted_messages().to_vec())
+                    .with_locale("de");
+            let rendered = update_catalog_file(
+                UpdateCatalogFileOptions::new(
+                    &path,
+                    "en",
+                    fixture.api_extracted_messages().to_vec(),
+                )
+                .with_options(options),
+            )
             .map_err(|error| error.to_string())?;
             bytes += rendered.content.len();
             std::hint::black_box(rendered);
@@ -899,13 +889,11 @@ fn bench_combine_catalogs(fixture: &MergeFixture, config: BenchConfig) -> Result
         let start = Instant::now();
         let mut bytes = 0usize;
         for _ in 0..config.iterations {
-            let rendered = combine_catalogs(CombineCatalogOptions {
-                inputs: &inputs,
-                locale: Some("de"),
-                source_locale: "en",
-                mode: CatalogMode::IcuPo,
-                ..CombineCatalogOptions::new(&[], "en")
-            })
+            let rendered = combine_catalogs(
+                CombineCatalogOptions::new(&inputs, "en")
+                    .with_locale("de")
+                    .with_mode(CatalogMode::IcuPo),
+            )
             .map_err(|error| error.to_string())?;
             bytes += rendered.content.len();
             std::hint::black_box(rendered);
@@ -1263,14 +1251,12 @@ fn fcl_escape_into(out: &mut String, value: &str) {
     }
 }
 fn fixture_parsed_catalog(fixture: &Fixture) -> Result<ParsedCatalog, String> {
-    parse_catalog(ParseCatalogOptions {
-        content: fixture.content(),
-        locale: inferred_fixture_locale(fixture.name()),
-        source_locale: "en",
-        mode: CatalogMode::IcuPo,
-        strict: false,
-    })
-    .map_err(|error| error.to_string())
+    let mut options =
+        ParseCatalogOptions::new(fixture.content(), "en").with_mode(CatalogMode::IcuPo);
+    if let Some(locale) = inferred_fixture_locale(fixture.name()) {
+        options = options.with_locale(locale);
+    }
+    parse_catalog(options).map_err(|error| error.to_string())
 }
 
 fn render_po_catalog(parsed: &ParsedCatalog) -> String {
@@ -1446,13 +1432,11 @@ mod tests {
         let fixture = fixture_by_name("catalog-modern-de-1000").expect("fixture exists");
         let parsed = fixture_parsed_catalog(&fixture).expect("parse PO catalog");
         let rendered = render_po_catalog(&parsed);
-        let reparsed = parse_catalog(ParseCatalogOptions {
-            content: &rendered,
-            locale: Some("de"),
-            source_locale: "en",
-            mode: CatalogMode::IcuPo,
-            strict: false,
-        })
+        let reparsed = parse_catalog(
+            ParseCatalogOptions::new(&rendered, "en")
+                .with_locale("de")
+                .with_mode(CatalogMode::IcuPo),
+        )
         .expect("reparse rendered PO");
 
         assert_eq!(parsed.locale, reparsed.locale);
@@ -1464,13 +1448,11 @@ mod tests {
         let fixture = fixture_by_name("catalog-modern-de-1000").expect("fixture exists");
         let po_parsed = fixture_parsed_catalog(&fixture).expect("parse PO catalog");
         let rendered = render_fcl_catalog(&po_parsed);
-        let fcl_parsed = parse_catalog(ParseCatalogOptions {
-            content: &rendered,
-            locale: Some("de"),
-            source_locale: "en",
-            mode: CatalogMode::IcuFcl,
-            strict: false,
-        })
+        let fcl_parsed = parse_catalog(
+            ParseCatalogOptions::new(&rendered, "en")
+                .with_locale("de")
+                .with_mode(CatalogMode::IcuFcl),
+        )
         .expect("parse rendered FCL");
 
         assert_eq!(po_parsed.locale, fcl_parsed.locale);

--- a/crates/ferrocat-cli/src/main.rs
+++ b/crates/ferrocat-cli/src/main.rs
@@ -371,11 +371,7 @@ impl AuditConfig {
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>();
-        let options = CatalogAuditOptions {
-            source_locale: &self.source_locale,
-            locales: &locale_filters,
-            ..CatalogAuditOptions::default()
-        };
+        let options = CatalogAuditOptions::new(&self.source_locale).with_locales(&locale_filters);
 
         audit_catalogs(&catalog_refs, &options)
             .map_err(|error| CliError::runtime(format!("catalog audit failed: {error}")))
@@ -391,13 +387,11 @@ fn load_catalog(
     let content = fs::read_to_string(path).map_err(|error| {
         CliError::runtime(format!("failed to read {}: {error}", path.display()))
     })?;
-    parse_catalog(ParseCatalogOptions {
-        content: &content,
-        locale: Some(locale),
-        source_locale,
-        mode: storage_format.catalog_mode(),
-        ..ParseCatalogOptions::new(&content, source_locale)
-    })
+    parse_catalog(
+        ParseCatalogOptions::new(&content, source_locale)
+            .with_locale(locale)
+            .with_mode(storage_format.catalog_mode()),
+    )
     .and_then(ferrocat_po::ParsedCatalog::into_normalized_view)
     .map_err(|error| CliError::runtime(format!("failed to parse {}: {error}", path.display())))
 }

--- a/crates/ferrocat-icu/src/analysis.rs
+++ b/crates/ferrocat-icu/src/analysis.rs
@@ -19,6 +19,7 @@ pub enum IcuDiagnosticSeverity {
 
 /// Broad role of an ICU argument in a parsed message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum IcuArgumentKind {
     /// Simple substitution such as `{name}`.
     Argument,
@@ -64,6 +65,7 @@ impl fmt::Display for IcuArgumentKind {
 
 /// Classification of an optional formatter style segment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum IcuStyleKind {
     /// Formatter has no style segment.
     None,
@@ -99,6 +101,7 @@ pub struct IcuFormatter {
 
 /// Consumer-defined support decision for an ICU formatter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum IcuFormatterSupport {
     /// The formatter kind and style are supported by the consumer.
     Supported,
@@ -167,6 +170,7 @@ pub struct IcuAnalysis {
 
 /// Options controlling ICU source/translation compatibility checks.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct IcuCompatibilityOptions {
     /// Whether translation-only data arguments should be reported.
     pub report_extra_arguments: bool,

--- a/crates/ferrocat-icu/src/error.rs
+++ b/crates/ferrocat-icu/src/error.rs
@@ -24,6 +24,7 @@ pub struct IcuPosition {
 
 /// Error returned when parsing ICU messages fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct IcuParseError {
     /// High-level failure kind.
     pub kind: IcuErrorKind,

--- a/crates/ferrocat-icu/src/parser.rs
+++ b/crates/ferrocat-icu/src/parser.rs
@@ -3,6 +3,7 @@ use crate::error::IcuParseError;
 
 /// Options controlling ICU parsing behavior.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct IcuParserOptions {
     /// When `true`, rich-text style tags are treated as plain text.
     pub ignore_tag: bool,

--- a/crates/ferrocat-icu/src/pseudolocalization.rs
+++ b/crates/ferrocat-icu/src/pseudolocalization.rs
@@ -2,6 +2,7 @@ use crate::{IcuMessage, IcuNode, IcuOption, IcuParseError, parse_icu, stringify_
 
 /// Options controlling ICU-aware pseudolocalization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct IcuPseudolocalizationOptions<'a> {
     /// Literal prefix inserted at the start of the message when absent.
     pub prefix: &'a str,

--- a/crates/ferrocat-po/src/api/audit.rs
+++ b/crates/ferrocat-po/src/api/audit.rs
@@ -20,6 +20,7 @@ use super::{
 
 /// Options controlling catalog audit checks.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub struct CatalogAuditOptions<'a> {
     /// Source locale used as the expected message set.
     pub source_locale: &'a str,
@@ -88,6 +89,7 @@ impl CatalogAuditIcuOptions {
 
 /// Enables or disables individual catalog audit checks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct CatalogAuditChecks {
     /// Check that target locales cover active source messages.
     pub completeness: bool,

--- a/crates/ferrocat-po/src/api/compile_types.rs
+++ b/crates/ferrocat-po/src/api/compile_types.rs
@@ -58,6 +58,7 @@ pub type IcuFormatterSupportPolicy = fn(&IcuFormatter) -> IcuFormatterSupport;
 
 /// Options controlling runtime catalog compilation.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct CompileCatalogOptions<'a> {
     /// Built-in strategy used to derive stable runtime keys.
     pub key_strategy: CompiledKeyStrategy,
@@ -118,6 +119,7 @@ impl<'a> CompileCatalogOptions<'a> {
 
 /// Options controlling high-level compiled catalog artifact generation.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct CompileCatalogArtifactOptions<'a> {
     /// Locale for which the runtime artifact should be produced.
     pub requested_locale: &'a str,
@@ -248,6 +250,7 @@ impl CompileCatalogArtifactIcuOptions {
 
 /// Options controlling selected-subset compiled catalog artifact generation.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct CompileSelectedCatalogArtifactOptions<'a> {
     /// Requested compiled runtime IDs to include in the artifact.
     pub compiled_ids: &'a [String],
@@ -303,6 +306,7 @@ pub enum CompileCatalogArtifactReportSelection<'a> {
 
 /// Options controlling compiled artifact generation with a sibling provenance report.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct CompileCatalogArtifactReportOptions<'a> {
     /// Shared artifact compile options applied to the generated artifact.
     pub options: CompileCatalogArtifactOptions<'a>,

--- a/crates/ferrocat-po/src/api/coverage.rs
+++ b/crates/ferrocat-po/src/api/coverage.rs
@@ -9,6 +9,7 @@ use super::{ApiError, CatalogMessageKey, NormalizedParsedCatalog, validate_sourc
 
 /// Options controlling catalog coverage reports.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub struct CatalogCoverageOptions<'a> {
     /// Source locale whose active message identities define expected coverage.
     pub source_locale: &'a str,

--- a/crates/ferrocat-po/src/api/review.rs
+++ b/crates/ferrocat-po/src/api/review.rs
@@ -14,6 +14,7 @@ use super::{
 
 /// Options controlling catalog review reports.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub struct CatalogReviewOptions<'a> {
     /// Source locale whose active identities define the expected current set.
     pub source_locale: &'a str,

--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -524,6 +524,7 @@ impl CatalogFileFormat {
 
 /// Options for combining catalog files on disk.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct CombineCatalogFilesOptions<'a> {
     /// Input catalog paths in precedence order.
     pub input_paths: &'a [PathBuf],
@@ -571,6 +572,76 @@ impl<'a> CombineCatalogFilesOptions<'a> {
             include_origins: true,
             include_obsolete: false,
         }
+    }
+
+    /// Returns options that use the given input paths.
+    #[must_use]
+    pub fn with_input_paths(mut self, input_paths: &'a [PathBuf]) -> Self {
+        self.input_paths = input_paths;
+        self
+    }
+
+    /// Returns options that atomically replace the given output path.
+    #[must_use]
+    pub fn with_output_path(mut self, output_path: &'a Path) -> Self {
+        self.output_path = output_path;
+        self
+    }
+
+    /// Returns options that use the given explicit file format.
+    #[must_use]
+    pub fn with_format(mut self, format: CatalogFileFormat) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Returns options that read and render with the given catalog mode.
+    #[must_use]
+    pub fn with_mode(mut self, mode: CatalogMode) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+
+    /// Returns options that use the given combined catalog locale.
+    #[must_use]
+    pub fn with_locale(mut self, locale: &'a str) -> Self {
+        self.locale = Some(locale);
+        self
+    }
+
+    /// Returns options that resolve conflicts with the given strategy.
+    #[must_use]
+    pub fn with_conflict_strategy(mut self, conflict_strategy: CatalogConflictStrategy) -> Self {
+        self.conflict_strategy = conflict_strategy;
+        self
+    }
+
+    /// Returns options that apply the given message selection.
+    #[must_use]
+    pub fn with_selection(mut self, selection: CatalogCombineSelection) -> Self {
+        self.selection = selection;
+        self
+    }
+
+    /// Returns options that render the combined catalog with the given sort order.
+    #[must_use]
+    pub fn with_order_by(mut self, order_by: OrderBy) -> Self {
+        self.order_by = order_by;
+        self
+    }
+
+    /// Returns options that enable or disable rendered source origins.
+    #[must_use]
+    pub fn with_include_origins(mut self, include_origins: bool) -> Self {
+        self.include_origins = include_origins;
+        self
+    }
+
+    /// Returns options that include or skip obsolete definitions.
+    #[must_use]
+    pub fn with_include_obsolete(mut self, include_obsolete: bool) -> Self {
+        self.include_obsolete = include_obsolete;
+        self
     }
 }
 
@@ -960,6 +1031,7 @@ impl Default for PlaceholderCommentMode {
 /// References render the source file only; Ferrocat does not track or emit line
 /// numbers (see [`CatalogOrigin`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct RenderOptions<'a> {
     /// Sort order for the final rendered catalog.
     pub order_by: OrderBy,
@@ -1020,6 +1092,7 @@ impl<'a> RenderOptions<'a> {
 
 /// Options for in-memory catalog updates.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct UpdateCatalogOptions<'a> {
     /// Locale of the catalog being updated. When `None`, Ferrocat infers it from the existing file.
     pub locale: Option<&'a str>,
@@ -1120,6 +1193,7 @@ impl<'a> UpdateCatalogOptions<'a> {
 
 /// Options for updating a catalog file on disk.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct UpdateCatalogFileOptions<'a> {
     /// Path to the catalog file that should be read and conditionally written.
     pub target_path: &'a Path,
@@ -1143,10 +1217,18 @@ impl<'a> UpdateCatalogFileOptions<'a> {
             options: UpdateCatalogOptions::new(source_locale, input),
         }
     }
+
+    /// Returns file update options that use the given in-memory update options.
+    #[must_use]
+    pub fn with_options(mut self, options: UpdateCatalogOptions<'a>) -> Self {
+        self.options = options;
+        self
+    }
 }
 
 /// Options for combining multiple catalogs into one deterministic catalog.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct CombineCatalogOptions<'a> {
     /// Input catalogs in precedence order.
     pub inputs: &'a [CatalogCombineInput<'a>],
@@ -1189,10 +1271,67 @@ impl<'a> CombineCatalogOptions<'a> {
             include_obsolete: false,
         }
     }
+
+    /// Returns options that use the given input catalogs.
+    #[must_use]
+    pub fn with_inputs(mut self, inputs: &'a [CatalogCombineInput<'a>]) -> Self {
+        self.inputs = inputs;
+        self
+    }
+
+    /// Returns options that use the given combined catalog locale.
+    #[must_use]
+    pub fn with_locale(mut self, locale: &'a str) -> Self {
+        self.locale = Some(locale);
+        self
+    }
+
+    /// Returns options that read and render with the given catalog mode.
+    #[must_use]
+    pub fn with_mode(mut self, mode: CatalogMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Returns options that resolve conflicts with the given strategy.
+    #[must_use]
+    pub fn with_conflict_strategy(mut self, conflict_strategy: CatalogConflictStrategy) -> Self {
+        self.conflict_strategy = conflict_strategy;
+        self
+    }
+
+    /// Returns options that apply the given message selection.
+    #[must_use]
+    pub fn with_selection(mut self, selection: CatalogCombineSelection) -> Self {
+        self.selection = selection;
+        self
+    }
+
+    /// Returns options that render the combined catalog with the given sort order.
+    #[must_use]
+    pub fn with_order_by(mut self, order_by: OrderBy) -> Self {
+        self.order_by = order_by;
+        self
+    }
+
+    /// Returns options that enable or disable rendered source origins.
+    #[must_use]
+    pub fn with_include_origins(mut self, include_origins: bool) -> Self {
+        self.include_origins = include_origins;
+        self
+    }
+
+    /// Returns options that include or skip obsolete definitions.
+    #[must_use]
+    pub fn with_include_obsolete(mut self, include_obsolete: bool) -> Self {
+        self.include_obsolete = include_obsolete;
+        self
+    }
 }
 
 /// Options for parsing a catalog into the higher-level message model.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ParseCatalogOptions<'a> {
     /// Catalog content to parse.
     pub content: &'a str,
@@ -1625,6 +1764,67 @@ mod tests {
         assert_eq!(parse.locale, Some("fr"));
         assert_eq!(parse.mode, CatalogMode::IcuFcl);
         assert!(parse.strict);
+
+        let input_paths = [PathBuf::from("base.po"), PathBuf::from("overlay.po")];
+        let output_path = Path::new("messages.fcl");
+        let combine_files = CombineCatalogFilesOptions::new(&[], Path::new("unused.po"), "en")
+            .with_input_paths(&input_paths)
+            .with_output_path(output_path)
+            .with_format(CatalogFileFormat::Fcl)
+            .with_mode(CatalogMode::IcuFcl)
+            .with_locale("de")
+            .with_conflict_strategy(CatalogConflictStrategy::UseLast)
+            .with_selection(CatalogCombineSelection::Unique)
+            .with_order_by(OrderBy::Origin)
+            .with_include_origins(false)
+            .with_include_obsolete(true);
+
+        assert_eq!(combine_files.input_paths, &input_paths);
+        assert_eq!(combine_files.output_path, output_path);
+        assert_eq!(combine_files.format, Some(CatalogFileFormat::Fcl));
+        assert_eq!(combine_files.mode, Some(CatalogMode::IcuFcl));
+        assert_eq!(combine_files.locale, Some("de"));
+        assert_eq!(
+            combine_files.conflict_strategy,
+            CatalogConflictStrategy::UseLast
+        );
+        assert_eq!(combine_files.selection, CatalogCombineSelection::Unique);
+        assert_eq!(combine_files.order_by, OrderBy::Origin);
+        assert!(!combine_files.include_origins);
+        assert!(combine_files.include_obsolete);
+
+        let inputs = [CatalogCombineInput::labeled(
+            "msgid \"Hello\"\nmsgstr \"Hallo\"\n",
+            "base",
+        )];
+        let combine = CombineCatalogOptions::new(&[], "en")
+            .with_inputs(&inputs)
+            .with_locale("de")
+            .with_mode(CatalogMode::GettextPo)
+            .with_conflict_strategy(CatalogConflictStrategy::UseLast)
+            .with_selection(CatalogCombineSelection::Unique)
+            .with_order_by(OrderBy::Origin)
+            .with_include_origins(false)
+            .with_include_obsolete(true);
+
+        assert_eq!(combine.inputs, &inputs);
+        assert_eq!(combine.locale, Some("de"));
+        assert_eq!(combine.mode, CatalogMode::GettextPo);
+        assert_eq!(combine.conflict_strategy, CatalogConflictStrategy::UseLast);
+        assert_eq!(combine.selection, CatalogCombineSelection::Unique);
+        assert_eq!(combine.order_by, OrderBy::Origin);
+        assert!(!combine.include_origins);
+        assert!(combine.include_obsolete);
+
+        let file_update = UpdateCatalogFileOptions::new(
+            Path::new("messages.po"),
+            "en",
+            CatalogUpdateInput::default(),
+        )
+        .with_options(update.clone());
+
+        assert_eq!(file_update.target_path, Path::new("messages.po"));
+        assert_eq!(file_update.options, update);
     }
 
     #[test]

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -636,6 +636,7 @@ impl<'a> Iterator for MsgStrIter<'a> {
 
 /// Options controlling PO serialization.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct SerializeOptions {
     /// Preferred soft line-wrap limit for long string literals.
     pub fold_length: usize,

--- a/crates/ferrocat-po/tests/property_po.rs
+++ b/crates/ferrocat-po/tests/property_po.rs
@@ -80,18 +80,15 @@ proptest! {
 
     #[test]
     fn catalog_api_accepts_equivalent_generated_po_and_fcl(entries in entries_strategy()) {
-        let po = parse_catalog(ParseCatalogOptions {
-            content: &render_po(&entries),
-            locale: Some("de"),
-            mode: CatalogMode::IcuPo,
-            ..ParseCatalogOptions::new("", "en")
-        })
+        let po = parse_catalog(
+            ParseCatalogOptions::new(&render_po(&entries), "en")
+                .with_locale("de")
+                .with_mode(CatalogMode::IcuPo),
+        )
         .expect("generated PO catalog should parse");
-        let fcl = parse_catalog(ParseCatalogOptions {
-            content: &render_fcl(&entries),
-            mode: CatalogMode::IcuFcl,
-            ..ParseCatalogOptions::new("", "en")
-        })
+        let fcl = parse_catalog(
+            ParseCatalogOptions::new(&render_fcl(&entries), "en").with_mode(CatalogMode::IcuFcl),
+        )
         .expect("generated FCL catalog should parse");
 
         prop_assert_eq!(po.messages.len(), fcl.messages.len());

--- a/crates/ferrocat/examples/fcl_with_mt_metadata.rs
+++ b/crates/ferrocat/examples/fcl_with_mt_metadata.rs
@@ -10,16 +10,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         hash = hash
     );
 
-    let result = update_catalog(UpdateCatalogOptions {
-        locale: Some("de"),
-        mode: CatalogMode::IcuFcl,
-        existing: Some(&existing),
-        input: CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
-            msgid: "Hello".to_owned(),
-            ..SourceExtractedMessage::default()
-        }]),
-        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
-    })?;
+    let input = CatalogUpdateInput::SourceFirst(vec![SourceExtractedMessage {
+        msgid: "Hello".to_owned(),
+        ..SourceExtractedMessage::default()
+    }]);
+    let result = update_catalog(
+        UpdateCatalogOptions::new("en", input)
+            .with_locale("de")
+            .with_mode(CatalogMode::IcuFcl)
+            .with_existing(&existing),
+    )?;
 
     assert!(result.content.starts_with("%FCL1"));
     assert!(result.content.contains("ai=example/mt:0.92"));

--- a/crates/ferrocat/examples/release_audit.rs
+++ b/crates/ferrocat/examples/release_audit.rs
@@ -4,13 +4,10 @@ fn catalog(
     content: &str,
     locale: &str,
 ) -> Result<NormalizedParsedCatalog, Box<dyn std::error::Error>> {
-    Ok(ferrocat::parse_catalog(ParseCatalogOptions {
-        content,
-        locale: Some(locale),
-        source_locale: "en",
-        ..ParseCatalogOptions::new("", "en")
-    })?
-    .into_normalized_view()?)
+    Ok(
+        ferrocat::parse_catalog(ParseCatalogOptions::new(content, "en").with_locale(locale))?
+            .into_normalized_view()?,
+    )
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/ferrocat/examples/runtime_compile.rs
+++ b/crates/ferrocat/examples/runtime_compile.rs
@@ -7,13 +7,10 @@ fn catalog(
     content: &str,
     locale: &str,
 ) -> Result<NormalizedParsedCatalog, Box<dyn std::error::Error>> {
-    Ok(parse_catalog(ParseCatalogOptions {
-        content,
-        locale: Some(locale),
-        source_locale: "en",
-        ..ParseCatalogOptions::new("", "en")
-    })?
-    .into_normalized_view()?)
+    Ok(
+        parse_catalog(ParseCatalogOptions::new(content, "en").with_locale(locale))?
+            .into_normalized_view()?,
+    )
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -23,10 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
     let german = catalog("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "de")?;
 
-    let options = CompileCatalogArtifactOptions {
-        source_fallback: true,
-        ..CompileCatalogArtifactOptions::new("de", "en")
-    };
+    let options = CompileCatalogArtifactOptions::new("de", "en").with_source_fallback(true);
     let artifact = compile_catalog_artifact(&[&source, &german], &options)?;
 
     assert_eq!(artifact.messages.len(), 2);

--- a/crates/ferrocat/tests/smoke.rs
+++ b/crates/ferrocat/tests/smoke.rs
@@ -68,21 +68,16 @@ msgstr "world"
     }]);
 
     // Every catalog mode must be selectable through umbrella re-exports alone.
-    parse_catalog(ParseCatalogOptions {
-        content: "msgid \"hello\"\nmsgstr \"world\"\n",
-        locale: Some("de"),
-        source_locale: "en",
-        mode: CatalogMode::GettextPo,
-        ..ParseCatalogOptions::new("", "en")
-    })
+    parse_catalog(
+        ParseCatalogOptions::new("msgid \"hello\"\nmsgstr \"world\"\n", "en")
+            .with_locale("de")
+            .with_mode(CatalogMode::GettextPo),
+    )
     .expect("parse gettext-compat catalog");
 
-    let parsed_catalog = parse_catalog(ParseCatalogOptions {
-        content: "msgid \"hello\"\nmsgstr \"world\"\n",
-        locale: Some("de"),
-        source_locale: "en",
-        ..ParseCatalogOptions::new("", "en")
-    })
+    let parsed_catalog = parse_catalog(
+        ParseCatalogOptions::new("msgid \"hello\"\nmsgstr \"world\"\n", "en").with_locale("de"),
+    )
     .expect("parse catalog");
     let normalized = parsed_catalog
         .into_normalized_view()
@@ -97,12 +92,9 @@ msgstr "world"
         Some(EffectiveTranslation::Singular("world".to_owned()))
     );
 
-    let source = parse_catalog(ParseCatalogOptions {
-        content: "msgid \"hello\"\nmsgstr \"hello\"\n",
-        locale: Some("en"),
-        source_locale: "en",
-        ..ParseCatalogOptions::new("", "en")
-    })
+    let source = parse_catalog(
+        ParseCatalogOptions::new("msgid \"hello\"\nmsgstr \"hello\"\n", "en").with_locale("en"),
+    )
     .expect("parse source catalog")
     .into_normalized_view()
     .expect("normalized source catalog");

--- a/docs/app/routes/guide/runtime-compilation.mdx
+++ b/docs/app/routes/guide/runtime-compilation.mdx
@@ -17,10 +17,10 @@ Use `NormalizedParsedCatalog::compile` when you want a runtime-facing lookup str
 ```rust
 use ferrocat::{CompileCatalogOptions, ParseCatalogOptions, parse_catalog};
 
-let parsed = parse_catalog(ParseCatalogOptions {
-    locale: Some("de"),
-    ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
-})?;
+let parsed = parse_catalog(
+    ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
+        .with_locale("de"),
+)?;
 let normalized = parsed.into_normalized_view()?;
 let compiled = normalized.compile(&CompileCatalogOptions::default())?;
 
@@ -43,15 +43,15 @@ use ferrocat::{
     CompileCatalogArtifactOptions, ParseCatalogOptions, compile_catalog_artifact, parse_catalog,
 };
 
-let source = parse_catalog(ParseCatalogOptions {
-    locale: Some("en"),
-    ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en")
-})?
+let source = parse_catalog(
+    ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en")
+        .with_locale("en"),
+)?
 .into_normalized_view()?;
-let requested = parse_catalog(ParseCatalogOptions {
-    locale: Some("de"),
-    ..ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
-})?
+let requested = parse_catalog(
+    ParseCatalogOptions::new("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "en")
+        .with_locale("de"),
+)?
 .into_normalized_view()?;
 
 let artifact = compile_catalog_artifact(

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -82,6 +82,11 @@ compatibility rules around the compiled artifact JSON contract.
 
 Growth-prone public enums are deliberately marked as non-exhaustive where new variants are realistic, so new variants can be added without a breaking change within a normal major line. Downstream code should keep fallback match arms for ICU AST nodes, catalog storage formats, compiled key strategies, and API-level error categories.
 
+Public options structs follow the same growth pattern. Construct options with
+`new()`, `default()`, and `with_*` setters instead of functional record update
+or struct literals; fields stay public for inspection, but external crates
+should not depend on exhaustive field lists.
+
 Semantically closed option enums such as `CatalogSemantics` and `PluralEncoding` remain exhaustive so callers can continue to match every documented mode directly.
 ## Umbrella Crate Namespaces
 


### PR DESCRIPTION
Closes #190.

## Summary

- marks public growth-oriented options structs as `#[non_exhaustive]` across `ferrocat-po` and `ferrocat-icu`
- marks ICU analysis growth surfaces as `#[non_exhaustive]`: `IcuArgumentKind`, `IcuStyleKind`, `IcuFormatterSupport`, and `IcuParseError`
- adds missing `with_*` setters for `CombineCatalogOptions`, `CombineCatalogFilesOptions`, and `UpdateCatalogFileOptions`
- migrates externally compiled examples, CLI code, integration tests, conformance harness code, and benchmark setup away from functional-record-update construction
- documents the options convention in the API overview and updates runtime compilation examples

## API Impact

This is an intentional 2.1 API cleanup break. External crates can still read public fields, but they can no longer construct these options with struct literals or functional record update. Callers should use `new()`, `default()`, and `with_*` setters.

I intentionally did not remove existing `_with_*` functions in this PR. Keeping them avoids extra breakage for no immediate gain; the durable fix is that future knobs can now grow through options structs instead of adding more parallel entry points.

The commit uses `feat(api)` without a Conventional Commits breaking marker so release-please keeps this in the reviewed 2.1 cleanup line.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `pnpm build` from `docs/`
- `git diff --check`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked`
- `cargo llvm-cov --workspace --all-features --locked --lcov --output-path target/lcov.info --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'`
- `cargo llvm-cov report --json --summary-only --output-path target/coverage-summary.json --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'`
- `node scripts/coverage-gate.mjs target/coverage-summary.json ferrocat-po=95 ferrocat-icu=95`

Coverage gate:

- `ferrocat-po`: `97.37%` against `95.00%`
- `ferrocat-icu`: `96.75%` against `95.00%`
