### PR TITLE
feat(api): add ergonomic message helpers

### DIFF
--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -291,6 +291,19 @@ impl CatalogMessageKey {
             msgctxt,
         }
     }
+
+    /// Creates a message key from `msgid` and context.
+    ///
+    /// This is equivalent to `CatalogMessageKey::new(msgid, Some(msgctxt.into()))`
+    /// but lets callers pass borrowed context strings without spelling the
+    /// intermediate `Some(String)`.
+    #[must_use]
+    pub fn with_context(msgid: impl Into<String>, msgctxt: impl Into<String>) -> Self {
+        Self {
+            msgid: msgid.into(),
+            msgctxt: Some(msgctxt.into()),
+        }
+    }
 }
 
 /// Severity level attached to a [`Diagnostic`].
@@ -1539,7 +1552,7 @@ mod tests {
 
         assert_eq!(
             singular.key(),
-            CatalogMessageKey::new("Hello", Some("button".to_owned()))
+            CatalogMessageKey::with_context("Hello", "button")
         );
         assert!(matches!(
             singular.effective_translation(),

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -490,6 +490,17 @@ pub enum MsgStr {
 }
 
 impl MsgStr {
+    /// Creates a plural translation payload without normalizing by slot count.
+    ///
+    /// Use this when the plural shape matters even if the value vector has one
+    /// slot, such as gettext catalogs for one-form locales. `From<Vec<String>>`
+    /// normalizes empty vectors to [`MsgStr::None`] and single-value vectors to
+    /// [`MsgStr::Singular`].
+    #[must_use]
+    pub fn plural(values: Vec<String>) -> Self {
+        Self::Plural(values)
+    }
+
     /// Returns `true` when no translation values are present.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
@@ -808,6 +819,18 @@ mod tests {
         assert_eq!(msgstr.get(0), Some("eins"));
         assert_eq!(msgstr.get(1), Some("viele"));
         assert_eq!(msgstr.get(2), None);
+    }
+
+    #[test]
+    fn msgstr_plural_constructor_preserves_single_slot_shape() {
+        let values = vec!["translation".to_owned()];
+        let plural = MsgStr::plural(values.clone());
+
+        assert_eq!(plural, MsgStr::Plural(values.clone()));
+        assert_ne!(plural, MsgStr::from(values.clone()));
+        assert_eq!(plural.len(), 1);
+        assert_eq!(plural.first_str(), Some("translation"));
+        assert_eq!(plural.into_vec(), values);
     }
 
     #[test]

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -66,6 +66,13 @@ Serializable public output includes:
 - compiled runtime catalog and compiled-ID report records
 - `CompiledCatalogArtifact`
 
+`MsgStr::from(Vec<String>)` keeps the historical low-level normalization: empty
+vectors become `MsgStr::None`, and one-value vectors become
+`MsgStr::Singular`. Use `MsgStr::plural(...)` when the plural shape itself must
+survive, including one-slot plural profiles. For catalog identity helpers,
+`CatalogMessageKey::with_context(msgid, msgctxt)` avoids forcing callers to
+write `Some("context".to_owned())` at every contextual lookup site.
+
 `CompiledCatalogArtifact` is the host-facing runtime payload and has a versioned
 JSON contract. Serialized artifacts include `schema_version: 1`, `messages`,
 `missing`, and `diagnostics`. Deserialization rejects unknown artifact schema


### PR DESCRIPTION
## Summary

- add `MsgStr::plural(Vec<String>)` for callers that need to preserve plural shape even with one plural slot
- add `CatalogMessageKey::with_context(...)` so contextual lookups do not have to allocate and wrap `Some(String)` at every call site
- document the distinction in the API overview
- intentionally leave the broader naming, error-shape, iterator, and compile-option cleanup list on #192 for a separate 3.0/design pass

Refs #192.

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test -p ferrocat-po --lib --all-features --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p ferrocat-po --all-features --no-deps --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- [x] `pnpm build` from `docs/`
- [x] `git diff --check`
- [x] `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked`
- [x] `cargo llvm-cov --workspace --all-features --locked --lcov --output-path target/lcov.info --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'`
- [x] `cargo llvm-cov report --json --summary-only --output-path target/coverage-summary.json --ignore-filename-regex 'crates/ferrocat-(bench|conformance)/'`
- [x] `node scripts/coverage-gate.mjs target/coverage-summary.json ferrocat-cli=85 ferrocat-po=95 ferrocat-icu=95`

Coverage gate result:

- `ferrocat-cli`: 87.13% (474/544)
- `ferrocat-po`: 97.37% (10670/10958)
- `ferrocat-icu`: 96.75% (2383/2463)

## Notes

- public API additions are documented in Rustdoc and `docs/app/routes/reference/api-overview.mdx`
- benchmark impact is not expected: this adds tiny constructors/helpers and no hot-path behavior change
- #192 remains open for the larger 3.0 cleanup batch