### PR TITLE
feat(icu)!: accept self-closing component placeholders `<n/>`

### DIFF
--- a/api-snapshots/ferrocat-icu.txt
+++ b/api-snapshots/ferrocat-icu.txt
@@ -108,6 +108,7 @@ pub ferrocat_icu::IcuNode::Select::options: alloc::vec::Vec<ferrocat_icu::IcuOpt
 pub ferrocat_icu::IcuNode::Tag
 pub ferrocat_icu::IcuNode::Tag::children: alloc::vec::Vec<Self>
 pub ferrocat_icu::IcuNode::Tag::name: alloc::string::String
+pub ferrocat_icu::IcuNode::Tag::self_closing: bool
 pub ferrocat_icu::IcuNode::Time
 pub ferrocat_icu::IcuNode::Time::name: alloc::string::String
 pub ferrocat_icu::IcuNode::Time::style: core::option::Option<alloc::string::String>

--- a/conformance/fixtures/icu/tag_self_closing.txt
+++ b/conformance/fixtures/icu/tag_self_closing.txt
@@ -1,0 +1,1 @@
+line one<0/>line two

--- a/crates/ferrocat-bench/src/compare.rs
+++ b/crates/ferrocat-bench/src/compare.rs
@@ -2233,7 +2233,7 @@ impl IcuCollector {
                 self.visit_options(options, depth + 1, true);
             }
             IcuNode::Pound => self.pound_count += 1,
-            IcuNode::Tag { name, children } => {
+            IcuNode::Tag { name, children, .. } => {
                 self.tag_names.insert(name.clone());
                 self.visit_nodes(children, depth + 1);
             }

--- a/crates/ferrocat-conformance/src/cases/icu_official.rs
+++ b/crates/ferrocat-conformance/src/cases/icu_official.rs
@@ -69,6 +69,21 @@ fn cases() -> Vec<ConformanceCase> {
         ),
 
         parse_case(
+            "icu.tag_self_closing",
+            "icu/tag_self_closing.txt",
+            IcuParseExpected {
+                node_kinds: strings(["literal", "tag", "literal"]),
+                top_level_count: Some(3),
+                first_literal: Some("line one".to_owned()),
+                ..IcuParseExpected::default()
+            },
+        )
+        .source(
+            "https://github.com/sebastian-software/ferrocat/issues/227",
+            "Self-closing component placeholders (<n/>) parse as empty tags",
+        ),
+
+        parse_case(
             "icu.apostrophe_escape",
             "icu/apostrophe_escape.txt",
             IcuParseExpected {

--- a/crates/ferrocat-icu/src/analysis.rs
+++ b/crates/ferrocat-icu/src/analysis.rs
@@ -479,7 +479,7 @@ fn visit_nodes(nodes: &[IcuNode], analysis: &mut IcuAnalysis) {
                 });
                 visit_options(options, analysis);
             }
-            IcuNode::Tag { name, children } => {
+            IcuNode::Tag { name, children, .. } => {
                 analysis.tags.push(IcuTagSummary { name: name.clone() });
                 visit_nodes(children, analysis);
             }
@@ -858,6 +858,15 @@ mod tests {
                 .iter()
                 .any(|argument| argument.kind == IcuArgumentKind::Select)
         );
+    }
+
+    #[test]
+    fn analysis_surfaces_self_closing_tag_names() {
+        let message = parse_icu("line one<0/>line two").expect("parse");
+        let analysis = analyze_icu(&message);
+
+        assert_eq!(extract_tag_names(&message), vec!["0"]);
+        assert_eq!(analysis.tags.len(), 1);
     }
 
     #[test]

--- a/crates/ferrocat-icu/src/ast.rs
+++ b/crates/ferrocat-icu/src/ast.rs
@@ -112,5 +112,10 @@ pub enum IcuNode {
         name: String,
         /// Nested child nodes inside the tag body.
         children: Vec<Self>,
+        /// Whether the tag used the self-closing form (`<name/>`).
+        ///
+        /// Self-closing tags always have empty `children`; the flag preserves
+        /// the compact `<name/>` shape so serialization round-trips faithfully.
+        self_closing: bool,
     },
 }

--- a/crates/ferrocat-icu/src/parser.rs
+++ b/crates/ferrocat-icu/src/parser.rs
@@ -701,8 +701,7 @@ mod tests {
 
     #[test]
     fn parses_self_closing_tag_inside_plural_branch() {
-        let message =
-            parse_icu("{count, plural, one {a<br/>b} other {items}}").expect("parse");
+        let message = parse_icu("{count, plural, one {a<br/>b} other {items}}").expect("parse");
         assert_eq!(
             crate::stringify_icu(&message),
             "{count, plural, one {a<br/>b} other {items}}"

--- a/crates/ferrocat-icu/src/parser.rs
+++ b/crates/ferrocat-icu/src/parser.rs
@@ -72,6 +72,7 @@ struct Parser<'a> {
 impl<'a> Parser<'a> {
     const OFFSET_PREFIX: &'static [u8] = b"offset:";
     const CLOSE_TAG_PREFIX: &'static [u8] = b"</";
+    const SELF_CLOSING_TAG_SUFFIX: &'static [u8] = b"/>";
 
     const fn new(input: &'a str, options: &'a IcuParserOptions) -> Self {
         Self {
@@ -277,6 +278,14 @@ impl<'a> Parser<'a> {
     fn parse_tag(&mut self, plural_depth: usize) -> Result<IcuNode, IcuParseError> {
         self.expect_char('<')?;
         let name = self.parse_tag_name()?;
+        if self.starts_with_bytes(Self::SELF_CLOSING_TAG_SUFFIX) {
+            self.pos += Self::SELF_CLOSING_TAG_SUFFIX.len();
+            return Ok(IcuNode::Tag {
+                name,
+                children: Vec::new(),
+                self_closing: true,
+            });
+        }
         self.expect_char('>')?;
         let children = self.parse_nodes(Some(&name), plural_depth)?;
         self.expect_bytes(Self::CLOSE_TAG_PREFIX)?;
@@ -285,7 +294,11 @@ impl<'a> Parser<'a> {
             return Err(self.error("Mismatched closing tag"));
         }
         self.expect_char('>')?;
-        Ok(IcuNode::Tag { name, children })
+        Ok(IcuNode::Tag {
+            name,
+            children,
+            self_closing: false,
+        })
     }
 
     fn parse_apostrophe_literal(&mut self) -> Result<String, IcuParseError> {
@@ -665,8 +678,43 @@ mod tests {
             parse_icu("<0>{count, plural, one {<b>#</b>} other {items}}</0>").expect("parse");
         assert!(matches!(
             &message.nodes[0],
-            IcuNode::Tag { name, children } if name == "0" && !children.is_empty()
+            IcuNode::Tag { name, children, self_closing }
+                if name == "0" && !children.is_empty() && !self_closing
         ));
+    }
+
+    #[test]
+    fn parses_self_closing_tag() {
+        let message = parse_icu("Foo <0/> bar").expect("parse");
+        assert!(matches!(
+            &message.nodes[1],
+            IcuNode::Tag { name, children, self_closing }
+                if name == "0" && children.is_empty() && *self_closing
+        ));
+    }
+
+    #[test]
+    fn self_closing_tag_round_trips() {
+        let message = parse_icu("line one<0/>line two").expect("parse");
+        assert_eq!(crate::stringify_icu(&message), "line one<0/>line two");
+    }
+
+    #[test]
+    fn parses_self_closing_tag_inside_plural_branch() {
+        let message =
+            parse_icu("{count, plural, one {a<br/>b} other {items}}").expect("parse");
+        assert_eq!(
+            crate::stringify_icu(&message),
+            "{count, plural, one {a<br/>b} other {items}}"
+        );
+    }
+
+    #[test]
+    fn paired_and_self_closing_tags_serialize_distinctly() {
+        let paired = parse_icu("<0></0>").expect("parse paired");
+        let self_closing = parse_icu("<0/>").expect("parse self-closing");
+        assert_eq!(crate::stringify_icu(&paired), "<0></0>");
+        assert_eq!(crate::stringify_icu(&self_closing), "<0/>");
     }
 
     #[test]

--- a/crates/ferrocat-icu/src/pseudolocalization.rs
+++ b/crates/ferrocat-icu/src/pseudolocalization.rs
@@ -147,9 +147,14 @@ fn pseudolocalize_node(node: &IcuNode, options: &IcuPseudolocalizationOptions<'_
             options: pseudolocalize_options(cases, options),
         },
         IcuNode::Pound => IcuNode::Pound,
-        IcuNode::Tag { name, children } => IcuNode::Tag {
+        IcuNode::Tag {
+            name,
+            children,
+            self_closing,
+        } => IcuNode::Tag {
             name: name.clone(),
             children: pseudolocalize_nodes(children, options),
+            self_closing: *self_closing,
         },
     }
 }

--- a/crates/ferrocat-icu/src/serialize.rs
+++ b/crates/ferrocat-icu/src/serialize.rs
@@ -64,14 +64,22 @@ fn render_node(node: &IcuNode, out: &mut String) {
             out.push('}');
         }
         IcuNode::Pound => out.push('#'),
-        IcuNode::Tag { name, children } => {
+        IcuNode::Tag {
+            name,
+            children,
+            self_closing,
+        } => {
             out.push('<');
             out.push_str(name);
-            out.push('>');
-            render_nodes(children, out);
-            out.push_str("</");
-            out.push_str(name);
-            out.push('>');
+            if *self_closing {
+                out.push_str("/>");
+            } else {
+                out.push('>');
+                render_nodes(children, out);
+                out.push_str("</");
+                out.push_str(name);
+                out.push('>');
+            }
         }
     }
 }

--- a/crates/ferrocat-icu/src/utils.rs
+++ b/crates/ferrocat-icu/src/utils.rs
@@ -82,7 +82,7 @@ fn visit_nodes(nodes: &[IcuNode], visitor: &mut impl FnMut(&str)) {
                 visitor(name);
                 visit_options(options, visitor);
             }
-            IcuNode::Tag { name, children } => {
+            IcuNode::Tag { name, children, .. } => {
                 visitor(name);
                 visit_nodes(children, visitor);
             }

--- a/crates/ferrocat-po/src/api/plural.rs
+++ b/crates/ferrocat-po/src/api/plural.rs
@@ -829,16 +829,24 @@ fn render_projectable_icu_node(node: &IcuNode, out: &mut String) -> Result<(), &
         IcuNode::Ago { name, style } => render_formatter("ago", name, style.as_deref(), out),
         IcuNode::Name { name, style } => render_formatter("name", name, style.as_deref(), out),
         IcuNode::Pound => out.push('#'),
-        IcuNode::Tag { name, children } => {
+        IcuNode::Tag {
+            name,
+            children,
+            self_closing,
+        } => {
             out.push('<');
             out.push_str(name);
-            out.push('>');
-            for child in children {
-                render_projectable_icu_node(child, out)?;
+            if *self_closing {
+                out.push_str("/>");
+            } else {
+                out.push('>');
+                for child in children {
+                    render_projectable_icu_node(child, out)?;
+                }
+                out.push_str("</");
+                out.push_str(name);
+                out.push('>');
             }
-            out.push_str("</");
-            out.push_str(name);
-            out.push('>');
         }
         IcuNode::Select { .. } | IcuNode::Plural { .. } => {
             return Err(

--- a/crates/ferrocat-po/src/api/plural.rs
+++ b/crates/ferrocat-po/src/api/plural.rs
@@ -1170,7 +1170,7 @@ mod tests {
     #[test]
     fn project_icu_plural_renders_supported_nested_leaf_nodes() {
         let projection = project_icu_plural(
-            "{count, plural, one {It''s '{'one'}' <b>{name}</b> {price, number, integer} {created, date, short} {time, time, HH:mm} {items, list, conjunction} {elapsed, duration} {since, ago} {person, name}} other {# files}}",
+            "{count, plural, one {It''s '{'one'}' <b>{name}</b><0/> {price, number, integer} {created, date, short} {time, time, HH:mm} {items, list, conjunction} {elapsed, duration} {since, ago} {person, name}} other {# files}}",
         );
 
         match projection {
@@ -1179,29 +1179,12 @@ mod tests {
                 assert_eq!(
                     parsed.branches.get("one").map(String::as_str),
                     Some(
-                        "It''s '{'one'}' <b>{name}</b> {price, number, integer} {created, date, short} {time, time, HH:mm} {items, list, conjunction} {elapsed, duration} {since, ago} {person, name}"
+                        "It''s '{'one'}' <b>{name}</b><0/> {price, number, integer} {created, date, short} {time, time, HH:mm} {items, list, conjunction} {elapsed, duration} {since, ago} {person, name}"
                     )
                 );
                 assert_eq!(
                     parsed.branches.get("other").map(String::as_str),
                     Some("# files")
-                );
-            }
-            _ => panic!("expected projected plural"),
-        }
-    }
-
-    #[test]
-    fn project_icu_plural_preserves_self_closing_tags() {
-        let projection =
-            project_icu_plural("{count, plural, one {line one<0/>line two} other {# files}}");
-
-        match projection {
-            IcuPluralProjection::Projected(parsed) => {
-                assert_eq!(parsed.variable, "count");
-                assert_eq!(
-                    parsed.branches.get("one").map(String::as_str),
-                    Some("line one<0/>line two")
                 );
             }
             _ => panic!("expected projected plural"),

--- a/crates/ferrocat-po/src/api/plural.rs
+++ b/crates/ferrocat-po/src/api/plural.rs
@@ -1192,6 +1192,23 @@ mod tests {
     }
 
     #[test]
+    fn project_icu_plural_preserves_self_closing_tags() {
+        let projection =
+            project_icu_plural("{count, plural, one {line one<0/>line two} other {# files}}");
+
+        match projection {
+            IcuPluralProjection::Projected(parsed) => {
+                assert_eq!(parsed.variable, "count");
+                assert_eq!(
+                    parsed.branches.get("one").map(String::as_str),
+                    Some("line one<0/>line two")
+                );
+            }
+            _ => panic!("expected projected plural"),
+        }
+    }
+
+    #[test]
     fn project_icu_plural_reports_malformed_and_non_plural_candidates() {
         assert!(matches!(
             project_icu_plural("{count, plural, one {# file} other {# files}"),


### PR DESCRIPTION
## Summary

Fixes #227.

The ICU-with-tags parser rejected **self-closing component placeholders** (`<n/>`), accepting only the paired form (`<n>…</n>`). Any message containing a self-closing tag failed to parse with `Expected '>'`. This blocked compile-time catalog validation (`ferrocat::compile_catalog_artifact` → `invalid_icu_message`) for the very common `<Trans>line one<br/>line two</Trans>` pattern, which Palamedes (sebastian-software/palamedes#328) already extracts as `"line one<0/>line two"`.

## Approach — Option 2 (preserve self-closing form)

- `parse_tag` now detects a trailing `/>` after the tag name and returns an empty-children `Tag`.
- `IcuNode::Tag` gains a `self_closing: bool` flag so the serializer round-trips `<n/>` faithfully instead of normalizing to `<n></n>`.
- All match sites updated: `analysis`, `utils`, `pseudolocalization`, `serialize` (ferrocat-icu), plus `ferrocat-po` plural projection and `ferrocat-bench` compare.

## ⚠️ Breaking change

`IcuNode::Tag` has a new `self_closing: bool` field. `IcuNode` is **not** `#[non_exhaustive]`, so any exhaustive match on `IcuNode::Tag { name, children }` in downstream code must be updated. Marked as `feat!:` so release-please issues the major bump.

## Tests

- Parser: self-closing parse, round-trip, nested inside a plural branch, and paired-vs-self-closing serialization distinction.
- Analysis: `extract_tag_names` / `analyze_icu` surface self-closing tag names (core tag-mismatch detection).
- Conformance: new fixture `conformance/fixtures/icu/tag_self_closing.txt` + case `icu.tag_self_closing` in the official ICU suite.
- The existing invalid case `<a>broken</>` still correctly errors.

## Verification

- `cargo test --workspace` — green.
- `cargo clippy -p ferrocat-icu` — clean.
- Public API snapshot (`api-snapshots/ferrocat-icu.txt`) updated and verified against `nightly-2026-06-30` / `cargo-public-api 0.52.0` (`check-public-api-snapshots.sh` exits 0, no diff).

## References

- Downstream issue: sebastian-software/palamedes#328
- Affected crate: `ferrocat-icu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)