### PR TITLE
feat(icu): self-closing tags without breaking API + yank 3.0.0 (2.2.0)

### DIFF
--- a/.github/workflows/yank.yml
+++ b/.github/workflows/yank.yml
@@ -1,0 +1,47 @@
+name: Yank
+
+# One-off maintenance workflow to yank a published version from crates.io.
+# Added to retract 3.0.0 (superseded by the non-breaking 2.2.0). Trigger it
+# manually from the Actions tab *after* the replacement version is published,
+# then remove this workflow in a follow-up PR.
+
+env:
+  CARGO_TERM_COLOR: always
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to yank from crates.io
+        required: true
+        default: "3.0.0"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  yank:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate to crates.io
+        id: crates-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Yank published crates
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          for crate in ferrocat-icu ferrocat-po ferrocat ferrocat-cli; do
+            echo "Yanking ${crate}@${VERSION}"
+            cargo yank --version "$VERSION" "$crate"
+          done

--- a/api-snapshots/ferrocat-icu.txt
+++ b/api-snapshots/ferrocat-icu.txt
@@ -108,7 +108,6 @@ pub ferrocat_icu::IcuNode::Select::options: alloc::vec::Vec<ferrocat_icu::IcuOpt
 pub ferrocat_icu::IcuNode::Tag
 pub ferrocat_icu::IcuNode::Tag::children: alloc::vec::Vec<Self>
 pub ferrocat_icu::IcuNode::Tag::name: alloc::string::String
-pub ferrocat_icu::IcuNode::Tag::self_closing: bool
 pub ferrocat_icu::IcuNode::Time
 pub ferrocat_icu::IcuNode::Time::name: alloc::string::String
 pub ferrocat_icu::IcuNode::Time::style: core::option::Option<alloc::string::String>

--- a/crates/ferrocat-icu/src/ast.rs
+++ b/crates/ferrocat-icu/src/ast.rs
@@ -111,11 +111,10 @@ pub enum IcuNode {
         /// Tag name without angle brackets.
         name: String,
         /// Nested child nodes inside the tag body.
-        children: Vec<Self>,
-        /// Whether the tag used the self-closing form (`<name/>`).
         ///
-        /// Self-closing tags always have empty `children`; the flag preserves
-        /// the compact `<name/>` shape so serialization round-trips faithfully.
-        self_closing: bool,
+        /// A self-closing tag (`<name/>`) is represented as an empty `children`
+        /// vector; the serializer renders any empty tag in the compact
+        /// `<name/>` form.
+        children: Vec<Self>,
     },
 }

--- a/crates/ferrocat-icu/src/parser.rs
+++ b/crates/ferrocat-icu/src/parser.rs
@@ -283,7 +283,6 @@ impl<'a> Parser<'a> {
             return Ok(IcuNode::Tag {
                 name,
                 children: Vec::new(),
-                self_closing: true,
             });
         }
         self.expect_char('>')?;
@@ -294,11 +293,7 @@ impl<'a> Parser<'a> {
             return Err(self.error("Mismatched closing tag"));
         }
         self.expect_char('>')?;
-        Ok(IcuNode::Tag {
-            name,
-            children,
-            self_closing: false,
-        })
+        Ok(IcuNode::Tag { name, children })
     }
 
     fn parse_apostrophe_literal(&mut self) -> Result<String, IcuParseError> {
@@ -678,8 +673,8 @@ mod tests {
             parse_icu("<0>{count, plural, one {<b>#</b>} other {items}}</0>").expect("parse");
         assert!(matches!(
             &message.nodes[0],
-            IcuNode::Tag { name, children, self_closing }
-                if name == "0" && !children.is_empty() && !self_closing
+            IcuNode::Tag { name, children }
+                if name == "0" && !children.is_empty()
         ));
     }
 
@@ -688,8 +683,8 @@ mod tests {
         let message = parse_icu("Foo <0/> bar").expect("parse");
         assert!(matches!(
             &message.nodes[1],
-            IcuNode::Tag { name, children, self_closing }
-                if name == "0" && children.is_empty() && *self_closing
+            IcuNode::Tag { name, children }
+                if name == "0" && children.is_empty()
         ));
     }
 
@@ -709,10 +704,12 @@ mod tests {
     }
 
     #[test]
-    fn paired_and_self_closing_tags_serialize_distinctly() {
+    fn empty_tags_serialize_self_closing() {
+        // `<n/>` and the empty paired form `<n></n>` both parse to a tag with
+        // empty children and are serialized in the compact self-closing shape.
         let paired = parse_icu("<0></0>").expect("parse paired");
         let self_closing = parse_icu("<0/>").expect("parse self-closing");
-        assert_eq!(crate::stringify_icu(&paired), "<0></0>");
+        assert_eq!(crate::stringify_icu(&paired), "<0/>");
         assert_eq!(crate::stringify_icu(&self_closing), "<0/>");
     }
 

--- a/crates/ferrocat-icu/src/pseudolocalization.rs
+++ b/crates/ferrocat-icu/src/pseudolocalization.rs
@@ -147,14 +147,9 @@ fn pseudolocalize_node(node: &IcuNode, options: &IcuPseudolocalizationOptions<'_
             options: pseudolocalize_options(cases, options),
         },
         IcuNode::Pound => IcuNode::Pound,
-        IcuNode::Tag {
-            name,
-            children,
-            self_closing,
-        } => IcuNode::Tag {
+        IcuNode::Tag { name, children } => IcuNode::Tag {
             name: name.clone(),
             children: pseudolocalize_nodes(children, options),
-            self_closing: *self_closing,
         },
     }
 }

--- a/crates/ferrocat-icu/src/serialize.rs
+++ b/crates/ferrocat-icu/src/serialize.rs
@@ -64,14 +64,10 @@ fn render_node(node: &IcuNode, out: &mut String) {
             out.push('}');
         }
         IcuNode::Pound => out.push('#'),
-        IcuNode::Tag {
-            name,
-            children,
-            self_closing,
-        } => {
+        IcuNode::Tag { name, children } => {
             out.push('<');
             out.push_str(name);
-            if *self_closing {
+            if children.is_empty() {
                 out.push_str("/>");
             } else {
                 out.push('>');

--- a/crates/ferrocat-po/src/api/plural.rs
+++ b/crates/ferrocat-po/src/api/plural.rs
@@ -829,14 +829,10 @@ fn render_projectable_icu_node(node: &IcuNode, out: &mut String) -> Result<(), &
         IcuNode::Ago { name, style } => render_formatter("ago", name, style.as_deref(), out),
         IcuNode::Name { name, style } => render_formatter("name", name, style.as_deref(), out),
         IcuNode::Pound => out.push('#'),
-        IcuNode::Tag {
-            name,
-            children,
-            self_closing,
-        } => {
+        IcuNode::Tag { name, children } => {
             out.push('<');
             out.push_str(name);
-            if *self_closing {
+            if children.is_empty() {
                 out.push_str("/>");
             } else {
                 out.push('>');


### PR DESCRIPTION
## Warum

`3.0.0` wurde nur deshalb ein Major-Release, weil der Fix für #227 ein öffentliches Feld
`self_closing: bool` an `IcuNode::Tag` angehängt hat — eine quellcode-brechende API-Änderung,
die release-please automatisch von 2.1.1 auf 3.0.0 hochgezogen hat. Der Breaking Change ist
unnötig: Issue #227 verlangt nur, dass der Parser `<n/>` **akzeptiert** (Compile-Zeit-Validierung
für `"a<0/>b"`).

Dieser PR liefert denselben funktionalen Fix **ohne API-Änderung** (Option B) und erzwingt via
`Release-As: 2.2.0` ein non-breaking Minor-Release. `3.0.0` wird auf crates.io geyankt.

## Änderungen

**`feat(icu)`: self-closing ohne API-Änderung**
- `IcuNode::Tag` ist wieder `{ name, children }` — das `self_closing`-Feld entfällt.
- Parser normalisiert `<n/>` zu einem `Tag` mit leeren `children`.
- Serializer (icu + po-Projection) rendert **jeden** leeren Tag kompakt als `<n/>`;
  ein leeres Paar `<n></n>` wird ebenfalls zu `<n/>` normalisiert (semantisch identisch).
- Public-API-Snapshot um die `Tag::self_closing`-Zeile bereinigt.

**`ci(release)`: einmalige Yank-Action**
- `.github/workflows/yank.yml` (manuell, `workflow_dispatch`) yankt `3.0.0` der vier
  publizierten Crates über denselben crates.io-OIDC-Auth wie `publish.yml`.
- Wird in einem **Folge-PR wieder entfernt**.

## Nach dem Merge

1. release-please-PR prüfen, dass er auf **2.2.0** zielt → mergen → publish.yml veröffentlicht.
2. `Yank`-Action mit `version=3.0.0` starten (nach erfolgtem 2.2.0-Publish).
3. Folge-PR: `yank.yml` entfernen.

## Tests / Verifikation

- `cargo test --workspace --all-features` grün (u. a. `parses_self_closing_tag`,
  `self_closing_tag_round_trips`, `empty_tags_serialize_self_closing`,
  `parses_self_closing_tag_inside_plural_branch`, Conformance `icu.tag_self_closing`).
- `cargo clippy --workspace --all-features --all-targets` ohne Findings.
- `cargo fmt --all --check` sauber.
- Public-API-Snapshot-Check (nightly-2026-06-30, cargo-public-api 0.52.0) grün — Diff nur die
  entfernte `self_closing`-Zeile.

## Hinweise

- `3.0.0` bleibt als Tag/Release erhalten (Repo-Policy) und wird auf crates.io nur geyankt —
  vollständiges Entfernen ist bei crates.io nicht möglich.
- **Caveat**: Sollte der OIDC-Token `cargo yank` nicht erlauben, in `yank.yml` auf ein
  Repo-Secret `CRATES_IO_TOKEN` umstellen.

Refs #227
