### PR TITLE
ci(release): yank via CRATES_IO_TOKEN secret

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -236,15 +236,17 @@ jobs:
           publish_with_retry ferrocat 5 30
           publish_with_retry ferrocat-cli 5 30
 
-  # Manual maintenance: retract a published version from crates.io. Lives in
-  # publish.yml because crates.io Trusted Publishing binds the OIDC token to
-  # this workflow's filename, so a separate workflow cannot authenticate.
+  # Manual maintenance: retract a published version from crates.io.
+  #
+  # Uses a stored CRATES_IO_TOKEN secret (a crates.io API token with the "yank"
+  # scope) rather than Trusted Publishing: the OIDC token minted by
+  # crates-io-auth-action is scoped to publishing only and crates.io rejects
+  # yank with 403 "authentication failed".
   yank:
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.yank_version != '' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      id-token: write
 
     steps:
       - name: Check out repository
@@ -253,16 +255,16 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Authenticate to crates.io
-        id: crates-auth
-        uses: rust-lang/crates-io-auth-action@v1
-
       - name: Yank published crates
         shell: bash
         env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
           VERSION: ${{ github.event.inputs.yank_version }}
         run: |
+          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
+            echo "::error::CRATES_IO_TOKEN secret is not set; cannot yank." >&2
+            exit 1
+          fi
           for crate in ferrocat-icu ferrocat-po ferrocat ferrocat-cli; do
             echo "Yanking ${crate}@${VERSION}"
             cargo yank --version "$VERSION" "$crate"


### PR DESCRIPTION
Der Trusted-Publishing-OIDC-Token authentifiziert zwar, ist aber nur auf **Publish** gescoped — crates.io lehnt `cargo yank` mit `403 authentication failed` ab (bewiesen im Dispatch-Run 28752596518).

## Änderung
- Yank-Job in `publish.yml` nutzt jetzt ein gespeichertes Secret `CRATES_IO_TOKEN` (crates.io-API-Token mit **yank**-Scope) statt OIDC.
- `id-token: write` entfällt; Fail-fast, falls das Secret fehlt.

## Voraussetzung vor dem Dispatch
1. Auf https://crates.io/settings/tokens ein API-Token mit Scope **yank** erstellen.
2. Als Repo-Secret **`CRATES_IO_TOKEN`** hinterlegen (Settings → Secrets and variables → Actions).

## Danach
1. `Publish`-Workflow manuell mit `yank_version=3.0.0` dispatchen → 3.0.0 wird geyankt.
2. Folge-PR: den gesamten `yank`-Job + `workflow_dispatch` wieder aus `publish.yml` entfernen (und Secret optional löschen).

Refs #227