### PR TITLE
ci(release): consolidate GitHub product releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,8 @@ jobs:
       pull-requests: write
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
-      ferrocat_cli_release_created: ${{ steps.release.outputs['crates/ferrocat-cli--release_created'] }}
-      ferrocat_cli_tag_name: ${{ steps.release.outputs['crates/ferrocat-cli--tag_name'] }}
-      ferrocat_cli_version: ${{ steps.release.outputs['crates/ferrocat-cli--version'] }}
+      ferrocat_tag_name: ${{ steps.release.outputs['crates/ferrocat--tag_name'] }}
+      ferrocat_version: ${{ steps.release.outputs['crates/ferrocat--version'] }}
 
     steps:
       - name: Check out repository
@@ -56,22 +55,22 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
-      - name: Resolve ferrocat CLI release
-        id: cli-release
+      - name: Resolve Ferrocat product release
+        id: product-release
         shell: bash
         env:
-          RELEASE_PLEASE_CLI_TAG: ${{ needs.release-please.outputs.ferrocat_cli_tag_name }}
-          RELEASE_PLEASE_CLI_VERSION: ${{ needs.release-please.outputs.ferrocat_cli_version }}
+          RELEASE_PLEASE_TAG: ${{ needs.release-please.outputs.ferrocat_tag_name }}
+          RELEASE_PLEASE_VERSION: ${{ needs.release-please.outputs.ferrocat_version }}
         run: |
-          version="$RELEASE_PLEASE_CLI_VERSION"
+          version="$RELEASE_PLEASE_VERSION"
           if [ -z "$version" ]; then
             package_id="$(cargo pkgid -p ferrocat-cli)"
             version="${package_id##*#}"
           fi
 
-          tag="$RELEASE_PLEASE_CLI_TAG"
+          tag="$RELEASE_PLEASE_TAG"
           if [ -z "$tag" ]; then
-            tag="ferrocat-cli-v${version}"
+            tag="ferrocat-v${version}"
           fi
 
           artifact_name="ferrocat-${version}-${MUSL_TARGET}"
@@ -80,10 +79,10 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "artifact_name=${artifact_name}" >> "$GITHUB_OUTPUT"
 
-      - name: Confirm ferrocat CLI release exists
+      - name: Confirm Ferrocat product release exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release view "${{ steps.cli-release.outputs.tag }}" --json tagName,url
+        run: gh release view "${{ steps.product-release.outputs.tag }}" --json tagName,url
 
       - name: Install musl linker
         run: |
@@ -109,7 +108,7 @@ jobs:
       - name: Package musl CLI artifact
         shell: bash
         env:
-          ARTIFACT_NAME: ${{ steps.cli-release.outputs.artifact_name }}
+          ARTIFACT_NAME: ${{ steps.product-release.outputs.artifact_name }}
         run: |
           artifact_dir="target/dist/${ARTIFACT_NAME}"
 
@@ -127,9 +126,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
           gh release upload
-          "${{ steps.cli-release.outputs.tag }}"
-          "target/dist/${{ steps.cli-release.outputs.artifact_name }}.tar.gz"
-          "target/dist/${{ steps.cli-release.outputs.artifact_name }}.tar.gz.sha256"
+          "${{ steps.product-release.outputs.tag }}"
+          "target/dist/${{ steps.product-release.outputs.artifact_name }}.tar.gz"
+          "target/dist/${{ steps.product-release.outputs.artifact_name }}.tar.gz.sha256"
           --clobber
 
   publish-rust:
@@ -228,3 +227,65 @@ jobs:
           publish_with_retry ferrocat-po 5 30
           publish_with_retry ferrocat 5 30
           publish_with_retry ferrocat-cli 5 30
+
+  cleanup-component-releases:
+    needs:
+      - release-please
+      - publish-cli-musl
+      - publish-rust
+    if: >-
+      ${{ always() && needs.release-please.outputs.releases_created == 'true'
+      && needs.publish-cli-musl.result == 'success'
+      && needs.publish-rust.result == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Consolidate and remove component GitHub releases
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRODUCT_TAG: ${{ needs.release-please.outputs.ferrocat_tag_name }}
+          RELEASE_VERSION: ${{ needs.release-please.outputs.ferrocat_version }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "Release Please did not report the Ferrocat version." >&2
+            exit 1
+          fi
+
+          product_tag="$PRODUCT_TAG"
+          if [ -z "$product_tag" ]; then
+            product_tag="ferrocat-v${RELEASE_VERSION}"
+          fi
+
+          notes_file="$(mktemp)"
+          trap 'rm -f "$notes_file"' EXIT
+          gh release view "$product_tag" --json body --jq .body > "$notes_file"
+
+          component_tags=()
+          for component in ferrocat-po ferrocat-icu ferrocat-conformance ferrocat-bench ferrocat-cli; do
+            tag="${component}-v${RELEASE_VERSION}"
+
+            if gh release view "$tag" >/dev/null 2>&1; then
+              component_tags+=("$tag")
+              component_notes="$(gh release view "$tag" --json body --jq .body)"
+              if [ -n "$component_notes" ]; then
+                {
+                  printf '\n\n---\n\n## %s\n\n' "$component"
+                  printf '%s\n' "$component_notes"
+                } >> "$notes_file"
+              fi
+            fi
+          done
+
+          if [ "${#component_tags[@]}" -gt 0 ]; then
+            gh release edit "$product_tag" --notes-file "$notes_file"
+          fi
+
+          for tag in "${component_tags[@]}"; do
+            # Do not pass --cleanup-tag: Release Please still needs these tags.
+            gh release delete "$tag" --yes
+          done

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cargo install ferrocat-cli
 ferrocat audit --source-locale en --source locales/en.po --target de=locales/de.po
 ```
 
-The `ferrocat-cli` GitHub release also publishes a prebuilt Linux musl archive for `x86_64-unknown-linux-musl`. The archive is named `ferrocat-<version>-x86_64-unknown-linux-musl.tar.gz` and contains the `ferrocat` binary plus license and README metadata.
+Each Ferrocat version has one GitHub product release. It also publishes a prebuilt Linux musl archive for `x86_64-unknown-linux-musl`. The archive is named `ferrocat-<version>-x86_64-unknown-linux-musl.tar.gz` and contains the `ferrocat` binary plus license and README metadata.
 
 ## Quick Start
 
@@ -147,7 +147,7 @@ for the crate-by-crate feature profile details.
 - **MSRV:** Rust `1.93.0`
 - **MSRV policy:** align with OXC when practical, while avoiding churn from tracking only the newest stable toolchain
 - **MSRV bumps:** raising the MSRV is treated as a minor-version change and called out in the changelog; patch releases do not raise the MSRV
-- **Prebuilt CLI target:** `x86_64-unknown-linux-musl` is validated in CI and published as a smoke-tested GitHub Release archive for `ferrocat-cli`
+- **Prebuilt CLI target:** `x86_64-unknown-linux-musl` is validated in CI and published as a smoke-tested Ferrocat GitHub Release archive
 - **Semver:** the public API follows semantic versioning. Until the API surface settles and the crate has more downstream consumers, minor releases may still ship reviewed breaking cleanups (renames, stricter types, `#[non_exhaustive]` additions); every break is listed in the changelog with migration notes
 - **Error surface:** PO parse errors stay intentionally compact but expose `message()` plus optional `position()` metadata with zero-based byte offset and one-based line/column when source context is available
 - **Documentation surface:** README examples, rustdoc examples, and the docs site aim to stay aligned

--- a/crates/ferrocat-cli/README.md
+++ b/crates/ferrocat-cli/README.md
@@ -13,7 +13,7 @@ ferrocat audit \
   --format text
 ```
 
-`ferrocat-cli` releases include a prebuilt `x86_64-unknown-linux-musl` archive
+Ferrocat product releases include a prebuilt `x86_64-unknown-linux-musl` archive
 named `ferrocat-<version>-x86_64-unknown-linux-musl.tar.gz`. The release
 workflow smoke-tests the packaged `ferrocat` binary before uploading it.
 

--- a/docs/app/routes/operations/release-verification.mdx
+++ b/docs/app/routes/operations/release-verification.mdx
@@ -19,8 +19,11 @@ This checklist verifies a real Rust-only `ferrocat` release after the publish wo
 - Confirm the published crates resolved to the same release version.
 - Confirm the workspace-only crates in the repo are also version-aligned with the published crates.
 - Confirm internal `ferrocat*` path dependencies in the crate manifests were updated to matching versions where applicable.
-- Confirm the GitHub release tag matches the published version created by Release Please.
-- For `ferrocat-cli` releases, confirm the
+- Confirm the product GitHub release is `ferrocat-v<version>` and matches the
+  published crate version. Component tags remain for Release Please bookkeeping,
+  but only the product release should be visible in GitHub Releases. Its release
+  notes include the component changes for that version.
+- Confirm the product release includes the
   `ferrocat-<version>-x86_64-unknown-linux-musl.tar.gz` asset and matching
   `.sha256` file were uploaded to the GitHub release.
 


### PR DESCRIPTION
## What changed

Ferrocat now keeps `ferrocat-vX.Y.Z` as the one visible GitHub product release. Release Please still creates the component tags it needs for bookkeeping, but a final publish job folds component release notes into the product release and removes the five redundant component release entries after the crates and CLI archive are published.

The musl CLI archive now lands on the Ferrocat product release instead of the `ferrocat-cli` release. The release verification docs and both READMEs now point to the product release too.

## Why

All workspace crates ship at the same linked version, so six GitHub releases per version made the Releases page noisy without adding useful release boundaries.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "workflow YAML parses"'`\n- extracted cleanup script checked with `bash -n`\n- `pnpm build` in `docs/`