### PR TITLE
fix(release): synchronize product lockfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,54 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
+      # The product release uses the virtual workspace manifest as its version
+      # source. Release Please's simple strategy updates that manifest but not
+      # Cargo.lock, so regenerate the lockfile on the release PR branch before
+      # CI validates it with --locked.
+      - name: Set Rust for release lockfile
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: dtolnay/rust-toolchain@1.93.0
+
+      - name: Synchronize release PR lockfile
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          release_branch="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --base "$GITHUB_REF_NAME" \
+              --label "autorelease: pending" \
+              --json headRefName \
+              --jq 'map(select(.headRefName | startswith("release-please--branches--"))) | .[0].headRefName'
+          )"
+
+          if [ -z "$release_branch" ] || [ "$release_branch" = "null" ]; then
+            echo "Expected a pending Release Please branch for ${GITHUB_REF_NAME}." >&2
+            exit 1
+          fi
+
+          git fetch origin "$release_branch"
+          git switch --detach "origin/$release_branch"
+          # The release PR changed only local workspace package versions. A
+          # regular check updates those Cargo.lock entries while retaining the
+          # existing locked registry dependency set; `generate-lockfile` would
+          # also upgrade unrelated registry packages.
+          cargo check --workspace --all-targets --all-features
+
+          if git diff --quiet -- Cargo.lock; then
+            echo "Cargo.lock is already current."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore(release): synchronize Cargo.lock"
+          git push origin "HEAD:refs/heads/$release_branch"
+
   publish-cli-musl:
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}

--- a/docs/release-version.ts
+++ b/docs/release-version.ts
@@ -1,9 +1,9 @@
 import releaseManifest from "../.release-please-manifest.json"
 
-const releaseVersion = releaseManifest["crates/ferrocat"]
+const releaseVersion = releaseManifest["."]
 
 if (typeof releaseVersion !== "string" || releaseVersion.trim() === "") {
-  throw new Error("Missing crates/ferrocat version in .release-please-manifest.json")
+  throw new Error("Missing product version in .release-please-manifest.json")
 }
 
 export const ferrocatReleaseVersion = releaseVersion


### PR DESCRIPTION
## Summary

Fixes the product release PR path after the move to one root component.

- syncs `Cargo.lock` on the Release Please PR branch only when that PR is created or updated
- keeps registry dependency versions pinned; only the six local workspace package versions move
- reads the docs version from the root manifest key (`.`)

## Proof

A publishing-free Action run created one `2.3.0` product release PR, then added a bot commit with exactly the six expected `Cargo.lock` updates. No package was published.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-features --locked`
- `pnpm install --frozen-lockfile && pnpm build` in `docs/`