### PR TITLE
chore(release): remove migration boundary

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
   "include-component-in-tag": true,
-  "last-release-sha": "49767429bb761464c6261d37af1f995ced6b0b90",
   "packages": {
     ".": {
       "component": "ferrocat",


### PR DESCRIPTION
## What changed

Removes the top-level `last-release-sha` override from the Release Please configuration.

## Why

The one-time product-release migration has now completed successfully with `ferrocat-v3.0.1`. Keeping the override would force future changelog discovery to continue from the old `2.2.0` boundary instead of the newly established product release.

## Impact

Future releases keep the single root product component and will discover their previous release normally from `ferrocat-v3.0.1`.

## Verification

- `jq empty .release-please-config.json`
- Confirmed the config and manifest each contain exactly one root package key: `.`
- `git diff --check`
- No Rust or documentation source changed