### PR TITLE
feat(po): expose PO serialization options through catalog update and combine

### DIFF
--- a/api-snapshots/ferrocat-po.txt
+++ b/api-snapshots/ferrocat-po.txt
@@ -446,6 +446,7 @@ pub ferrocat_po::CombineCatalogFilesOptions::locale: core::option::Option<&'a st
 pub ferrocat_po::CombineCatalogFilesOptions::mode: core::option::Option<ferrocat_po::CatalogMode>
 pub ferrocat_po::CombineCatalogFilesOptions::order_by: ferrocat_po::OrderBy
 pub ferrocat_po::CombineCatalogFilesOptions::output_path: &'a std::path::Path
+pub ferrocat_po::CombineCatalogFilesOptions::po_serialize: ferrocat_po::SerializeOptions
 pub ferrocat_po::CombineCatalogFilesOptions::selection: ferrocat_po::CatalogCombineSelection
 pub ferrocat_po::CombineCatalogFilesOptions::source_locale: &'a str
 impl<'a> ferrocat_po::CombineCatalogFilesOptions<'a>
@@ -459,6 +460,7 @@ pub fn ferrocat_po::CombineCatalogFilesOptions<'a>::with_locale(self, &'a str) -
 pub fn ferrocat_po::CombineCatalogFilesOptions<'a>::with_mode(self, ferrocat_po::CatalogMode) -> Self
 pub fn ferrocat_po::CombineCatalogFilesOptions<'a>::with_order_by(self, ferrocat_po::OrderBy) -> Self
 pub fn ferrocat_po::CombineCatalogFilesOptions<'a>::with_output_path(self, &'a std::path::Path) -> Self
+pub fn ferrocat_po::CombineCatalogFilesOptions<'a>::with_po_serialize_options(self, ferrocat_po::SerializeOptions) -> Self
 pub fn ferrocat_po::CombineCatalogFilesOptions<'a>::with_selection(self, ferrocat_po::CatalogCombineSelection) -> Self
 #[non_exhaustive] pub struct ferrocat_po::CombineCatalogOptions<'a>
 pub ferrocat_po::CombineCatalogOptions::conflict_strategy: ferrocat_po::CatalogConflictStrategy
@@ -468,6 +470,7 @@ pub ferrocat_po::CombineCatalogOptions::inputs: &'a [ferrocat_po::CatalogCombine
 pub ferrocat_po::CombineCatalogOptions::locale: core::option::Option<&'a str>
 pub ferrocat_po::CombineCatalogOptions::mode: ferrocat_po::CatalogMode
 pub ferrocat_po::CombineCatalogOptions::order_by: ferrocat_po::OrderBy
+pub ferrocat_po::CombineCatalogOptions::po_serialize: ferrocat_po::SerializeOptions
 pub ferrocat_po::CombineCatalogOptions::selection: ferrocat_po::CatalogCombineSelection
 pub ferrocat_po::CombineCatalogOptions::source_locale: &'a str
 impl<'a> ferrocat_po::CombineCatalogOptions<'a>
@@ -479,6 +482,7 @@ pub fn ferrocat_po::CombineCatalogOptions<'a>::with_inputs(self, &'a [ferrocat_p
 pub fn ferrocat_po::CombineCatalogOptions<'a>::with_locale(self, &'a str) -> Self
 pub fn ferrocat_po::CombineCatalogOptions<'a>::with_mode(self, ferrocat_po::CatalogMode) -> Self
 pub fn ferrocat_po::CombineCatalogOptions<'a>::with_order_by(self, ferrocat_po::OrderBy) -> Self
+pub fn ferrocat_po::CombineCatalogOptions<'a>::with_po_serialize_options(self, ferrocat_po::SerializeOptions) -> Self
 pub fn ferrocat_po::CombineCatalogOptions<'a>::with_selection(self, ferrocat_po::CatalogCombineSelection) -> Self
 #[non_exhaustive] pub struct ferrocat_po::CompileCatalogArtifactIcuOptions
 pub ferrocat_po::CompileCatalogArtifactIcuOptions::formatter_support: core::option::Option<ferrocat_po::IcuFormatterSupportPolicy>
@@ -792,12 +796,14 @@ impl<T> core::iter::traits::marker::FusedIterator for ferrocat_po::PoVecIntoIter
 pub ferrocat_po::RenderOptions::custom_header_attributes: core::option::Option<&'a alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>>
 pub ferrocat_po::RenderOptions::include_origins: bool
 pub ferrocat_po::RenderOptions::order_by: ferrocat_po::OrderBy
+pub ferrocat_po::RenderOptions::po_serialize: ferrocat_po::SerializeOptions
 pub ferrocat_po::RenderOptions::print_placeholders_in_comments: ferrocat_po::PlaceholderCommentMode
 impl<'a> ferrocat_po::RenderOptions<'a>
 pub fn ferrocat_po::RenderOptions<'a>::with_custom_header_attributes(self, &'a alloc::collections::btree::map::BTreeMap<alloc::string::String, alloc::string::String>) -> Self
 pub fn ferrocat_po::RenderOptions<'a>::with_include_origins(self, bool) -> Self
 pub fn ferrocat_po::RenderOptions<'a>::with_order_by(self, ferrocat_po::OrderBy) -> Self
 pub fn ferrocat_po::RenderOptions<'a>::with_placeholder_comments(self, ferrocat_po::PlaceholderCommentMode) -> Self
+pub fn ferrocat_po::RenderOptions<'a>::with_po_serialize_options(self, ferrocat_po::SerializeOptions) -> Self
 impl core::default::Default for ferrocat_po::RenderOptions<'_>
 pub fn ferrocat_po::RenderOptions<'_>::default() -> Self
 #[non_exhaustive] pub struct ferrocat_po::SerializeOptions

--- a/crates/ferrocat-po/src/api/combine.rs
+++ b/crates/ferrocat-po/src/api/combine.rs
@@ -7,6 +7,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::SerializeOptions;
 use crate::diagnostic_codes;
 
 use super::catalog::{
@@ -40,10 +41,11 @@ struct CombineConfig<'a> {
     order_by: OrderBy,
     include_origins: bool,
     include_obsolete: bool,
+    po_serialize: &'a SerializeOptions,
 }
 
 impl<'a> CombineConfig<'a> {
-    fn from_options(options: &CombineCatalogOptions<'a>) -> Self {
+    fn from_options(options: &'a CombineCatalogOptions<'a>) -> Self {
         Self {
             locale: options.locale,
             source_locale: options.source_locale,
@@ -53,10 +55,11 @@ impl<'a> CombineConfig<'a> {
             order_by: options.order_by,
             include_origins: options.include_origins,
             include_obsolete: options.include_obsolete,
+            po_serialize: &options.po_serialize,
         }
     }
 
-    fn from_file_options(options: &CombineCatalogFilesOptions<'a>, mode: CatalogMode) -> Self {
+    fn from_file_options(options: &'a CombineCatalogFilesOptions<'a>, mode: CatalogMode) -> Self {
         Self {
             locale: options.locale,
             source_locale: options.source_locale,
@@ -66,6 +69,7 @@ impl<'a> CombineConfig<'a> {
             order_by: options.order_by,
             include_origins: options.include_origins,
             include_obsolete: options.include_obsolete,
+            po_serialize: &options.po_serialize,
         }
     }
 }
@@ -648,6 +652,7 @@ fn export_catalog_content_for_combine(
             include_origins: config.include_origins,
             print_placeholders_in_comments: PlaceholderCommentMode::default(),
             custom_header_attributes: None,
+            po_serialize: config.po_serialize.clone(),
         },
         ..UpdateCatalogOptions::new(config.source_locale, CatalogUpdateInput::default())
     };

--- a/crates/ferrocat-po/src/api/export.rs
+++ b/crates/ferrocat-po/src/api/export.rs
@@ -46,7 +46,7 @@ fn stringify_catalog_po(
     locale: Option<&str>,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<String, ApiError> {
-    let serialize_options = SerializeOptions::default();
+    let serialize_options = &options.render.po_serialize;
     let mut out = String::with_capacity(estimate_catalog_po_capacity(catalog));
     let mut scratch = String::new();
 
@@ -82,7 +82,7 @@ fn stringify_catalog_po(
             options,
             &mut plural_profiles,
             diagnostics,
-            &serialize_options,
+            serialize_options,
         )?;
         if iter.peek().is_some() {
             out.push('\n');

--- a/crates/ferrocat-po/src/api/tests/catalog.rs
+++ b/crates/ferrocat-po/src/api/tests/catalog.rs
@@ -1995,13 +1995,15 @@ fn combine_catalogs_can_disable_po_width_folding() {
     let existing = format!("msgid \"Hello\"\nmsgstr \"{LONG_TRANSLATION}\"\n");
     let inputs = [CatalogCombineInput::labeled(&existing, "existing.po")];
 
-    let result = combine_catalogs(CombineCatalogOptions {
-        inputs: &inputs,
-        source_locale: "en",
-        locale: Some("de"),
-        po_serialize: SerializeOptions::default().with_fold_length(0),
-        ..CombineCatalogOptions::new(&[], "en")
-    })
+    let result = combine_catalogs(
+        CombineCatalogOptions {
+            inputs: &inputs,
+            source_locale: "en",
+            locale: Some("de"),
+            ..CombineCatalogOptions::new(&[], "en")
+        }
+        .with_po_serialize_options(SerializeOptions::default().with_fold_length(0)),
+    )
     .expect("combine without width folding");
 
     assert!(
@@ -2023,13 +2025,15 @@ fn combine_catalog_files_can_disable_po_width_folding() {
     .expect("write ours");
     let input_paths = vec![ours.clone()];
 
-    let result = combine_catalog_files(CombineCatalogFilesOptions {
-        input_paths: &input_paths,
-        output_path: &ours,
-        locale: Some("de"),
-        po_serialize: SerializeOptions::default().with_fold_length(0),
-        ..CombineCatalogFilesOptions::new(&[], &ours, "en")
-    })
+    let result = combine_catalog_files(
+        CombineCatalogFilesOptions {
+            input_paths: &input_paths,
+            output_path: &ours,
+            locale: Some("de"),
+            ..CombineCatalogFilesOptions::new(&[], &ours, "en")
+        }
+        .with_po_serialize_options(SerializeOptions::default().with_fold_length(0)),
+    )
     .expect("combine files without width folding");
 
     let output = fs::read_to_string(&result.output_path).expect("read output");

--- a/crates/ferrocat-po/src/api/tests/catalog.rs
+++ b/crates/ferrocat-po/src/api/tests/catalog.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use crate::SerializeOptions;
+
 const POLISH_PLURAL_FORMS: &str = "nplurals=3; plural=(n == 1 ? 0 : (n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)) ? 1 : 2);";
 
 #[test]
@@ -1923,6 +1925,120 @@ fn combine_catalogs_use_last_preserves_non_empty_plural_slots_when_later_slot_is
     assert_eq!(parsed.items[0].msgstr[0], "Teil");
     assert_eq!(parsed.items[0].msgstr[1], "Dinge");
     assert_eq!(result.stats.conflicts_resolved, 1);
+}
+
+const LONG_TRANSLATION: &str = "This translation is deliberately much longer than eighty characters so the default serializer folds it.";
+
+#[test]
+fn update_catalog_can_disable_po_width_folding() {
+    let existing = format!(
+        "msgid \"Hello\"\nmsgstr \"{LONG_TRANSLATION}\"\n\nmsgid \"Multi\"\nmsgstr \"line1\\nline2\"\n"
+    );
+    let build_options = |render: RenderOptions<'static>| UpdateCatalogOptions {
+        locale: Some("de"),
+        render,
+        input: structured_input(vec![
+            ExtractedMessage::Singular(ExtractedSingularMessage {
+                msgid: "Hello".to_owned(),
+                ..ExtractedSingularMessage::default()
+            }),
+            ExtractedMessage::Singular(ExtractedSingularMessage {
+                msgid: "Multi".to_owned(),
+                ..ExtractedSingularMessage::default()
+            }),
+        ]),
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
+    };
+
+    let folded = update_catalog(UpdateCatalogOptions {
+        existing: Some(&existing),
+        ..build_options(RenderOptions::default())
+    })
+    .expect("update with default folding");
+    assert!(
+        !folded
+            .content
+            .contains(&format!("msgstr \"{LONG_TRANSLATION}\"")),
+        "default output should fold the long translation across lines"
+    );
+
+    let unfolded = update_catalog(UpdateCatalogOptions {
+        existing: Some(&existing),
+        ..build_options(
+            RenderOptions::default()
+                .with_po_serialize_options(SerializeOptions::default().with_fold_length(0)),
+        )
+    })
+    .expect("update without width folding");
+    assert!(
+        unfolded
+            .content
+            .contains(&format!("msgstr \"{LONG_TRANSLATION}\"\n")),
+        "disabling width folding must keep the long translation on one line"
+    );
+    assert!(
+        unfolded.content.contains("msgstr \"line1\\n\"\n\"line2\""),
+        "embedded newlines must keep valid multiline PO syntax without width folding"
+    );
+
+    let reparsed = parse_po(&unfolded.content).expect("reparse unfolded output");
+    let multi = reparsed
+        .items
+        .iter()
+        .find(|item| item.msgid == "Multi")
+        .expect("multi entry");
+    assert_eq!(multi.msgstr[0], "line1\nline2");
+}
+
+#[test]
+fn combine_catalogs_can_disable_po_width_folding() {
+    let existing = format!("msgid \"Hello\"\nmsgstr \"{LONG_TRANSLATION}\"\n");
+    let inputs = [CatalogCombineInput::labeled(&existing, "existing.po")];
+
+    let result = combine_catalogs(CombineCatalogOptions {
+        inputs: &inputs,
+        source_locale: "en",
+        locale: Some("de"),
+        po_serialize: SerializeOptions::default().with_fold_length(0),
+        ..CombineCatalogOptions::new(&[], "en")
+    })
+    .expect("combine without width folding");
+
+    assert!(
+        result
+            .content
+            .contains(&format!("msgstr \"{LONG_TRANSLATION}\"\n")),
+        "combine output must respect the disabled width folding"
+    );
+}
+
+#[test]
+fn combine_catalog_files_can_disable_po_width_folding() {
+    let temp_dir = unique_catalog_temp_dir("combine-files-fold");
+    let ours = temp_dir.join("ours.po");
+    fs::write(
+        &ours,
+        format!("msgid \"Hello\"\nmsgstr \"{LONG_TRANSLATION}\"\n"),
+    )
+    .expect("write ours");
+    let input_paths = vec![ours.clone()];
+
+    let result = combine_catalog_files(CombineCatalogFilesOptions {
+        input_paths: &input_paths,
+        output_path: &ours,
+        locale: Some("de"),
+        po_serialize: SerializeOptions::default().with_fold_length(0),
+        ..CombineCatalogFilesOptions::new(&[], &ours, "en")
+    })
+    .expect("combine files without width folding");
+
+    let output = fs::read_to_string(&result.output_path).expect("read output");
+    assert!(
+        output.contains(&format!("msgstr \"{LONG_TRANSLATION}\"\n")),
+        "file combine output must respect the disabled width folding"
+    );
+
+    let _ = fs::remove_dir_all(temp_dir);
 }
 
 #[test]

--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use rustc_hash::{FxHashMap, FxHasher};
 
-use crate::{ParseError, PoVec, diagnostic_codes::DiagnosticCode};
+use crate::{ParseError, PoVec, SerializeOptions, diagnostic_codes::DiagnosticCode};
 
 use super::mt::MachineMetadata;
 use super::plural::PluralProfile;
@@ -557,6 +557,11 @@ pub struct CombineCatalogFilesOptions<'a> {
     pub include_origins: bool,
     /// Whether obsolete definitions should participate in the combine operation.
     pub include_obsolete: bool,
+    /// PO serializer controls for the rendered output, e.g. width folding.
+    ///
+    /// This only affects PO rendering; FCL output has a canonical line shape
+    /// and ignores these controls.
+    pub po_serialize: SerializeOptions,
 }
 
 impl<'a> CombineCatalogFilesOptions<'a> {
@@ -577,6 +582,7 @@ impl<'a> CombineCatalogFilesOptions<'a> {
             order_by: OrderBy::Msgid,
             include_origins: true,
             include_obsolete: false,
+            po_serialize: SerializeOptions::default(),
         }
     }
 
@@ -647,6 +653,15 @@ impl<'a> CombineCatalogFilesOptions<'a> {
     #[must_use]
     pub fn with_include_obsolete(mut self, include_obsolete: bool) -> Self {
         self.include_obsolete = include_obsolete;
+        self
+    }
+
+    /// Returns options that render PO output with the given serializer
+    /// controls, e.g. `SerializeOptions::default().with_fold_length(0)` to
+    /// disable automatic width folding.
+    #[must_use]
+    pub fn with_po_serialize_options(mut self, po_serialize: SerializeOptions) -> Self {
+        self.po_serialize = po_serialize;
         self
     }
 }
@@ -1055,6 +1070,12 @@ pub struct RenderOptions<'a> {
     pub print_placeholders_in_comments: PlaceholderCommentMode,
     /// Optional additional header attributes to inject or override.
     pub custom_header_attributes: Option<&'a BTreeMap<String, String>>,
+    /// PO serializer controls for the rendered output, e.g. width folding.
+    ///
+    /// This only affects PO rendering. FCL output has a canonical line shape
+    /// and ignores these controls. Embedded newline characters always render
+    /// as valid multiline PO syntax, even with width folding disabled.
+    pub po_serialize: SerializeOptions,
 }
 
 impl Default for RenderOptions<'_> {
@@ -1064,6 +1085,7 @@ impl Default for RenderOptions<'_> {
             include_origins: true,
             print_placeholders_in_comments: PlaceholderCommentMode::Enabled { limit: 3 },
             custom_header_attributes: None,
+            po_serialize: SerializeOptions::default(),
         }
     }
 }
@@ -1100,6 +1122,15 @@ impl<'a> RenderOptions<'a> {
         custom_header_attributes: &'a BTreeMap<String, String>,
     ) -> Self {
         self.custom_header_attributes = Some(custom_header_attributes);
+        self
+    }
+
+    /// Returns options that render PO output with the given serializer
+    /// controls, e.g. `SerializeOptions::default().with_fold_length(0)` to
+    /// disable automatic width folding.
+    #[must_use]
+    pub fn with_po_serialize_options(mut self, po_serialize: SerializeOptions) -> Self {
+        self.po_serialize = po_serialize;
         self
     }
 }
@@ -1263,6 +1294,11 @@ pub struct CombineCatalogOptions<'a> {
     pub include_origins: bool,
     /// Whether obsolete definitions should participate in the combine operation.
     pub include_obsolete: bool,
+    /// PO serializer controls for the rendered output, e.g. width folding.
+    ///
+    /// This only affects PO rendering; FCL output has a canonical line shape
+    /// and ignores these controls.
+    pub po_serialize: SerializeOptions,
 }
 
 impl<'a> CombineCatalogOptions<'a> {
@@ -1270,7 +1306,8 @@ impl<'a> CombineCatalogOptions<'a> {
     ///
     /// Optional fields default to an inferred locale, ICU-native PO mode,
     /// first-definition conflict resolution, all message identities, `msgid`
-    /// ordering, rendered origins, and skipped obsolete entries.
+    /// ordering, rendered origins, skipped obsolete entries, and default PO
+    /// serialization.
     #[must_use]
     pub fn new(inputs: &'a [CatalogCombineInput<'a>], source_locale: &'a str) -> Self {
         Self {
@@ -1283,6 +1320,7 @@ impl<'a> CombineCatalogOptions<'a> {
             order_by: OrderBy::Msgid,
             include_origins: true,
             include_obsolete: false,
+            po_serialize: SerializeOptions::default(),
         }
     }
 
@@ -1339,6 +1377,15 @@ impl<'a> CombineCatalogOptions<'a> {
     #[must_use]
     pub fn with_include_obsolete(mut self, include_obsolete: bool) -> Self {
         self.include_obsolete = include_obsolete;
+        self
+    }
+
+    /// Returns options that render PO output with the given serializer
+    /// controls, e.g. `SerializeOptions::default().with_fold_length(0)` to
+    /// disable automatic width folding.
+    #[must_use]
+    pub fn with_po_serialize_options(mut self, po_serialize: SerializeOptions) -> Self {
+        self.po_serialize = po_serialize;
         self
     }
 }

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -778,6 +778,16 @@ in its original bytewise order. The compact built-in repertoire and its Unicode
 limits are documented in
 [ADR 0026](/architecture/adr/0026-cldr-root-catalog-order).
 
+`RenderOptions::po_serialize` exposes the low-level PO serializer controls to
+the same high-level flows, so hosts no longer need a parse/stringify post-pass
+to change the output shape. `combine_catalogs` and `combine_catalog_files`
+accept the same value directly as `po_serialize`. For example,
+`RenderOptions::default().with_po_serialize_options(SerializeOptions::default().with_fold_length(0))`
+disables automatic width folding for an update. Embedded newline characters
+still render as valid multiline PO syntax, and default output stays
+byte-identical to previous releases. FCL output has a canonical line shape and
+ignores these controls.
+
 Like parsing, updates should normally choose one `CatalogMode`. PO with ICU-native semantics remains the default. FCL storage uses a single `%FCL1` header line plus one tab-separated entry per line.
 
 Choose FCL when collaboration and automation matter more than maximum PO fidelity. The one-entry-per-line shape keeps large catalog diffs readable, keeps unchanged entries byte-identical across merge inputs for clean git 3-way merges, and makes ordinary Git conflict handling more practical, including hosted review flows where custom `.gitattributes` merge drivers may not be part of the web merge path.

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -220,6 +220,12 @@ Typical use cases:
 - generating PO content from your own tooling
 - normalizing formatting after edits
 
+`SerializeOptions` controls the output shape, for example
+`with_fold_length(0)` to disable automatic width folding. The same options
+also flow through the high-level update and combine flows via
+`RenderOptions::po_serialize`, so a host does not need to re-serialize
+finished catalog output just to change its shape.
+
 ## Catalog Workflows
 
 The high-level catalog request structs are now intentionally borrowing-first:


### PR DESCRIPTION
Closes #272

## Summary

The low-level PO serializer has always supported `SerializeOptions::with_fold_length(0)`, but the high-level catalog workflows rendered PO with hard-coded defaults, forcing hosts like Palamedes into a parse/stringify post-pass (and a second file write on the combine path) just to change the output shape.

- `RenderOptions` gains `po_serialize: SerializeOptions` plus `with_po_serialize_options(...)`, flowing through `update_catalog` / `update_catalog_file`
- `CombineCatalogOptions` and `CombineCatalogFilesOptions` accept the same `po_serialize` value directly, with matching builders
- The export path renders with the caller's options instead of `SerializeOptions::default()`

## Acceptance criteria from #272

- High-level catalog update can disable automatic PO folding — covered by `update_catalog_can_disable_po_width_folding`
- In-memory combine and file combine apply the same option — covered by `combine_catalogs_can_disable_po_width_folding` and `combine_catalog_files_can_disable_po_width_folding`
- The option flows through the shared keyword writer, so it applies to `msgid`, `msgstr`, plural slots, and contexts alike
- Embedded newline characters still render as valid multiline PO syntax with width folding disabled (asserted against the actual serializer shape)
- Default output stays byte-identical: all option structs are `#[non_exhaustive]`, the new field defaults to `SerializeOptions::default()`, and the full existing test suite passes unchanged
- FCL keeps its canonical line shape and ignores the PO-only controls (documented on every new field)

## Verification

`cargo test --workspace --all-features --locked`, `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, MSRV `cargo +1.93.0 check`, docs build, and `scripts/check-public-api-snapshots.sh` after regenerating `api-snapshots/ferrocat-po.txt` (6 added lines, purely additive).

Docs: the API overview's render-options section now documents the passthrough and the fold-off example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)