### PR TITLE
fix(coverage)!: classify fuzzy entries as incomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ msgstr "world"
 
 For the common "merge fresh extracted messages into an existing catalog" workflow, `merge_catalog` is the lean Gettext-style entry point. For N-way catalog overlays and `msgcat`-style set operations, use `combine_catalogs`; when catalogs already live on disk, `combine_catalog_files` adds format inference and atomic output replacement around the same semantics. For release checks across a source catalog and target catalogs, use `audit_catalogs`. For dashboards or translator handoffs, use `measure_catalog_coverage` and `review_catalogs`. For application delivery, compile requested-locale artifacts with fallback and ICU diagnostics; use `compile_catalog_artifact_report` when host tooling also needs per-message resolution provenance without changing the runtime artifact shape.
 
+Coverage, audit, and review inputs should be parsed with
+`parse_catalog_for_review`. It returns a normalized catalog that retains only
+semantic fuzzy identities, so active `#, fuzzy` PO and `f=fuzzy` FCL entries do
+not count as translated. The ordinary `parse_catalog` path continues to skip
+opaque flags and translator comments for high-throughput consumers that do not
+request report state.
+
 Beyond the basics, Ferrocat exposes byte-oriented and allocation-light borrowed parsers for hot paths, ICU analysis and source/translation compatibility checks (`analyze_icu`, `compare_icu_messages`, `validate_icu_formatter_support`), ICU-aware pseudolocalization, semantic metadata normalization around `msgid + msgctxt`, and AI-translation metadata that high-level writers clear automatically once a human edits the text. ICU scope is MessageFormat v1; MessageFormat 2 is tracked as a future standard but is not a near-term target.
 
 ## What Ferrocat Gives You

--- a/api-snapshots/ferrocat-po.txt
+++ b/api-snapshots/ferrocat-po.txt
@@ -8,6 +8,7 @@ pub const ferrocat_po::diagnostic_codes::catalog::ALL: &[&str]
 pub const ferrocat_po::diagnostic_codes::catalog::DUPLICATE_METADATA: &str
 pub const ferrocat_po::diagnostic_codes::catalog::EMPTY_TRANSLATION: &str
 pub const ferrocat_po::diagnostic_codes::catalog::EXTRA_TRANSLATION: &str
+pub const ferrocat_po::diagnostic_codes::catalog::FUZZY_FLAG: &str
 pub const ferrocat_po::diagnostic_codes::catalog::METADATA_UNKNOWN_MESSAGE: &str
 pub const ferrocat_po::diagnostic_codes::catalog::MISSING_LOCALE: &str
 pub const ferrocat_po::diagnostic_codes::catalog::MISSING_SOURCE_LOCALE: &str
@@ -105,6 +106,7 @@ pub ferrocat_po::CatalogMachineTranslationStatus::Stale
 #[non_exhaustive] pub enum ferrocat_po::CatalogMessageStatus
 pub ferrocat_po::CatalogMessageStatus::Empty
 pub ferrocat_po::CatalogMessageStatus::Extra
+pub ferrocat_po::CatalogMessageStatus::Fuzzy
 pub ferrocat_po::CatalogMessageStatus::Missing
 pub ferrocat_po::CatalogMessageStatus::Obsolete
 pub ferrocat_po::CatalogMessageStatus::Translated
@@ -251,6 +253,7 @@ pub fn ferrocat_po::BorrowedPoItem<'_>::into_owned(self) -> ferrocat_po::PoItem
 #[non_exhaustive] pub struct ferrocat_po::CatalogAuditChecks
 pub ferrocat_po::CatalogAuditChecks::completeness: bool
 pub ferrocat_po::CatalogAuditChecks::extra_messages: bool
+pub ferrocat_po::CatalogAuditChecks::fuzzy_flags: bool
 pub ferrocat_po::CatalogAuditChecks::icu_compatibility: bool
 pub ferrocat_po::CatalogAuditChecks::icu_syntax: bool
 pub ferrocat_po::CatalogAuditChecks::obsolete_entries: bool
@@ -258,6 +261,7 @@ pub ferrocat_po::CatalogAuditChecks::semantic_metadata: bool
 impl ferrocat_po::CatalogAuditChecks
 pub fn ferrocat_po::CatalogAuditChecks::with_completeness(self, bool) -> Self
 pub fn ferrocat_po::CatalogAuditChecks::with_extra_messages(self, bool) -> Self
+pub fn ferrocat_po::CatalogAuditChecks::with_fuzzy_flags(self, bool) -> Self
 pub fn ferrocat_po::CatalogAuditChecks::with_icu_compatibility(self, bool) -> Self
 pub fn ferrocat_po::CatalogAuditChecks::with_icu_syntax(self, bool) -> Self
 pub fn ferrocat_po::CatalogAuditChecks::with_obsolete_entries(self, bool) -> Self
@@ -344,6 +348,7 @@ pub struct ferrocat_po::CatalogLocaleCoverage
 pub ferrocat_po::CatalogLocaleCoverage::details: alloc::vec::Vec<ferrocat_po::CatalogCoverageMessage>
 pub ferrocat_po::CatalogLocaleCoverage::empty: usize
 pub ferrocat_po::CatalogLocaleCoverage::extra: usize
+pub ferrocat_po::CatalogLocaleCoverage::fuzzy: usize
 pub ferrocat_po::CatalogLocaleCoverage::locale: alloc::string::String
 pub ferrocat_po::CatalogLocaleCoverage::missing: usize
 pub ferrocat_po::CatalogLocaleCoverage::obsolete: usize
@@ -672,6 +677,7 @@ pub fn ferrocat_po::NormalizedParsedCatalog::get_by_parts(&self, &str, core::opt
 pub fn ferrocat_po::NormalizedParsedCatalog::into_parsed_catalog(self) -> ferrocat_po::ParsedCatalog
 pub fn ferrocat_po::NormalizedParsedCatalog::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&ferrocat_po::CatalogMessageKey, &ferrocat_po::CatalogMessage)> + '_
 pub fn ferrocat_po::NormalizedParsedCatalog::message_count(&self) -> usize
+pub const fn ferrocat_po::NormalizedParsedCatalog::has_review_state(&self) -> bool
 pub const fn ferrocat_po::NormalizedParsedCatalog::parsed_catalog(&self) -> &ferrocat_po::ParsedCatalog
 pub struct ferrocat_po::ObsoleteInfo
 pub ferrocat_po::ObsoleteInfo::since: core::option::Option<alloc::string::String>
@@ -711,6 +717,7 @@ pub ferrocat_po::ParsedCatalog::messages: alloc::vec::Vec<ferrocat_po::CatalogMe
 pub ferrocat_po::ParsedCatalog::semantics: ferrocat_po::CatalogSemantics
 impl ferrocat_po::ParsedCatalog
 pub fn ferrocat_po::ParsedCatalog::into_normalized_view(self) -> core::result::Result<ferrocat_po::NormalizedParsedCatalog, ferrocat_po::ApiError>
+pub fn ferrocat_po::ParsedCatalog::into_normalized_view_assuming_no_fuzzy(self) -> core::result::Result<ferrocat_po::NormalizedParsedCatalog, ferrocat_po::ApiError>
 pub struct ferrocat_po::PluralSource
 pub ferrocat_po::PluralSource::one: core::option::Option<alloc::string::String>
 pub ferrocat_po::PluralSource::other: alloc::string::String
@@ -860,6 +867,7 @@ pub fn ferrocat_po::machine_translation_hash(ferrocat_po::EffectiveTranslationRe
 pub fn ferrocat_po::measure_catalog_coverage(&[&ferrocat_po::NormalizedParsedCatalog], &ferrocat_po::CatalogCoverageOptions<'_>) -> core::result::Result<ferrocat_po::CatalogCoverageReport, ferrocat_po::ApiError>
 pub fn ferrocat_po::merge_catalog<'a>(&'a str, &[ferrocat_po::MergeMessageInput<'a>]) -> core::result::Result<alloc::string::String, ferrocat_po::ParseError>
 pub fn ferrocat_po::parse_catalog(ferrocat_po::ParseCatalogOptions<'_>) -> core::result::Result<ferrocat_po::ParsedCatalog, ferrocat_po::ApiError>
+pub fn ferrocat_po::parse_catalog_for_review(ferrocat_po::ParseCatalogOptions<'_>) -> core::result::Result<ferrocat_po::NormalizedParsedCatalog, ferrocat_po::ApiError>
 pub fn ferrocat_po::parse_po(&str) -> core::result::Result<ferrocat_po::PoFile, ferrocat_po::ParseError>
 pub fn ferrocat_po::parse_po_borrowed(&str) -> core::result::Result<ferrocat_po::BorrowedPoFile<'_>, ferrocat_po::ParseError>
 pub fn ferrocat_po::parse_po_bytes(&[u8]) -> core::result::Result<ferrocat_po::PoFile, ferrocat_po::ParseError>

--- a/api-snapshots/ferrocat-po.txt
+++ b/api-snapshots/ferrocat-po.txt
@@ -348,7 +348,6 @@ pub struct ferrocat_po::CatalogLocaleCoverage
 pub ferrocat_po::CatalogLocaleCoverage::details: alloc::vec::Vec<ferrocat_po::CatalogCoverageMessage>
 pub ferrocat_po::CatalogLocaleCoverage::empty: usize
 pub ferrocat_po::CatalogLocaleCoverage::extra: usize
-pub ferrocat_po::CatalogLocaleCoverage::fuzzy: usize
 pub ferrocat_po::CatalogLocaleCoverage::locale: alloc::string::String
 pub ferrocat_po::CatalogLocaleCoverage::missing: usize
 pub ferrocat_po::CatalogLocaleCoverage::obsolete: usize
@@ -357,6 +356,7 @@ pub ferrocat_po::CatalogLocaleCoverage::translated: usize
 impl ferrocat_po::CatalogLocaleCoverage
 pub fn ferrocat_po::CatalogLocaleCoverage::completion_percent(&self) -> f64
 pub fn ferrocat_po::CatalogLocaleCoverage::completion_ratio(&self) -> f64
+pub const fn ferrocat_po::CatalogLocaleCoverage::fuzzy(&self) -> usize
 pub const fn ferrocat_po::CatalogLocaleCoverage::incomplete(&self) -> usize
 pub struct ferrocat_po::CatalogLocaleReview
 pub ferrocat_po::CatalogLocaleReview::coverage: ferrocat_po::CatalogLocaleCoverage

--- a/api-snapshots/ferrocat.txt
+++ b/api-snapshots/ferrocat.txt
@@ -165,6 +165,7 @@ pub use ferrocat::measure_catalog_coverage
 pub use ferrocat::merge_catalog
 pub use ferrocat::normalize_message_metadata
 pub use ferrocat::parse_catalog
+pub use ferrocat::parse_catalog_for_review
 pub use ferrocat::parse_icu
 pub use ferrocat::parse_icu_with_options
 pub use ferrocat::parse_po
@@ -291,6 +292,7 @@ pub use ferrocat::catalog::diagnostic_codes
 pub use ferrocat::catalog::machine_translation_hash
 pub use ferrocat::catalog::measure_catalog_coverage
 pub use ferrocat::catalog::parse_catalog
+pub use ferrocat::catalog::parse_catalog_for_review
 pub use ferrocat::catalog::pseudolocalize_compiled_catalog_artifact
 pub use ferrocat::catalog::review_catalogs
 pub use ferrocat::catalog::update_catalog

--- a/crates/ferrocat-bench/src/compare.rs
+++ b/crates/ferrocat-bench/src/compare.rs
@@ -34,8 +34,8 @@ use ferrocat_po::{
     ExtractedSingularMessage, MergeMessageInput, MsgStr, NormalizedParsedCatalog,
     ParseCatalogOptions, ParsedCatalog, PluralSource, PoFile, SerializeOptions, TranslationShape,
     UpdateCatalogOptions, audit_catalogs, combine_catalogs, compile_catalog_artifact,
-    measure_catalog_coverage, merge_catalog, parse_catalog, parse_po, parse_po_borrowed,
-    review_catalogs, stringify_po, update_catalog,
+    measure_catalog_coverage, merge_catalog, parse_catalog, parse_catalog_for_review, parse_po,
+    parse_po_borrowed, review_catalogs, stringify_po, update_catalog,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/crates/ferrocat-bench/src/compare/operations.rs
+++ b/crates/ferrocat-bench/src/compare/operations.rs
@@ -1094,20 +1094,15 @@ pub(super) struct CatalogWorkflowFixture {
 
 impl CatalogWorkflowFixture {
     fn from_fixture(fixture: &Fixture) -> Result<Self, String> {
-        let parsed = parse_catalog(
-            ParseCatalogOptions::new(fixture.content(), "en")
-                .with_locale("en")
-                .with_mode(CatalogMode::IcuPo),
-        )
-        .map_err(|error| format!("failed to parse catalog workflow fixture: {error}"))?;
         let catalogs = ["en", "de", "fr", "es", "it", "pl"]
             .into_iter()
             .map(|locale| {
-                let mut catalog = parsed.clone();
-                catalog.locale = Some(locale.to_owned());
-                catalog.into_normalized_view().map_err(|error| {
-                    format!("failed to normalize catalog workflow fixture: {error}")
-                })
+                parse_catalog_for_review(
+                    ParseCatalogOptions::new(fixture.content(), "en")
+                        .with_locale(locale)
+                        .with_mode(CatalogMode::IcuPo),
+                )
+                .map_err(|error| format!("failed to parse catalog workflow fixture: {error}"))
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {

--- a/crates/ferrocat-cli/CHANGELOG.md
+++ b/crates/ferrocat-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- `ferrocat audit` now reports active fuzzy entries through the shared
+  review-aware catalog classifier.
+
 ## [2.2.0](https://github.com/sebastian-software/ferrocat/compare/ferrocat-cli-v3.0.0...ferrocat-cli-v2.2.0) (2026-07-05)
 
 

--- a/crates/ferrocat-cli/src/main.rs
+++ b/crates/ferrocat-cli/src/main.rs
@@ -6,7 +6,7 @@ use std::process::ExitCode;
 
 use ferrocat_po::{
     CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary, CatalogMode, DiagnosticSeverity,
-    NormalizedParsedCatalog, ParseCatalogOptions, audit_catalogs, parse_catalog,
+    NormalizedParsedCatalog, ParseCatalogOptions, audit_catalogs, parse_catalog_for_review,
 };
 
 const EXIT_AUDIT_FAILED: u8 = 1;
@@ -387,12 +387,11 @@ fn load_catalog(
     let content = fs::read_to_string(path).map_err(|error| {
         CliError::runtime(format!("failed to read {}: {error}", path.display()))
     })?;
-    parse_catalog(
+    parse_catalog_for_review(
         ParseCatalogOptions::new(&content, source_locale)
             .with_locale(locale)
             .with_mode(storage_format.catalog_mode()),
     )
-    .and_then(ferrocat_po::ParsedCatalog::into_normalized_view)
     .map_err(|error| CliError::runtime(format!("failed to parse {}: {error}", path.display())))
 }
 
@@ -585,6 +584,43 @@ mod tests {
             serde_json::from_slice(&stdout).expect("JSON output should parse");
         assert_eq!(json["summary"]["errors"], 0);
         assert_eq!(json["summary"]["target_locales"], 1);
+    }
+
+    #[test]
+    fn audit_command_reports_fuzzy_translations() {
+        let tempdir = tempfile_dir();
+        let source_path = tempdir.path().join("en.po");
+        let target_path = tempdir.path().join("de.po");
+        fs::write(&source_path, "msgid \"Checkout\"\nmsgstr \"Checkout\"\n")
+            .expect("write source fixture");
+        fs::write(
+            &target_path,
+            "#, fuzzy\nmsgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n",
+        )
+        .expect("write target fixture");
+
+        let mut stdout = Vec::new();
+        let exit_code = run_with_writer(
+            [
+                "audit".to_owned(),
+                "--source-locale".to_owned(),
+                "en".to_owned(),
+                "--source".to_owned(),
+                source_path.display().to_string(),
+                "--target".to_owned(),
+                format!("de={}", target_path.display()),
+                "--format".to_owned(),
+                "json".to_owned(),
+            ],
+            &mut stdout,
+        )
+        .expect("audit command should run");
+
+        assert_eq!(exit_code, std::process::ExitCode::SUCCESS);
+        let json: serde_json::Value =
+            serde_json::from_slice(&stdout).expect("JSON output should parse");
+        assert_eq!(json["summary"]["infos"], 1);
+        assert_eq!(json["diagnostics"][0]["code"], "catalog.fuzzy_flag");
     }
 
     #[test]

--- a/crates/ferrocat-po/CHANGELOG.md
+++ b/crates/ferrocat-po/CHANGELOG.md
@@ -9,9 +9,10 @@
   inputs from `parse_catalog_for_review` (or programmatic catalogs explicitly
   normalized with `into_normalized_view_assuming_no_fuzzy`). This prevents
   discarded fuzzy state from being counted as translated.
-- `CatalogMessageStatus::Fuzzy`, `CatalogLocaleCoverage::fuzzy`,
+- `CatalogMessageStatus::Fuzzy`, `CatalogLocaleCoverage::fuzzy()`,
   `CatalogAuditChecks::fuzzy_flags`, and the `catalog.fuzzy_flag` diagnostic are
-  restored in public and serialized report shapes.
+  restored. The derived accessor keeps the externally constructible coverage
+  struct semver-compatible.
 
 ### Bug Fixes
 

--- a/crates/ferrocat-po/CHANGELOG.md
+++ b/crates/ferrocat-po/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### ⚠ BREAKING CHANGES
+
+- `measure_catalog_coverage`, default fuzzy-enabled `audit_catalogs`, and
+  current target catalogs passed to `review_catalogs` now require normalized
+  inputs from `parse_catalog_for_review` (or programmatic catalogs explicitly
+  normalized with `into_normalized_view_assuming_no_fuzzy`). This prevents
+  discarded fuzzy state from being counted as translated.
+- `CatalogMessageStatus::Fuzzy`, `CatalogLocaleCoverage::fuzzy`,
+  `CatalogAuditChecks::fuzzy_flags`, and the `catalog.fuzzy_flag` diagnostic are
+  restored in public and serialized report shapes.
+
+### Bug Fixes
+
+- Active PO `#, fuzzy` and FCL `f=fuzzy` entries no longer count as translated;
+  coverage, audit, and review share the same empty/plural/obsolete/fuzzy
+  precedence.
+
 ## [2.2.0](https://github.com/sebastian-software/ferrocat/compare/ferrocat-po-v3.0.0...ferrocat-po-v2.2.0) (2026-07-05)
 
 

--- a/crates/ferrocat-po/src/api.rs
+++ b/crates/ferrocat-po/src/api.rs
@@ -25,7 +25,9 @@ pub use self::audit::{
     CatalogAuditChecks, CatalogAuditDiagnostic, CatalogAuditIcuOptions, CatalogAuditMessageRef,
     CatalogAuditOptions, CatalogAuditReport, CatalogAuditSummary, audit_catalogs,
 };
-pub use self::catalog::{parse_catalog, update_catalog, update_catalog_file};
+pub use self::catalog::{
+    parse_catalog, parse_catalog_for_review, update_catalog, update_catalog_file,
+};
 pub use self::combine::{combine_catalog_files, combine_catalogs};
 pub use self::compile::{
     compile_catalog_artifact, compile_catalog_artifact_report, compile_catalog_artifact_selected,

--- a/crates/ferrocat-po/src/api/audit.rs
+++ b/crates/ferrocat-po/src/api/audit.rs
@@ -117,6 +117,8 @@ pub struct CatalogAuditChecks {
     pub icu_compatibility: bool,
     /// Validate source-side semantic message metadata.
     pub semantic_metadata: bool,
+    /// Report active entries carrying the semantic `fuzzy` review marker.
+    pub fuzzy_flags: bool,
     /// Report obsolete entries.
     pub obsolete_entries: bool,
 }
@@ -129,6 +131,7 @@ impl Default for CatalogAuditChecks {
             icu_syntax: true,
             icu_compatibility: true,
             semantic_metadata: true,
+            fuzzy_flags: true,
             obsolete_entries: true,
         }
     }
@@ -167,6 +170,13 @@ impl CatalogAuditChecks {
     #[must_use]
     pub fn with_semantic_metadata(mut self, semantic_metadata: bool) -> Self {
         self.semantic_metadata = semantic_metadata;
+        self
+    }
+
+    /// Returns checks with fuzzy-entry reporting enabled or disabled.
+    #[must_use]
+    pub fn with_fuzzy_flags(mut self, fuzzy_flags: bool) -> Self {
+        self.fuzzy_flags = fuzzy_flags;
         self
     }
 
@@ -285,21 +295,22 @@ impl CatalogAuditReport {
 ///
 /// Returns [`ApiError::InvalidArguments`] when `source_locale` is empty or when
 /// catalogs cannot be inspected because their declared locales are missing or
-/// duplicated.
+/// duplicated, or when a required catalog was not parsed with
+/// [`super::parse_catalog_for_review`].
 ///
 /// # Examples
 ///
 /// ```rust
-/// use ferrocat_po::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog};
+/// use ferrocat_po::{
+///     CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog_for_review,
+/// };
 ///
-/// let source = parse_catalog(
+/// let source = parse_catalog_for_review(
 ///     ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en").with_locale("en"),
-/// )?
-/// .into_normalized_view()?;
-/// let target = parse_catalog(
+/// )?;
+/// let target = parse_catalog_for_review(
 ///     ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"\"\n", "en").with_locale("de"),
-/// )?
-/// .into_normalized_view()?;
+/// )?;
 ///
 /// let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
 /// assert!(report.has_errors());
@@ -334,7 +345,11 @@ pub fn audit_catalogs(
     let source_locale = source_catalog.parsed_catalog().locale.as_deref();
     let mut source_icu_cache = ParsedIcuCache::new();
 
-    if options.checks.obsolete_entries || options.checks.icu_syntax {
+    if options.checks.fuzzy_flags {
+        source_catalog.require_review_state("audit_catalogs")?;
+    }
+
+    if options.checks.fuzzy_flags || options.checks.obsolete_entries || options.checks.icu_syntax {
         audit_catalog_entries(
             source_catalog,
             source_locale,
@@ -365,6 +380,9 @@ pub fn audit_catalogs(
         let Some(target_catalog) = catalog_index.get(target_locale.as_str()).copied() else {
             continue;
         };
+        if options.checks.fuzzy_flags || options.checks.completeness {
+            target_catalog.require_review_state("audit_catalogs")?;
+        }
         let mut target_icu_cache = ParsedIcuCache::new();
         audit_catalog_entries(
             target_catalog,
@@ -477,6 +495,15 @@ fn audit_catalog_entries(
                 None,
             ));
         }
+        if options.checks.fuzzy_flags && message.obsolete.is_none() && catalog.is_fuzzy(key) {
+            report.diagnostics.push(CatalogAuditDiagnostic::new(
+                DiagnosticSeverity::Info,
+                diagnostic_codes::catalog::FUZZY_FLAG,
+                "Catalog entry carries a fuzzy review marker.",
+                Some(message_ref.clone()),
+                Some("fuzzy".to_owned()),
+            ));
+        }
         if options.checks.icu_syntax && message.obsolete.is_none() {
             let cache_parse = parsed_icu_cache.is_some();
             let parsed_candidate = audit_icu_syntax_for_message(
@@ -529,7 +556,7 @@ fn audit_target_catalog(
                         Some(target_locale.to_owned()),
                     ));
                 }
-                CatalogMessageStatus::Translated => {}
+                CatalogMessageStatus::Translated | CatalogMessageStatus::Fuzzy => {}
                 CatalogMessageStatus::Extra => {
                     unreachable!("expected source-key classification cannot produce extra status")
                 }
@@ -755,6 +782,7 @@ mod tests {
             .with_icu_syntax(false)
             .with_icu_compatibility(false)
             .with_semantic_metadata(false)
+            .with_fuzzy_flags(false)
             .with_obsolete_entries(false);
 
         assert!(!checks.completeness);
@@ -762,6 +790,7 @@ mod tests {
         assert!(!checks.icu_syntax);
         assert!(!checks.icu_compatibility);
         assert!(!checks.semantic_metadata);
+        assert!(!checks.fuzzy_flags);
         assert!(!checks.obsolete_entries);
 
         let options = CatalogAuditOptions::new("en")

--- a/crates/ferrocat-po/src/api/catalog.rs
+++ b/crates/ferrocat-po/src/api/catalog.rs
@@ -47,12 +47,11 @@ pub(super) struct Catalog {
 
 /// One catalog entry in the canonical internal model.
 ///
-/// `opaque` is deliberately internal: the catalog layer gives translator
-/// comments and flags no semantics (see
-/// [ADR 0027](/architecture/adr/0027-opaque-po-metadata-roundtrip)), it only
-/// keeps them attached to the `(msgctxt, msgid)` identity so a source-first
-/// update does not destroy translator-owned metadata. They are not projected
-/// into the public [`CatalogMessage`].
+/// `opaque` is deliberately internal: the catalog layer keeps translator
+/// comments and arbitrary flags attached to the `(msgctxt, msgid)` identity so
+/// a source-first update does not destroy translator-owned metadata (ADR 0027).
+/// Only the dedicated review projection observes exact `fuzzy` (ADR 0028);
+/// none of this metadata is projected into the public [`CatalogMessage`].
 ///
 /// Do not shrink the other fields to "compensate" for the extra one:
 /// `size_of::<CanonicalMessage>()` must stay `>= size_of::<CatalogMessage>()`
@@ -75,7 +74,8 @@ pub(super) struct CanonicalMessage {
 }
 
 /// Translator-owned `#` comments and per-entry `#,` flags, preserved opaquely
-/// across updates and never interpreted (ADR 0027).
+/// across updates; exact `fuzzy` is observed only by the review projection
+/// (ADRs 0027 and 0028).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(super) struct OpaqueMetadata {
     pub(super) translator_comments: Vec<String>,
@@ -101,11 +101,16 @@ impl CanonicalMessage {
 /// Whether an import keeps the opaque PO round-trip metadata.
 ///
 /// The public `parse_catalog` projection has no slot for it, so building the
-/// block there would only be allocated-and-dropped churn on every parse;
-/// update and combine flows must keep it (ADR 0027).
+/// block there would only be allocated-and-dropped churn on every parse.
+/// Update/combine keep everything (ADR 0027); the report projection keeps only
+/// exact `fuzzy` (ADR 0028).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum OpaqueCapture {
+    /// Preserve all opaque metadata for update/combine round-tripping.
     Keep,
+    /// Preserve only the semantic `fuzzy` marker needed by report classifiers.
+    ReviewState,
+    /// Skip opaque metadata for the default high-throughput public projection.
     Discard,
 }
 
@@ -319,11 +324,38 @@ pub fn update_catalog_file(
 /// assert_eq!(catalog.messages.len(), 1);
 /// # Ok::<(), ferrocat_po::ApiError>(())
 /// ```
-#[expect(
-    clippy::needless_pass_by_value,
-    reason = "Public API takes owned option structs so callers can build and move them ergonomically."
-)]
 pub fn parse_catalog(options: ParseCatalogOptions<'_>) -> Result<ParsedCatalog, ApiError> {
+    parse_catalog_projection(options, OpaqueCapture::Discard).map(|(catalog, _)| catalog)
+}
+
+/// Parses catalog content directly into a normalized, review-aware projection.
+///
+/// Unlike [`parse_catalog`], this entry point retains the semantic presence of
+/// the `fuzzy` flag for coverage, audit, and review classification. Arbitrary
+/// gettext flags and translator comments remain opaque and are not exposed.
+///
+/// # Errors
+///
+/// Returns [`ApiError`] when the catalog content cannot be parsed, the source
+/// locale is missing, strict ICU projection fails, or duplicate message
+/// identities prevent normalization.
+pub fn parse_catalog_for_review(
+    options: ParseCatalogOptions<'_>,
+) -> Result<super::NormalizedParsedCatalog, ApiError> {
+    let (catalog, fuzzy_keys) = parse_catalog_projection(options, OpaqueCapture::ReviewState)?;
+    super::NormalizedParsedCatalog::new_with_review_state(catalog, fuzzy_keys)
+}
+
+fn parse_catalog_projection(
+    options: ParseCatalogOptions<'_>,
+    opaque_capture: OpaqueCapture,
+) -> Result<
+    (
+        ParsedCatalog,
+        std::collections::BTreeSet<super::CatalogMessageKey>,
+    ),
+    ApiError,
+> {
     super::validate_source_locale(options.source_locale)?;
     let catalog = parse_catalog_to_internal(
         options.content,
@@ -333,21 +365,36 @@ pub fn parse_catalog(options: ParseCatalogOptions<'_>) -> Result<ParsedCatalog, 
         options.mode.plural_encoding(),
         options.strict,
         options.mode.storage_format(),
-        OpaqueCapture::Discard,
+        opaque_capture,
     )?;
+    let fuzzy_keys = if opaque_capture == OpaqueCapture::ReviewState {
+        catalog
+            .messages
+            .iter()
+            .filter(|message| message.flags().iter().any(|flag| flag == "fuzzy"))
+            .map(|message| {
+                super::CatalogMessageKey::new(message.msgid.clone(), message.msgctxt.clone())
+            })
+            .collect()
+    } else {
+        std::collections::BTreeSet::new()
+    };
     let messages = catalog
         .messages
         .into_iter()
         .map(public_message_from_canonical)
         .collect();
 
-    Ok(ParsedCatalog {
-        locale: catalog.locale,
-        semantics: options.mode.semantics(),
-        headers: catalog.headers,
-        messages,
-        diagnostics: catalog.diagnostics,
-    })
+    Ok((
+        ParsedCatalog {
+            locale: catalog.locale,
+            semantics: options.mode.semantics(),
+            headers: catalog.headers,
+            messages,
+            diagnostics: catalog.diagnostics,
+        },
+        fuzzy_keys,
+    ))
 }
 
 /// Collapses the accepted extractor input shapes into one merge-oriented form.
@@ -1015,12 +1062,20 @@ fn import_message_from_po(
     // placeholder split); translator-owned `#` comments and `#,` flags are kept
     // separately and opaquely so an update cannot rewrite or drop them.
     let (comments, placeholders) = split_placeholder_comments(item.extracted_comments);
-    // The public parse projection has no slot for the opaque block, so it
-    // skips building it instead of allocating strings only to drop them.
+    // The default public projection skips this block entirely. Reporting keeps
+    // only exact `fuzzy`; update/combine keep the full round-trip payload.
     let opaque = match opaque_capture {
         OpaqueCapture::Keep => OpaqueMetadata::from_parts(
             item.comments.into_iter().map(Cow::into_owned).collect(),
             item.flags.into_iter().map(Cow::into_owned).collect(),
+        ),
+        OpaqueCapture::ReviewState => OpaqueMetadata::from_parts(
+            Vec::new(),
+            item.flags
+                .into_iter()
+                .filter(|flag| flag == "fuzzy")
+                .map(Cow::into_owned)
+                .collect(),
         ),
         OpaqueCapture::Discard => None,
     };

--- a/crates/ferrocat-po/src/api/coverage.rs
+++ b/crates/ferrocat-po/src/api/coverage.rs
@@ -65,9 +65,6 @@ pub struct CatalogLocaleCoverage {
     pub missing: usize,
     /// Expected messages with an empty effective translation.
     pub empty: usize,
-    /// Expected messages with a non-empty active translation carrying the
-    /// semantic `fuzzy` review marker.
-    pub fuzzy: usize,
     /// Expected messages with only an obsolete target entry.
     pub obsolete: usize,
     /// Active target messages that are not present in the active source set.
@@ -77,6 +74,20 @@ pub struct CatalogLocaleCoverage {
 }
 
 impl CatalogLocaleCoverage {
+    /// Returns expected messages with a non-empty active translation carrying
+    /// the semantic `fuzzy` review marker.
+    ///
+    /// Fuzzy is the remaining mutually exclusive expected-message state after
+    /// subtracting translated, missing, empty, and obsolete messages.
+    #[must_use]
+    pub const fn fuzzy(&self) -> usize {
+        self.total
+            .saturating_sub(self.translated)
+            .saturating_sub(self.missing)
+            .saturating_sub(self.empty)
+            .saturating_sub(self.obsolete)
+    }
+
     /// Returns messages that still need translator attention.
     #[must_use]
     pub const fn incomplete(&self) -> usize {
@@ -239,10 +250,10 @@ fn coverage_for_locale(
 fn increment_status(coverage: &mut CatalogLocaleCoverage, status: CatalogMessageStatus) {
     match status {
         CatalogMessageStatus::Translated => coverage.translated += 1,
-        CatalogMessageStatus::Fuzzy => coverage.fuzzy += 1,
         CatalogMessageStatus::Missing => coverage.missing += 1,
         CatalogMessageStatus::Empty => coverage.empty += 1,
         CatalogMessageStatus::Obsolete => coverage.obsolete += 1,
         CatalogMessageStatus::Extra => coverage.extra += 1,
+        CatalogMessageStatus::Fuzzy => {}
     }
 }

--- a/crates/ferrocat-po/src/api/coverage.rs
+++ b/crates/ferrocat-po/src/api/coverage.rs
@@ -59,12 +59,15 @@ pub struct CatalogLocaleCoverage {
     pub locale: String,
     /// Active source messages expected for this locale.
     pub total: usize,
-    /// Expected messages with non-empty active translations.
+    /// Expected messages with non-empty, non-fuzzy active translations.
     pub translated: usize,
     /// Expected messages with no target entry.
     pub missing: usize,
     /// Expected messages with an empty effective translation.
     pub empty: usize,
+    /// Expected messages with a non-empty active translation carrying the
+    /// semantic `fuzzy` review marker.
+    pub fuzzy: usize,
     /// Expected messages with only an obsolete target entry.
     pub obsolete: usize,
     /// Active target messages that are not present in the active source set.
@@ -113,7 +116,7 @@ pub struct CatalogCoverageMessage {
 /// Builds a read-only completeness and coverage report for normalized catalogs.
 ///
 /// The report uses the source locale's active messages as the expected set.
-/// Empty, obsolete, and absent target messages do not count as translated.
+/// Fuzzy, empty, obsolete, and absent target messages do not count as translated.
 /// Active target-only messages are counted as `extra` and do not affect the
 /// completion denominator.
 ///
@@ -122,18 +125,16 @@ pub struct CatalogCoverageMessage {
 /// ```rust
 /// use ferrocat_po::{
 ///     CatalogCoverageOptions, CatalogMessageStatus, ParseCatalogOptions, measure_catalog_coverage,
-///     parse_catalog,
+///     parse_catalog_for_review,
 /// };
 ///
-/// let source = parse_catalog(
+/// let source = parse_catalog_for_review(
 ///     ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"\"\n", "en").with_locale("en"),
-/// )?
-/// .into_normalized_view()?;
-/// let target = parse_catalog(
+/// )?;
+/// let target = parse_catalog_for_review(
 ///     ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"Speichern\"\n", "en")
 ///         .with_locale("de"),
-/// )?
-/// .into_normalized_view()?;
+/// )?;
 ///
 /// let options = CatalogCoverageOptions::new("en").with_details(true);
 /// let report = measure_catalog_coverage(&[&source, &target], &options)?;
@@ -148,7 +149,9 @@ pub struct CatalogCoverageMessage {
 /// # Errors
 ///
 /// Returns [`ApiError::InvalidArguments`] when locales are missing, empty,
-/// duplicated, or when a requested target locale is absent from the catalog set.
+/// duplicated, when a requested target locale is absent from the catalog set,
+/// or when a selected target was not parsed with
+/// [`super::parse_catalog_for_review`].
 pub fn measure_catalog_coverage(
     catalogs: &[&NormalizedParsedCatalog],
     options: &CatalogCoverageOptions<'_>,
@@ -177,6 +180,7 @@ pub fn measure_catalog_coverage(
         let target_catalog = catalog_index
             .get(target_locale.as_str())
             .expect("selected target locale must exist");
+        target_catalog.require_review_state("measure_catalog_coverage")?;
         locale_reports.push(coverage_for_locale(
             target_locale,
             target_catalog,
@@ -235,6 +239,7 @@ fn coverage_for_locale(
 fn increment_status(coverage: &mut CatalogLocaleCoverage, status: CatalogMessageStatus) {
     match status {
         CatalogMessageStatus::Translated => coverage.translated += 1,
+        CatalogMessageStatus::Fuzzy => coverage.fuzzy += 1,
         CatalogMessageStatus::Missing => coverage.missing += 1,
         CatalogMessageStatus::Empty => coverage.empty += 1,
         CatalogMessageStatus::Obsolete => coverage.obsolete += 1,

--- a/crates/ferrocat-po/src/api/fcl.rs
+++ b/crates/ferrocat-po/src/api/fcl.rs
@@ -914,6 +914,40 @@ mod tests {
     }
 
     #[test]
+    fn discard_projection_validates_opaque_tag_escapes_without_retaining_them() {
+        let valid =
+            format!("{FCL_MAGIC}\tsource=en\nid\t\tvalue\ttc=first\\tnote\tf=x\\\\custom\n");
+        let catalog = parse_catalog_to_internal_fcl(
+            &valid,
+            None,
+            "en",
+            CatalogSemantics::IcuNative,
+            false,
+            OpaqueCapture::Discard,
+        )
+        .expect("discard projection should validate opaque tags");
+        assert!(catalog.messages[0].translator_comments().is_empty());
+        assert!(catalog.messages[0].flags().is_empty());
+
+        for invalid in [
+            format!("{FCL_MAGIC}\tsource=en\nid\t\tvalue\ttc=bad\\xescape\n"),
+            format!("{FCL_MAGIC}\tsource=en\nid\t\tvalue\tf=dangling\\\n"),
+        ] {
+            assert!(
+                parse_catalog_to_internal_fcl(
+                    &invalid,
+                    None,
+                    "en",
+                    CatalogSemantics::IcuNative,
+                    false,
+                    OpaqueCapture::Discard,
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
     fn rejects_malformed_headers() {
         assert!(parse_err("nope\nid\t\tv\n")); // missing %FCL1 magic
         assert!(parse_err(&format!("{FCL_MAGIC}\tbogus=x\nid\t\tv\n"))); // unknown header key

--- a/crates/ferrocat-po/src/api/fcl.rs
+++ b/crates/ferrocat-po/src/api/fcl.rs
@@ -110,6 +110,29 @@ fn unescape(value: &str) -> Result<Cow<'_, str>, ApiError> {
     }
 }
 
+fn validate_escapes(value: &str) -> Result<(), ApiError> {
+    let bytes = value.as_bytes();
+    let mut start = 0;
+    while let Some(relative) = find_byte(b'\\', &bytes[start..]) {
+        let at = start + relative;
+        match bytes.get(at + 1) {
+            Some(b'\\' | b't' | b'n') => start = at + 2,
+            Some(_) => {
+                let other = value[at + 1..].chars().next().unwrap_or('\u{fffd}');
+                return Err(ApiError::InvalidArguments(format!(
+                    "invalid FCL escape `\\{other}`"
+                )));
+            }
+            None => {
+                return Err(ApiError::InvalidArguments(
+                    "dangling `\\` at end of FCL value".to_owned(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 // --- serialize ------------------------------------------------------------
 
 fn write_tag(out: &mut String, key: &str, value: &str) {
@@ -186,7 +209,8 @@ fn write_entry(out: &mut String, message: &CanonicalMessage, render: &RenderOpti
     );
 
     // Translator-owned notes and flags stay separate from `c` and keep their
-    // stored order; the catalog layer never interprets either.
+    // stored order. Export treats them as opaque even though the dedicated
+    // review projection observes exact `fuzzy`.
     for comment in message.translator_comments() {
         write_tag(out, "tc", comment);
     }
@@ -409,29 +433,40 @@ fn parse_entry(line: &str, opaque_capture: OpaqueCapture) -> Result<CanonicalMes
         let (key, raw_value) = split_once_byte(tag, b'=').ok_or_else(|| {
             ApiError::InvalidArguments(format!("invalid FCL tag {:?}", input_slice_as_str(tag)))
         })?;
-        // Keep the unescaped value borrowed; only allocate (`into_owned`) for tags
-        // whose value is stored.
-        let value = unescape(input_slice_as_str(raw_value))?;
+        let raw_value = input_slice_as_str(raw_value);
         match key {
             b"r" => {
                 validate_tag_order(&mut last_tag_rank, TAG_RANK_REFERENCE, "r")?;
-                origins.push(parse_origin(value));
+                origins.push(parse_origin(unescape(raw_value)?));
             }
             b"c" => {
                 validate_tag_order(&mut last_tag_rank, TAG_RANK_COMMENT, "c")?;
-                raw_comments.push(value);
+                raw_comments.push(unescape(raw_value)?);
             }
             b"tc" => {
                 validate_tag_order(&mut last_tag_rank, TAG_RANK_TRANSLATOR_COMMENT, "tc")?;
-                translator_comments.push(value.into_owned());
+                if opaque_capture == OpaqueCapture::Keep {
+                    translator_comments.push(unescape(raw_value)?.into_owned());
+                } else {
+                    validate_escapes(raw_value)?;
+                }
             }
             b"f" => {
                 validate_tag_order(&mut last_tag_rank, TAG_RANK_FLAG, "f")?;
-                flags.push(value.into_owned());
+                match opaque_capture {
+                    OpaqueCapture::Keep => flags.push(unescape(raw_value)?.into_owned()),
+                    OpaqueCapture::ReviewState => {
+                        validate_escapes(raw_value)?;
+                        if raw_value == "fuzzy" {
+                            flags.push("fuzzy".to_owned());
+                        }
+                    }
+                    OpaqueCapture::Discard => validate_escapes(raw_value)?,
+                }
             }
             b"o" => {
                 validate_tag_order(&mut last_tag_rank, TAG_RANK_OBSOLETE, "o")?;
-                set_obsolete(&mut obsolete, Some(value.into_owned()))?;
+                set_obsolete(&mut obsolete, Some(unescape(raw_value)?.into_owned()))?;
             }
             b"lock" => {
                 validate_tag_order(&mut last_tag_rank, TAG_RANK_LOCK, "lock")?;
@@ -440,7 +475,7 @@ fn parse_entry(line: &str, opaque_capture: OpaqueCapture) -> Result<CanonicalMes
                         "duplicate FCL tag `lock`".to_owned(),
                     ));
                 }
-                lock = Some(value.into_owned());
+                lock = Some(unescape(raw_value)?.into_owned());
             }
             b"ai" => {
                 validate_tag_order(&mut last_tag_rank, TAG_RANK_AI, "ai")?;
@@ -449,6 +484,7 @@ fn parse_entry(line: &str, opaque_capture: OpaqueCapture) -> Result<CanonicalMes
                         "duplicate FCL tag `ai`".to_owned(),
                     ));
                 }
+                let value = unescape(raw_value)?;
                 ai = Some(parse_ai_descriptor(&value));
             }
             other => {
@@ -481,6 +517,7 @@ fn parse_entry(line: &str, opaque_capture: OpaqueCapture) -> Result<CanonicalMes
         comments,
         opaque: match opaque_capture {
             OpaqueCapture::Keep => OpaqueMetadata::from_parts(translator_comments, flags),
+            OpaqueCapture::ReviewState => OpaqueMetadata::from_parts(Vec::new(), flags),
             OpaqueCapture::Discard => None,
         },
         origins,

--- a/crates/ferrocat-po/src/api/message_status.rs
+++ b/crates/ferrocat-po/src/api/message_status.rs
@@ -11,8 +11,11 @@ use super::{CatalogMessage, CatalogMessageKey, EffectiveTranslationRef, Normaliz
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[non_exhaustive]
 pub enum CatalogMessageStatus {
-    /// Active target message exists and has a non-empty translation.
+    /// Active target message exists and has a non-empty, non-fuzzy translation.
     Translated,
+    /// Active target message exists, has a non-empty translation, and carries
+    /// the semantic `fuzzy` review marker.
+    Fuzzy,
     /// No active or obsolete target entry exists for the active source identity.
     Missing,
     /// Active target entry exists, but its effective translation is empty.
@@ -44,6 +47,9 @@ pub(super) fn classify_expected_message(
     }
     if translation_is_empty(message) {
         return CatalogMessageStatus::Empty;
+    }
+    if target_catalog.is_fuzzy(key) {
+        return CatalogMessageStatus::Fuzzy;
     }
     CatalogMessageStatus::Translated
 }

--- a/crates/ferrocat-po/src/api/message_status.rs
+++ b/crates/ferrocat-po/src/api/message_status.rs
@@ -13,9 +13,6 @@ use super::{CatalogMessage, CatalogMessageKey, EffectiveTranslationRef, Normaliz
 pub enum CatalogMessageStatus {
     /// Active target message exists and has a non-empty, non-fuzzy translation.
     Translated,
-    /// Active target message exists, has a non-empty translation, and carries
-    /// the semantic `fuzzy` review marker.
-    Fuzzy,
     /// No active or obsolete target entry exists for the active source identity.
     Missing,
     /// Active target entry exists, but its effective translation is empty.
@@ -24,6 +21,9 @@ pub enum CatalogMessageStatus {
     Obsolete,
     /// Active target entry is not present in the active source identity set.
     Extra,
+    /// Active target message exists, has a non-empty translation, and carries
+    /// the semantic `fuzzy` review marker.
+    Fuzzy,
 }
 
 pub(super) fn active_message_keys(

--- a/crates/ferrocat-po/src/api/review.rs
+++ b/crates/ferrocat-po/src/api/review.rs
@@ -222,40 +222,38 @@ pub enum CatalogMachineTranslationStatus {
 /// Target status rollups reuse [`CatalogMessageStatus`] and therefore match
 /// [`super::audit_catalogs`] and [`super::measure_catalog_coverage`] semantics.
 /// Translation change details are limited to source identities whose current
-/// target status is [`CatalogMessageStatus::Translated`]; missing, empty, and
-/// obsolete current entries are surfaced by the coverage counters.
+/// target status is [`CatalogMessageStatus::Translated`]; missing, empty,
+/// fuzzy, and obsolete current entries are surfaced by the coverage counters.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use ferrocat_po::{CatalogReviewOptions, ParseCatalogOptions, review_catalogs, parse_catalog};
+/// use ferrocat_po::{
+///     CatalogReviewOptions, ParseCatalogOptions, parse_catalog_for_review, review_catalogs,
+/// };
 ///
-/// let previous_source = parse_catalog(
+/// let previous_source = parse_catalog_for_review(
 ///     ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"\"\n", "en").with_locale("en"),
-/// )?
-/// .into_normalized_view()?;
-/// let previous_target = parse_catalog(
+/// )?;
+/// let previous_target = parse_catalog_for_review(
 ///     ParseCatalogOptions::new("msgid \"Save\"\nmsgstr \"Speichern\"\n", "en")
 ///         .with_locale("de"),
-/// )?
-/// .into_normalized_view()?;
+/// )?;
 ///
-/// let current_source = parse_catalog(
+/// let current_source = parse_catalog_for_review(
 ///     ParseCatalogOptions::new(
 ///         "msgid \"Save\"\nmsgstr \"\"\n\nmsgid \"Cancel\"\nmsgstr \"\"\n",
 ///         "en",
 ///     )
 ///     .with_locale("en"),
-/// )?
-/// .into_normalized_view()?;
-/// let current_target = parse_catalog(
+/// )?;
+/// let current_target = parse_catalog_for_review(
 ///     ParseCatalogOptions::new(
 ///         "msgid \"Save\"\nmsgstr \"Sichern\"\n\nmsgid \"Cancel\"\nmsgstr \"\"\n",
 ///         "en",
 ///     )
 ///     .with_locale("de"),
-/// )?
-/// .into_normalized_view()?;
+/// )?;
 ///
 /// let options = CatalogReviewOptions::new("en").with_details(true);
 /// let report = review_catalogs(
@@ -274,7 +272,8 @@ pub enum CatalogMachineTranslationStatus {
 ///
 /// Returns [`ApiError::InvalidArguments`] when either catalog state is missing
 /// required locales, contains duplicate locales, or a requested target locale is
-/// not available in the current catalog state.
+/// not available in the current catalog state, or when a current target was not
+/// parsed with [`super::parse_catalog_for_review`].
 pub fn review_catalogs(
     previous_catalogs: &[&NormalizedParsedCatalog],
     current_catalogs: &[&NormalizedParsedCatalog],
@@ -522,7 +521,7 @@ mod tests {
     use crate::api::{
         AiProvenance, ApiError, CatalogMessage, CatalogMessageKey, CatalogMode, CatalogSemantics,
         EffectiveTranslationRef, MachineMetadata, ParseCatalogOptions, ParsedCatalog,
-        TranslationShape, machine_translation_hash, parse_catalog,
+        TranslationShape, machine_translation_hash, parse_catalog_for_review,
     };
 
     fn catalog(content: &str, locale: &str) -> crate::api::NormalizedParsedCatalog {
@@ -545,14 +544,12 @@ mod tests {
         locale: Option<&str>,
         mode: CatalogMode,
     ) -> crate::api::NormalizedParsedCatalog {
-        parse_catalog(ParseCatalogOptions {
+        parse_catalog_for_review(ParseCatalogOptions {
             locale,
             mode,
             ..ParseCatalogOptions::new(content, "en")
         })
         .expect("parse catalog")
-        .into_normalized_view()
-        .expect("normalize catalog")
     }
 
     fn catalog_with_messages(
@@ -566,7 +563,7 @@ mod tests {
             messages,
             diagnostics: Vec::new(),
         }
-        .into_normalized_view()
+        .into_normalized_view_assuming_no_fuzzy()
         .expect("normalize catalog")
     }
 

--- a/crates/ferrocat-po/src/api/review.rs
+++ b/crates/ferrocat-po/src/api/review.rs
@@ -222,8 +222,10 @@ pub enum CatalogMachineTranslationStatus {
 /// Target status rollups reuse [`CatalogMessageStatus`] and therefore match
 /// [`super::audit_catalogs`] and [`super::measure_catalog_coverage`] semantics.
 /// Translation change details are limited to source identities whose current
-/// target status is [`CatalogMessageStatus::Translated`]; missing, empty,
-/// fuzzy, and obsolete current entries are surfaced by the coverage counters.
+/// target has a non-empty active translation. Fuzzy translations remain
+/// eligible because their review marker and value change are independent
+/// signals; missing, empty, and obsolete current entries are surfaced by the
+/// coverage counters.
 ///
 /// # Examples
 ///
@@ -397,8 +399,10 @@ fn translation_change_report(
     let mut report = CatalogTranslationChangeReport::default();
 
     for source_key in current_source_keys {
-        if classify_expected_message(current_target, source_key) != CatalogMessageStatus::Translated
-        {
+        if !matches!(
+            classify_expected_message(current_target, source_key),
+            CatalogMessageStatus::Translated | CatalogMessageStatus::Fuzzy
+        ) {
             continue;
         }
         let Some(previous_message) = previous_target

--- a/crates/ferrocat-po/src/api/tests/audit.rs
+++ b/crates/ferrocat-po/src/api/tests/audit.rs
@@ -8,18 +8,16 @@ use crate::{CatalogAuditChecks, CatalogAuditIcuOptions};
 use super::super::icu_syntax::{icu_parse_count, reset_icu_parse_count};
 use super::{
     CatalogAuditOptions, CatalogMode, DiagnosticSeverity, IcuSyntaxPolicy, ParseCatalogOptions,
-    audit_catalogs, parse_catalog,
+    audit_catalogs, parse_catalog_for_review,
 };
 
 fn catalog(content: &str, locale: &str) -> super::super::NormalizedParsedCatalog {
-    parse_catalog(ParseCatalogOptions {
+    parse_catalog_for_review(ParseCatalogOptions {
         locale: Some(locale),
         mode: CatalogMode::IcuPo,
         ..ParseCatalogOptions::new(content, "en")
     })
     .expect("parse catalog")
-    .into_normalized_view()
-    .expect("normalize catalog")
 }
 
 fn diagnostic_codes(report: &super::super::CatalogAuditReport) -> Vec<&str> {
@@ -121,6 +119,20 @@ fn audit_reports_empty_target_translation() {
         audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en")).expect("audit");
 
     assert!(diagnostic_codes(&report).contains(&"catalog.empty_translation"));
+}
+
+#[test]
+fn audit_reports_fuzzy_without_classifying_it_as_missing_or_empty() {
+    let source = catalog("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en");
+    let target = catalog("#, fuzzy\nmsgid \"Hello\"\nmsgstr \"Hallo\"\n", "de");
+
+    let report =
+        audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en")).expect("audit");
+    let codes = diagnostic_codes(&report);
+
+    assert!(codes.contains(&"catalog.fuzzy_flag"));
+    assert!(!codes.contains(&"catalog.missing_translation"));
+    assert!(!codes.contains(&"catalog.empty_translation"));
 }
 
 #[test]

--- a/crates/ferrocat-po/src/api/tests/audit.rs
+++ b/crates/ferrocat-po/src/api/tests/audit.rs
@@ -8,7 +8,7 @@ use crate::{CatalogAuditChecks, CatalogAuditIcuOptions};
 use super::super::icu_syntax::{icu_parse_count, reset_icu_parse_count};
 use super::{
     CatalogAuditOptions, CatalogMode, DiagnosticSeverity, IcuSyntaxPolicy, ParseCatalogOptions,
-    audit_catalogs, parse_catalog_for_review,
+    audit_catalogs, parse_catalog, parse_catalog_for_review,
 };
 
 fn catalog(content: &str, locale: &str) -> super::super::NormalizedParsedCatalog {
@@ -18,6 +18,17 @@ fn catalog(content: &str, locale: &str) -> super::super::NormalizedParsedCatalog
         ..ParseCatalogOptions::new(content, "en")
     })
     .expect("parse catalog")
+}
+
+fn catalog_without_review(content: &str, locale: &str) -> super::super::NormalizedParsedCatalog {
+    parse_catalog(ParseCatalogOptions {
+        locale: Some(locale),
+        mode: CatalogMode::IcuPo,
+        ..ParseCatalogOptions::new(content, "en")
+    })
+    .expect("parse catalog")
+    .into_normalized_view()
+    .expect("normalize catalog")
 }
 
 fn diagnostic_codes(report: &super::super::CatalogAuditReport) -> Vec<&str> {
@@ -133,6 +144,23 @@ fn audit_reports_fuzzy_without_classifying_it_as_missing_or_empty() {
     assert!(codes.contains(&"catalog.fuzzy_flag"));
     assert!(!codes.contains(&"catalog.missing_translation"));
     assert!(!codes.contains(&"catalog.empty_translation"));
+}
+
+#[test]
+fn audit_rejects_discarded_source_or_target_review_state() {
+    let source = catalog("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en");
+    let target = catalog("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "de");
+    let source_without_review = catalog_without_review("msgid \"Hello\"\nmsgstr \"Hello\"\n", "en");
+    let target_without_review = catalog_without_review("msgid \"Hello\"\nmsgstr \"Hallo\"\n", "de");
+
+    for catalogs in [
+        [&source_without_review, &target],
+        [&source, &target_without_review],
+    ] {
+        let error = audit_catalogs(&catalogs, &CatalogAuditOptions::new("en"))
+            .expect_err("audit must reject discarded fuzzy state");
+        assert!(error.to_string().contains("parse_catalog_for_review"));
+    }
 }
 
 #[test]

--- a/crates/ferrocat-po/src/api/tests/catalog.rs
+++ b/crates/ferrocat-po/src/api/tests/catalog.rs
@@ -2719,8 +2719,8 @@ fn update_catalog_preserves_unknown_flags_verbatim() {
     })
     .expect("update");
 
-    // Flags render as one line after the references and are never interpreted:
-    // `fuzzy` does not revive a status, `x-custom` survives unchanged.
+    // Update treats flags as opaque round-trip state: `fuzzy` and `x-custom`
+    // both survive unchanged. Report classification is tested separately.
     assert!(result.content.contains("#, fuzzy, x-custom\n"));
     let parsed = parse_po(&result.content).expect("parse output");
     assert_eq!(parsed.items[0].flags.as_slice(), ["fuzzy", "x-custom"]);

--- a/crates/ferrocat-po/src/api/tests/coverage.rs
+++ b/crates/ferrocat-po/src/api/tests/coverage.rs
@@ -48,7 +48,7 @@ fn coverage_report_counts_expected_message_statuses() {
     assert_eq!(locale.total, 5);
     assert_eq!(locale.translated, 1);
     assert_eq!(locale.empty, 1);
-    assert_eq!(locale.fuzzy, 1);
+    assert_eq!(locale.fuzzy(), 1);
     assert_eq!(locale.obsolete, 1);
     assert_eq!(locale.missing, 1);
     assert_eq!(locale.extra, 1);
@@ -74,7 +74,7 @@ fn coverage_report_classifies_fcl_fuzzy_like_po_fuzzy() {
     let locale = &report.locales[0];
 
     assert_eq!(locale.translated, 0);
-    assert_eq!(locale.fuzzy, 1);
+    assert_eq!(locale.fuzzy(), 1);
     assert_eq!(locale.details[0].status, CatalogMessageStatus::Fuzzy);
 }
 
@@ -294,14 +294,14 @@ fn coverage_statuses_are_mutually_exclusive_when_fuzzy_overlaps_other_state() {
     let locale = &report.locales[0];
 
     assert_eq!(locale.translated, 0);
-    assert_eq!(locale.fuzzy, 0);
+    assert_eq!(locale.fuzzy(), 0);
     assert_eq!(locale.empty, 1);
     assert_eq!(locale.obsolete, 1);
     assert_eq!(locale.missing, 0);
     assert_eq!(locale.extra, 1);
     assert_eq!(
         locale.total,
-        locale.translated + locale.fuzzy + locale.empty + locale.obsolete + locale.missing
+        locale.translated + locale.fuzzy() + locale.empty + locale.obsolete + locale.missing
     );
 }
 

--- a/crates/ferrocat-po/src/api/tests/coverage.rs
+++ b/crates/ferrocat-po/src/api/tests/coverage.rs
@@ -1,6 +1,7 @@
 use super::{
-    ApiError, CatalogCoverageOptions, CatalogMessageKey, CatalogMessageStatus, PluralEncoding,
-    measure_catalog_coverage, normalized_catalog,
+    ApiError, CatalogCoverageOptions, CatalogMessageKey, CatalogMessageStatus, ParseCatalogOptions,
+    PluralEncoding, measure_catalog_coverage, normalized_catalog, normalized_fcl_catalog,
+    parse_catalog,
 };
 
 fn invalid_arguments_message(error: ApiError) -> String {
@@ -45,15 +46,36 @@ fn coverage_report_counts_expected_message_statuses() {
     assert_eq!(report.source_messages, 5);
     assert_eq!(report.target_locales, 1);
     assert_eq!(locale.total, 5);
-    // The `#, fuzzy` entry imports as a normal translation now that flags are
-    // dropped, so it counts as translated rather than a separate fuzzy bucket.
-    assert_eq!(locale.translated, 2);
+    assert_eq!(locale.translated, 1);
     assert_eq!(locale.empty, 1);
+    assert_eq!(locale.fuzzy, 1);
     assert_eq!(locale.obsolete, 1);
     assert_eq!(locale.missing, 1);
     assert_eq!(locale.extra, 1);
-    assert_eq!(locale.incomplete(), 3);
-    assert_eq!(locale.completion_percent(), 40.0);
+    assert_eq!(locale.incomplete(), 4);
+    assert_eq!(locale.completion_percent(), 20.0);
+    assert!(locale.details.iter().any(|detail| {
+        detail.source_key == CatalogMessageKey::new("Fuzzy", None)
+            && detail.status == CatalogMessageStatus::Fuzzy
+    }));
+}
+
+#[test]
+fn coverage_report_classifies_fcl_fuzzy_like_po_fuzzy() {
+    let source = normalized_fcl_catalog("%FCL1\tsource=en\nFuzzy\t\tFuzzy\n", Some("en"));
+    let target =
+        normalized_fcl_catalog("%FCL1\tsource=en\nFuzzy\t\tUnscharf\tf=fuzzy\n", Some("de"));
+
+    let report = measure_catalog_coverage(
+        &[&source, &target],
+        &CatalogCoverageOptions::new("en").with_details(true),
+    )
+    .expect("coverage");
+    let locale = &report.locales[0];
+
+    assert_eq!(locale.translated, 0);
+    assert_eq!(locale.fuzzy, 1);
+    assert_eq!(locale.details[0].status, CatalogMessageStatus::Fuzzy);
 }
 
 #[test]
@@ -84,6 +106,34 @@ fn coverage_report_includes_optional_details() {
         detail.source_key == CatalogMessageKey::new("Extra", None)
             && detail.status == CatalogMessageStatus::Extra
     }));
+}
+
+#[test]
+fn coverage_report_rejects_the_metadata_discarding_parse_projection() {
+    let source = normalized_catalog(
+        "msgid \"Hello\"\nmsgstr \"Hello\"\n",
+        Some("en"),
+        PluralEncoding::Icu,
+    );
+    let target = parse_catalog(
+        ParseCatalogOptions::new(
+            "#, fuzzy, x-custom\nmsgid \"Hello\"\nmsgstr \"Hallo\"\n",
+            "en",
+        )
+        .with_locale("de"),
+    )
+    .expect("parse catalog")
+    .into_normalized_view()
+    .expect("normalize catalog");
+
+    let error = measure_catalog_coverage(&[&source, &target], &CatalogCoverageOptions::new("en"))
+        .expect_err("discarded review state must not silently count fuzzy as translated");
+
+    assert!(
+        invalid_arguments_message(error).contains("parse_catalog_for_review"),
+        "error should explain the review-aware parse path"
+    );
+    assert!(!target.has_review_state());
 }
 
 #[test]
@@ -203,6 +253,56 @@ fn coverage_report_classifies_plural_messages_with_empty_slots() {
         detail.source_key == CatalogMessageKey::new("book", None)
             && detail.status == CatalogMessageStatus::Empty
     }));
+}
+
+#[test]
+fn coverage_statuses_are_mutually_exclusive_when_fuzzy_overlaps_other_state() {
+    let source = normalized_catalog(
+        concat!(
+            "msgid \"partial\"\n",
+            "msgid_plural \"partials\"\n",
+            "msgstr[0] \"partial\"\n",
+            "msgstr[1] \"partials\"\n\n",
+            "msgid \"obsolete\"\nmsgstr \"obsolete\"\n",
+        ),
+        Some("en"),
+        PluralEncoding::Gettext,
+    );
+    let target = normalized_catalog(
+        concat!(
+            "#, fuzzy\n",
+            "msgid \"partial\"\n",
+            "msgid_plural \"partials\"\n",
+            "msgstr[0] \"Teil\"\n",
+            "msgstr[1] \"\"\n\n",
+            "#~ #, fuzzy\n",
+            "#~ msgid \"obsolete\"\n",
+            "#~ msgstr \"veraltet\"\n\n",
+            "#, fuzzy\n",
+            "msgid \"extra\"\n",
+            "msgstr \"zusätzlich\"\n",
+        ),
+        Some("de"),
+        PluralEncoding::Gettext,
+    );
+
+    let report = measure_catalog_coverage(
+        &[&source, &target],
+        &CatalogCoverageOptions::new("en").with_details(true),
+    )
+    .expect("coverage");
+    let locale = &report.locales[0];
+
+    assert_eq!(locale.translated, 0);
+    assert_eq!(locale.fuzzy, 0);
+    assert_eq!(locale.empty, 1);
+    assert_eq!(locale.obsolete, 1);
+    assert_eq!(locale.missing, 0);
+    assert_eq!(locale.extra, 1);
+    assert_eq!(
+        locale.total,
+        locale.translated + locale.fuzzy + locale.empty + locale.obsolete + locale.missing
+    );
 }
 
 #[test]

--- a/crates/ferrocat-po/src/api/tests/mod.rs
+++ b/crates/ferrocat-po/src/api/tests/mod.rs
@@ -13,7 +13,7 @@ pub(super) use super::{
     TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs,
     combine_catalog_files, combine_catalogs, compile::compiled_key_for, compile_catalog_artifact,
     compile_catalog_artifact_report, compile_catalog_artifact_selected, compiled_key,
-    machine_translation_hash, measure_catalog_coverage, parse_catalog,
+    machine_translation_hash, measure_catalog_coverage, parse_catalog, parse_catalog_for_review,
     plural::cached_icu_plural_categories_for, review_catalogs, update_catalog, update_catalog_file,
 };
 pub(super) use crate::parse_po;
@@ -45,26 +45,22 @@ pub(super) fn normalized_catalog(
         PluralEncoding::Icu => CatalogMode::IcuPo,
         PluralEncoding::Gettext => CatalogMode::GettextPo,
     };
-    parse_catalog(ParseCatalogOptions {
+    parse_catalog_for_review(ParseCatalogOptions {
         locale,
         mode,
         ..ParseCatalogOptions::new(content, "en")
     })
     .expect("parse catalog")
-    .into_normalized_view()
-    .expect("normalized view")
 }
 
 pub(super) fn normalized_fcl_catalog(
     content: &str,
     locale: Option<&str>,
 ) -> super::NormalizedParsedCatalog {
-    parse_catalog(ParseCatalogOptions {
+    parse_catalog_for_review(ParseCatalogOptions {
         locale,
         mode: CatalogMode::IcuFcl,
         ..ParseCatalogOptions::new(content, "en")
     })
     .expect("parse fcl catalog")
-    .into_normalized_view()
-    .expect("normalized fcl view")
 }

--- a/crates/ferrocat-po/src/api/tests/review.rs
+++ b/crates/ferrocat-po/src/api/tests/review.rs
@@ -42,3 +42,33 @@ fn review_report_exposes_public_summary_and_detail_api() {
     assert_eq!(report.locales[0].coverage.missing, 1);
     assert_eq!(report.locales[0].translations.details.len(), 1);
 }
+
+#[test]
+fn review_report_uses_fuzzy_coverage_and_skips_fuzzy_translation_changes() {
+    let source = normalized_catalog(
+        "msgid \"Hello\"\nmsgstr \"Hello\"\n",
+        Some("en"),
+        PluralEncoding::Icu,
+    );
+    let previous_target = normalized_catalog(
+        "msgid \"Hello\"\nmsgstr \"Hallo\"\n",
+        Some("de"),
+        PluralEncoding::Icu,
+    );
+    let current_target = normalized_catalog(
+        "#, fuzzy\nmsgid \"Hello\"\nmsgstr \"Guten Tag\"\n",
+        Some("de"),
+        PluralEncoding::Icu,
+    );
+
+    let report = review_catalogs(
+        &[&source, &previous_target],
+        &[&source, &current_target],
+        &CatalogReviewOptions::new("en").with_details(true),
+    )
+    .expect("review");
+
+    assert_eq!(report.locales[0].coverage.translated, 0);
+    assert_eq!(report.locales[0].coverage.fuzzy, 1);
+    assert_eq!(report.locales[0].translations.changed, 0);
+}

--- a/crates/ferrocat-po/src/api/tests/review.rs
+++ b/crates/ferrocat-po/src/api/tests/review.rs
@@ -44,7 +44,7 @@ fn review_report_exposes_public_summary_and_detail_api() {
 }
 
 #[test]
-fn review_report_uses_fuzzy_coverage_and_skips_fuzzy_translation_changes() {
+fn review_report_keeps_fuzzy_coverage_and_reports_translation_changes() {
     let source = normalized_catalog(
         "msgid \"Hello\"\nmsgstr \"Hello\"\n",
         Some("en"),
@@ -70,5 +70,7 @@ fn review_report_uses_fuzzy_coverage_and_skips_fuzzy_translation_changes() {
 
     assert_eq!(report.locales[0].coverage.translated, 0);
     assert_eq!(report.locales[0].coverage.fuzzy(), 1);
-    assert_eq!(report.locales[0].translations.changed, 0);
+    assert_eq!(report.summary.translation_changed, 1);
+    assert_eq!(report.locales[0].translations.changed, 1);
+    assert_eq!(report.locales[0].translations.details.len(), 1);
 }

--- a/crates/ferrocat-po/src/api/tests/review.rs
+++ b/crates/ferrocat-po/src/api/tests/review.rs
@@ -69,6 +69,6 @@ fn review_report_uses_fuzzy_coverage_and_skips_fuzzy_translation_changes() {
     .expect("review");
 
     assert_eq!(report.locales[0].coverage.translated, 0);
-    assert_eq!(report.locales[0].coverage.fuzzy, 1);
+    assert_eq!(report.locales[0].coverage.fuzzy(), 1);
     assert_eq!(report.locales[0].translations.changed, 0);
 }

--- a/crates/ferrocat-po/src/api/types.rs
+++ b/crates/ferrocat-po/src/api/types.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, btree_map};
+use std::collections::{BTreeMap, BTreeSet, btree_map};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
@@ -704,6 +704,22 @@ impl ParsedCatalog {
     pub fn into_normalized_view(self) -> Result<NormalizedParsedCatalog, ApiError> {
         NormalizedParsedCatalog::new(self)
     }
+
+    /// Builds a lookup-oriented view for a programmatically constructed
+    /// catalog that is known not to contain fuzzy messages.
+    ///
+    /// Parsed PO or FCL content should use [`super::parse_catalog_for_review`]
+    /// instead, because [`super::parse_catalog`] deliberately discards flags.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApiError::Conflict`] when the parsed catalog contains
+    /// duplicate `msgid`/`msgctxt` pairs.
+    pub fn into_normalized_view_assuming_no_fuzzy(
+        self,
+    ) -> Result<NormalizedParsedCatalog, ApiError> {
+        NormalizedParsedCatalog::new_with_review_state(self, BTreeSet::new())
+    }
 }
 
 /// Parsed catalog with fast key-based lookup helpers.
@@ -712,11 +728,26 @@ pub struct NormalizedParsedCatalog {
     pub(super) catalog: ParsedCatalog,
     pub(super) key_index: BTreeMap<CatalogMessageKey, usize>,
     msgid_hash_index: FxHashMap<u64, Vec<usize>>,
+    review_fuzzy_keys: Option<BTreeSet<CatalogMessageKey>>,
 }
 
 impl NormalizedParsedCatalog {
     /// Builds the lookup index once and rejects duplicate gettext identities up front.
     pub(super) fn new(catalog: ParsedCatalog) -> Result<Self, ApiError> {
+        Self::new_with_optional_review_state(catalog, None)
+    }
+
+    pub(super) fn new_with_review_state(
+        catalog: ParsedCatalog,
+        fuzzy_keys: BTreeSet<CatalogMessageKey>,
+    ) -> Result<Self, ApiError> {
+        Self::new_with_optional_review_state(catalog, Some(fuzzy_keys))
+    }
+
+    fn new_with_optional_review_state(
+        catalog: ParsedCatalog,
+        review_fuzzy_keys: Option<BTreeSet<CatalogMessageKey>>,
+    ) -> Result<Self, ApiError> {
         let mut key_index = BTreeMap::new();
         let mut msgid_hash_index = FxHashMap::<u64, Vec<usize>>::with_capacity_and_hasher(
             catalog.messages.len(),
@@ -745,7 +776,34 @@ impl NormalizedParsedCatalog {
             catalog,
             key_index,
             msgid_hash_index,
+            review_fuzzy_keys,
         })
+    }
+
+    /// Returns whether this catalog carries the semantic review state required
+    /// by coverage, audit, and review reports.
+    ///
+    /// [`super::parse_catalog_for_review`] creates a review-aware catalog.
+    /// The default [`super::parse_catalog`] projection intentionally does not.
+    #[must_use]
+    pub const fn has_review_state(&self) -> bool {
+        self.review_fuzzy_keys.is_some()
+    }
+
+    pub(super) fn require_review_state(&self, operation: &str) -> Result<(), ApiError> {
+        if self.has_review_state() {
+            Ok(())
+        } else {
+            Err(ApiError::InvalidArguments(format!(
+                "{operation} requires review-aware catalogs; parse catalog content with parse_catalog_for_review"
+            )))
+        }
+    }
+
+    pub(super) fn is_fuzzy(&self, key: &CatalogMessageKey) -> bool {
+        self.review_fuzzy_keys
+            .as_ref()
+            .is_some_and(|keys| keys.contains(key))
     }
 
     /// Returns the underlying parsed catalog.

--- a/crates/ferrocat-po/src/diagnostic_codes.rs
+++ b/crates/ferrocat-po/src/diagnostic_codes.rs
@@ -107,6 +107,8 @@ pub mod catalog {
     pub const MISSING_LOCALE: &str = "catalog.missing_locale";
     /// Catalog contains an obsolete entry.
     pub const OBSOLETE_ENTRY: &str = "catalog.obsolete_entry";
+    /// Active catalog entry carries the semantic `fuzzy` review marker.
+    pub const FUZZY_FLAG: &str = "catalog.fuzzy_flag";
     /// Target locale is missing an active source message.
     pub const MISSING_TRANSLATION: &str = "catalog.missing_translation";
     /// Target locale has an empty translation for an active source message.
@@ -123,6 +125,7 @@ pub mod catalog {
         MISSING_SOURCE_LOCALE,
         MISSING_LOCALE,
         OBSOLETE_ENTRY,
+        FUZZY_FLAG,
         MISSING_TRANSLATION,
         EMPTY_TRANSLATION,
         EXTRA_TRANSLATION,

--- a/crates/ferrocat-po/src/lib.rs
+++ b/crates/ferrocat-po/src/lib.rs
@@ -77,18 +77,18 @@
 //! ```
 //!
 //! ```rust
-//! use ferrocat_po::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog};
+//! use ferrocat_po::{
+//!     CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog_for_review,
+//! };
 //!
-//! let source = parse_catalog(
+//! let source = parse_catalog_for_review(
 //!     ParseCatalogOptions::new("msgid \"Hello {name}\"\nmsgstr \"Hello {name}\"\n", "en")
 //!         .with_locale("en"),
-//! )?
-//! .into_normalized_view()?;
-//! let target = parse_catalog(
+//! )?;
+//! let target = parse_catalog_for_review(
 //!     ParseCatalogOptions::new("msgid \"Hello {name}\"\nmsgstr \"Hallo\"\n", "en")
 //!         .with_locale("de"),
-//! )?
-//! .into_normalized_view()?;
+//! )?;
 //! let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
 //!
 //! assert!(report.has_errors());
@@ -139,7 +139,7 @@ pub use api::{
     SourceExtractedMessage, TranslationShape, UpdateCatalogFileOptions, UpdateCatalogOptions,
     audit_catalogs, combine_catalog_files, combine_catalogs, compile_catalog_artifact,
     compile_catalog_artifact_report, compile_catalog_artifact_selected, compiled_key,
-    machine_translation_hash, measure_catalog_coverage, parse_catalog,
+    machine_translation_hash, measure_catalog_coverage, parse_catalog, parse_catalog_for_review,
     pseudolocalize_compiled_catalog_artifact, review_catalogs, update_catalog, update_catalog_file,
 };
 pub use borrowed::{

--- a/crates/ferrocat/CHANGELOG.md
+++ b/crates/ferrocat/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### ⚠ BREAKING CHANGES
+
+- Coverage, fuzzy-enabled audit, and current review targets now require
+  review-aware normalized catalogs from `parse_catalog_for_review`.
+- `CatalogMessageStatus::Fuzzy`, `CatalogLocaleCoverage::fuzzy`,
+  `CatalogAuditChecks::fuzzy_flags`, and `catalog.fuzzy_flag` are restored.
+
+### Bug Fixes
+
+- Active PO and FCL fuzzy entries no longer count as translated, including in
+  the coverage rollups embedded in review reports.
+
 ## [3.1.0](https://github.com/sebastian-software/ferrocat/compare/ferrocat-v3.0.1...ferrocat-v3.1.0) (2026-07-30)
 
 

--- a/crates/ferrocat/CHANGELOG.md
+++ b/crates/ferrocat/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Coverage, fuzzy-enabled audit, and current review targets now require
   review-aware normalized catalogs from `parse_catalog_for_review`.
-- `CatalogMessageStatus::Fuzzy`, `CatalogLocaleCoverage::fuzzy`,
+- `CatalogMessageStatus::Fuzzy`, `CatalogLocaleCoverage::fuzzy()`,
   `CatalogAuditChecks::fuzzy_flags`, and `catalog.fuzzy_flag` are restored.
 
 ### Bug Fixes

--- a/crates/ferrocat/src/lib.rs
+++ b/crates/ferrocat/src/lib.rs
@@ -64,15 +64,14 @@
 //!
 //! ```rust
 //! use ferrocat::catalog::{
-//!     CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog,
+//!     CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog_for_review,
 //! };
 //!
-//! let source = parse_catalog(
+//! let source = parse_catalog_for_review(
 //!     ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en").with_locale("en"),
-//! )?
-//! .into_normalized_view()?;
-//! let target = parse_catalog(ParseCatalogOptions::new("", "en").with_locale("de"))?
-//! .into_normalized_view()?;
+//! )?;
+//! let target =
+//!     parse_catalog_for_review(ParseCatalogOptions::new("", "en").with_locale("de"))?;
 //! let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
 //!
 //! assert!(report.has_errors());
@@ -115,8 +114,9 @@ pub mod catalog {
         UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs, combine_catalog_files,
         combine_catalogs, compile_catalog_artifact, compile_catalog_artifact_report,
         compile_catalog_artifact_selected, compiled_key, machine_translation_hash,
-        measure_catalog_coverage, parse_catalog, pseudolocalize_compiled_catalog_artifact,
-        review_catalogs, update_catalog, update_catalog_file,
+        measure_catalog_coverage, parse_catalog, parse_catalog_for_review,
+        pseudolocalize_compiled_catalog_artifact, review_catalogs, update_catalog,
+        update_catalog_file,
     };
 }
 
@@ -205,8 +205,8 @@ pub use ferrocat_po::{
     UpdateCatalogFileOptions, UpdateCatalogOptions, audit_catalogs, combine_catalog_files,
     combine_catalogs, compile_catalog_artifact, compile_catalog_artifact_report,
     compile_catalog_artifact_selected, compiled_key, machine_translation_hash,
-    measure_catalog_coverage, parse_catalog, pseudolocalize_compiled_catalog_artifact,
-    review_catalogs, update_catalog, update_catalog_file,
+    measure_catalog_coverage, parse_catalog, parse_catalog_for_review,
+    pseudolocalize_compiled_catalog_artifact, review_catalogs, update_catalog, update_catalog_file,
 };
 pub use ferrocat_po::{
     BorrowedHeader, BorrowedMsgStr, BorrowedPoFile, BorrowedPoItem, Header, MergeMessageInput,

--- a/crates/ferrocat/tests/smoke.rs
+++ b/crates/ferrocat/tests/smoke.rs
@@ -6,7 +6,7 @@ use ferrocat::{
         CompileSelectedCatalogArtifactOptions, CompiledCatalogIdIndex, CompiledKeyStrategy,
         EffectiveTranslation, EffectiveTranslationRef, ParseCatalogOptions, SourceExtractedMessage,
         audit_catalogs, combine_catalogs, compile_catalog_artifact,
-        compile_catalog_artifact_selected, parse_catalog,
+        compile_catalog_artifact_selected, parse_catalog, parse_catalog_for_review,
     },
     icu, parse_po_bytes, po,
 };
@@ -98,8 +98,16 @@ msgstr "world"
     .expect("parse source catalog")
     .into_normalized_view()
     .expect("normalized source catalog");
+    let review_source = parse_catalog_for_review(
+        ParseCatalogOptions::new("msgid \"hello\"\nmsgstr \"hello\"\n", "en").with_locale("en"),
+    )
+    .expect("parse review source catalog");
+    let review_target = parse_catalog_for_review(
+        ParseCatalogOptions::new("msgid \"hello\"\nmsgstr \"world\"\n", "en").with_locale("de"),
+    )
+    .expect("parse review target catalog");
     let audit = audit_catalogs(
-        &[&source, &normalized],
+        &[&review_source, &review_target],
         &CatalogAuditOptions::new("en").with_icu_options(CatalogAuditIcuOptions::default()),
     )
     .expect("audit catalogs with icu options");

--- a/docs/app/routes/architecture/adr/0023-drop-gettext-flags-merge-comments.mdx
+++ b/docs/app/routes/architecture/adr/0023-drop-gettext-flags-merge-comments.mdx
@@ -6,7 +6,7 @@ order: 230
 
 # ADR 0023: Drop gettext Flags and Merge Comments
 
-- Status: Accepted (2.0.0), partially superseded by [ADR 0027](/architecture/adr/0027-opaque-po-metadata-roundtrip)
+- Status: Accepted (2.0.0), partially superseded by [ADR 0027](/architecture/adr/0027-opaque-po-metadata-roundtrip) and [ADR 0028](/architecture/adr/0028-fuzzy-review-state-projection)
 - Date: 2026-06-30
 
 > [ADR 0027](/architecture/adr/0027-opaque-po-metadata-roundtrip) supersedes the
@@ -14,8 +14,10 @@ order: 230
 > semantic meaning in the catalog layer, but they are no longer discarded: they
 > are preserved opaquely against the message identity through update and
 > combine, and FCL regains `tc=` and `f=` tags for them. Everything below about
-> semantics — no `Fuzzy` status, no fuzzy audit check, no coverage counter —
-> still holds.
+> semantics originally remained unchanged. [ADR 0028](/architecture/adr/0028-fuzzy-review-state-projection)
+> now makes one narrow correction: an opt-in review projection interprets the
+> exact `fuzzy` marker for audit, coverage, and review. Arbitrary flags remain
+> absent from the public message model and opaque to update/combine behavior.
 
 ## Context
 

--- a/docs/app/routes/architecture/adr/0027-opaque-po-metadata-roundtrip.mdx
+++ b/docs/app/routes/architecture/adr/0027-opaque-po-metadata-roundtrip.mdx
@@ -6,7 +6,7 @@ order: 270
 
 # ADR 0027: Preserve Translator Comments and Flags as Opaque Round-Trip State
 
-- Status: Accepted
+- Status: Accepted, partially superseded by [ADR 0028](/architecture/adr/0028-fuzzy-review-state-projection)
 - Date: 2026-07-30
 - Partially supersedes: [ADR 0023](/architecture/adr/0023-drop-gettext-flags-merge-comments)
 - Relates to: [ADR 0006](/architecture/adr/0006-separate-po-core-from-high-level-catalog-api)
@@ -16,8 +16,10 @@ order: 270
 [ADR 0023](/architecture/adr/0023-drop-gettext-flags-merge-comments) removed the
 gettext flag concept from the catalog layer and collapsed the two comment kinds
 into one notes list. That decision was about *semantics*, and it still holds:
-Ferrocat has no use for a `fuzzy` status it never produces, and printf format
-flags say nothing about an ICU catalog.
+Ferrocat did not produce a `fuzzy` status, and printf format flags say nothing
+about an ICU catalog. ADR 0028 later narrows the first statement: an opt-in
+report projection recognizes the exact `fuzzy` marker without exposing the
+general flag list.
 
 It also had a side effect that was not the point of the decision. Because the
 catalog model had nowhere to put them, a high-level update *destroyed* this
@@ -68,14 +70,16 @@ as the existing catalog with the same extractor input reproduces the same bytes.
 
 ### What this does not change
 
-This ADR grants no meaning to any of it. Everything ADR 0023 decided about
-semantics stands:
+This ADR originally granted no meaning to any of it. ADR 0028 partially
+supersedes that rule for the exact `fuzzy` marker in an opt-in report
+projection:
 
-- there is no `CatalogMessageStatus::Fuzzy`, and `#, fuzzy` on import does not
-  produce one — it is a string in a list;
-- `CatalogAuditChecks::fuzzy_flags` and the `catalog.fuzzy_flag` diagnostic do
-  not come back;
-- the coverage `fuzzy` counter does not come back;
+- `CatalogMessageStatus::Fuzzy`, `CatalogAuditChecks::fuzzy_flags`,
+  `catalog.fuzzy_flag`, and the coverage `fuzzy` counter are available when
+  catalogs are parsed with `parse_catalog_for_review`;
+- the default public parse projection still drops all flags, while update and
+  combine continue to preserve them opaquely;
+- no flag other than exact `fuzzy` acquires semantic meaning;
 - the comment-kind split drives no behavior. Ferrocat does not read translator
   comments differently from extracted ones; it only knows which line prefix they
   came from so it can write them back the same way.

--- a/docs/app/routes/architecture/adr/0028-fuzzy-review-state-projection.mdx
+++ b/docs/app/routes/architecture/adr/0028-fuzzy-review-state-projection.mdx
@@ -49,7 +49,7 @@ Add a dedicated review-aware parse projection:
   no flag field, this explicitly declares that the constructed messages are
   non-fuzzy.
 - `CatalogMessageStatus::Fuzzy`,
-  `CatalogLocaleCoverage::fuzzy`,
+  `CatalogLocaleCoverage::fuzzy()`,
   `CatalogAuditChecks::fuzzy_flags`, and
   `catalog.fuzzy_flag` are restored.
 
@@ -88,8 +88,9 @@ Negative:
 
 - report callers must use `parse_catalog_for_review`; passing a normalized view
   derived from ordinary `parse_catalog` now returns an argument error
-- the public status enum and serialized coverage/audit report shapes regain
-  fuzzy fields and values
+- coverage details can carry the `fuzzy` status, and the per-locale
+  `fuzzy()` accessor derives its count without adding a field to the
+  externally constructible report struct
 - Ferrocat now interprets one member of an otherwise opaque flag list, so future
   review markers need another explicit architecture decision rather than being
   inferred from arbitrary metadata

--- a/docs/app/routes/architecture/adr/0028-fuzzy-review-state-projection.mdx
+++ b/docs/app/routes/architecture/adr/0028-fuzzy-review-state-projection.mdx
@@ -1,0 +1,120 @@
+---
+title: "ADR 0028: Project Fuzzy as Opt-In Review State"
+description: "Accepted architecture decision record: coverage, audit, and review classify fuzzy entries without exposing arbitrary gettext flags or slowing the default catalog projection."
+order: 280
+---
+
+# ADR 0028: Project Fuzzy as Opt-In Review State
+
+- Status: Accepted
+- Date: 2026-07-30
+- Partially supersedes: [ADR 0023](/architecture/adr/0023-drop-gettext-flags-merge-comments), [ADR 0027](/architecture/adr/0027-opaque-po-metadata-roundtrip)
+- Relates to: [ADR 0014](/architecture/adr/0014-ferrocat-palamedes-boundary), [ADR 0017](/architecture/adr/0017-catalog-audit-reports)
+
+## Context
+
+ADR 0023 removed gettext flags from the public catalog message model. ADR 0027
+later preserved those flags internally as opaque round-trip state, while still
+prohibiting any semantic interpretation. That combination protected catalog
+updates from data loss, but left coverage unable to distinguish a verified
+translation from an active `#, fuzzy` entry.
+
+Gettext defines `fuzzy` as a review-needed marker. Counting such an entry as
+translated overstates completion. The gap also forced Palamedes to parse every
+PO target twice: once through the format-neutral catalog API and again through
+the low-level PO API to join fuzzy flags back onto message identities. Its
+manual coverage loop then risked diverging from Ferrocat's plural completeness
+rule.
+
+Restoring every flag to `CatalogMessage` would solve the visibility problem at
+the wrong layer. Most callers do not request reports, arbitrary flags such as
+`c-format` have no ICU meaning, and the public high-throughput projection should
+not allocate metadata it immediately discards.
+
+## Decision
+
+Add a dedicated review-aware parse projection:
+
+- `parse_catalog_for_review` parses PO or FCL directly into a normalized
+  catalog and retains only the identities carrying an exact `fuzzy` flag.
+- The ordinary `parse_catalog` path continues to discard translator comments
+  and flags from its public projection. It does not allocate or expose review
+  state.
+- `NormalizedParsedCatalog` records whether review state is available.
+  Coverage, audit completeness/fuzzy checks, and current-state review reject a
+  metadata-discarding projection instead of silently counting an unknown fuzzy
+  entry as translated.
+- Programmatically constructed `ParsedCatalog` values can opt into reporting
+  with `into_normalized_view_assuming_no_fuzzy`; because `CatalogMessage` has
+  no flag field, this explicitly declares that the constructed messages are
+  non-fuzzy.
+- `CatalogMessageStatus::Fuzzy`,
+  `CatalogLocaleCoverage::fuzzy`,
+  `CatalogAuditChecks::fuzzy_flags`, and
+  `catalog.fuzzy_flag` are restored.
+
+The shared classifier applies one precedence order to an expected target
+identity:
+
+1. absent is `missing`;
+2. obsolete is `obsolete`;
+3. an empty singular or any empty required plural form is `empty`;
+4. a non-empty active entry with the review marker is `fuzzy`;
+5. otherwise it is `translated`.
+
+An active target identity outside the active source set remains `extra`,
+regardless of its flag. These states are mutually exclusive. Only `translated`
+contributes to completion.
+
+This is a narrow exception to ADR 0027's "flags carry no semantics" rule.
+Ferrocat still does not infer fuzzy matches, move translations by similarity,
+or expose arbitrary flags. It recognizes only the exact `fuzzy` marker when a
+caller explicitly requests report state.
+
+## Consequences
+
+Positive:
+
+- coverage no longer treats review-needed translations as complete
+- PO `#, fuzzy` and FCL `f=fuzzy` have identical report behavior
+- coverage, audit, and review use one classification rule, including partial
+  gettext plurals
+- Palamedes can remove its second PO parse, manual identity join, and local
+  coverage classifier
+- ordinary parse callers keep the allocation-light projection introduced after
+  ADR 0027
+
+Negative:
+
+- report callers must use `parse_catalog_for_review`; passing a normalized view
+  derived from ordinary `parse_catalog` now returns an argument error
+- the public status enum and serialized coverage/audit report shapes regain
+  fuzzy fields and values
+- Ferrocat now interprets one member of an otherwise opaque flag list, so future
+  review markers need another explicit architecture decision rather than being
+  inferred from arbitrary metadata
+
+## Alternatives Considered
+
+### Expose All Flags on `CatalogMessage`
+
+Rejected because it would reverse the useful public-model boundary from ADR
+0023, increase the default projection cost, and encourage callers to build new
+semantics on unstructured gettext metadata.
+
+### Keep Counting Fuzzy as Translated
+
+Rejected because it contradicts the review-needed meaning of `fuzzy`, the
+original coverage contract, and the completion rule downstream hosts need.
+
+### Add a File-Only Coverage API
+
+Rejected because audit and review need the same state, callers may already hold
+normalized catalogs, and a separate content API would duplicate locale-set
+validation and report classification.
+
+### Silently Treat Missing Review State as Non-Fuzzy
+
+Rejected because a fast parse projection cannot distinguish "no fuzzy flags"
+from "flags were discarded." A clear argument error prevents an incorrect
+completion result.

--- a/docs/app/routes/architecture/adr/index.mdx
+++ b/docs/app/routes/architecture/adr/index.mdx
@@ -36,3 +36,4 @@ Current records:
 - [0025: Obsolete Age and Age-Based Cleanup](/architecture/adr/0025-obsolete-age-and-cleanup)
 - [0026: Use CLDR Root Catalog Order by Default](/architecture/adr/0026-cldr-root-catalog-order)
 - [0027: Preserve Translator Comments and Flags as Opaque Round-Trip State](/architecture/adr/0027-opaque-po-metadata-roundtrip)
+- [0028: Project Fuzzy as Opt-In Review State](/architecture/adr/0028-fuzzy-review-state-projection)

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -535,7 +535,8 @@ Only `translated` messages count toward completion. Fuzzy, empty, obsolete, and
 absent entries remain visible as separate counters so hosts can choose their
 own threshold and presentation rules. An empty singular or partially empty
 required plural remains `empty` even if it also carries `fuzzy`; obsolete and
-extra identities likewise keep their structural state.
+extra identities likewise keep their structural state. Read the per-locale
+fuzzy count with `CatalogLocaleCoverage::fuzzy()`.
 
 ```rust
 use ferrocat::{

--- a/docs/app/routes/reference/api-overview.mdx
+++ b/docs/app/routes/reference/api-overview.mdx
@@ -161,6 +161,7 @@ find a stable named container, emit the file alone and leave `scope` empty.
 | Combine multiple catalogs with deterministic conflict and selection rules | `combine_catalogs` |
 | Read a Gettext PO or FCL catalog into the higher-level canonical catalog model | `parse_catalog` |
 | Build keyed lookup/helpers on top of a parsed catalog | `ParsedCatalog::into_normalized_view` |
+| Parse directly into a fuzzy-aware normalized catalog for reports | `parse_catalog_for_review` |
 | Audit source and target catalogs for release readiness | `audit_catalogs` |
 | Summarize per-locale catalog completeness | `measure_catalog_coverage` |
 | Compare catalog states for translator review handoffs | `review_catalogs` |
@@ -360,7 +361,12 @@ That gives you exactly three supported modes:
 - ICU-native Gettext PO mode: Gettext PO + `IcuNative`
 - ICU-native FCL catalog mode: FCL + `IcuNative`
 
-`parse_catalog` intentionally stays as the neutral parse step. If you want keyed lookups or effective-translation helpers, build a richer view explicitly with `ParsedCatalog::into_normalized_view()`.
+`parse_catalog` intentionally stays as the neutral, metadata-discarding parse
+step. If you want keyed lookups or effective-translation helpers, build a
+richer view explicitly with `ParsedCatalog::into_normalized_view()`. If the
+catalog will feed coverage, audit, or review, use `parse_catalog_for_review`
+instead; it returns a normalized view directly and retains only fuzzy message
+identities.
 
 The normalized view supports both owned-key lookup with `CatalogMessageKey` and borrowed identity lookup with `get_by_parts(msgid, msgctxt)`, which is useful in host adapters that already have borrowed source strings.
 
@@ -411,6 +417,7 @@ Default checks cover:
 - source locale presence
 - requested target locale presence
 - missing and empty target translations
+- active fuzzy translations that still need review
 - target-only active messages that look stale
 - obsolete entries
 - ICU syntax in active source and target messages
@@ -426,18 +433,18 @@ visible while accepting runtime-valid strings such as `you're available`.
 Diagnostics are machine-readable. Examples include:
 
 ```rust
-use ferrocat::{CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog};
+use ferrocat::{
+    CatalogAuditOptions, ParseCatalogOptions, audit_catalogs, parse_catalog_for_review,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let source = parse_catalog(
+    let source = parse_catalog_for_review(
         ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
             .with_locale("en"),
-    )?
-    .into_normalized_view()?;
-    let target = parse_catalog(
+    )?;
+    let target = parse_catalog_for_review(
         ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"\"\n", "en").with_locale("de"),
-    )?
-    .into_normalized_view()?;
+    )?;
 
     let report = audit_catalogs(&[&source, &target], &CatalogAuditOptions::new("en"))?;
     assert!(report.has_errors());
@@ -517,32 +524,34 @@ source locale's active, non-obsolete identities define the expected set for each
 target locale. Each target message is classified with the same shared status
 taxonomy used by catalog audit:
 
-- `translated`: active target entry with a non-empty translation
+- `translated`: active target entry with a non-empty, non-fuzzy translation
+- `fuzzy`: active target entry has a non-empty translation that still needs review
 - `missing`: no active or obsolete target entry exists
 - `empty`: active target entry exists, but its effective translation is empty
 - `obsolete`: target entry exists for the source identity, but is obsolete
 - `extra`: active target entry is not present in the active source set
 
-Only `translated` messages count toward completion. Empty, obsolete, and absent
-entries remain visible as separate counters so hosts can choose their own
-threshold and presentation rules.
+Only `translated` messages count toward completion. Fuzzy, empty, obsolete, and
+absent entries remain visible as separate counters so hosts can choose their
+own threshold and presentation rules. An empty singular or partially empty
+required plural remains `empty` even if it also carries `fuzzy`; obsolete and
+extra identities likewise keep their structural state.
 
 ```rust
 use ferrocat::{
-    CatalogCoverageOptions, ParseCatalogOptions, measure_catalog_coverage, parse_catalog,
+    CatalogCoverageOptions, ParseCatalogOptions, measure_catalog_coverage,
+    parse_catalog_for_review,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let source = parse_catalog(
+    let source = parse_catalog_for_review(
         ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
             .with_locale("en"),
-    )?
-    .into_normalized_view()?;
-    let target = parse_catalog(
+    )?;
+    let target = parse_catalog_for_review(
         ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
             .with_locale("de"),
-    )?
-    .into_normalized_view()?;
+    )?;
 
     let report = measure_catalog_coverage(&[&source, &target], &CatalogCoverageOptions::new("en"))?;
     assert_eq!(report.locales[0].completion_percent(), 100.0);
@@ -553,6 +562,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 Set `CatalogCoverageOptions::with_details(true)` when callers also need
 per-message rows. File discovery, threshold failures, JSON/table formatting, and
 pseudo-locale filtering stay outside the core API.
+
+`parse_catalog_for_review` retains only semantic fuzzy identities and returns a
+normalized catalog directly. Arbitrary flags and translator comments remain
+opaque. The ordinary `parse_catalog` path keeps skipping this metadata for
+high-throughput callers that do not request reports; passing its normalized
+projection to coverage returns an argument error instead of silently treating
+unknown fuzzy state as translated.
 
 ### `review_catalogs`
 
@@ -572,33 +588,29 @@ Ferrocat reports a removal plus an addition instead of guessing intent.
 
 ```rust
 use ferrocat::{
-    CatalogReviewOptions, ParseCatalogOptions, review_catalogs, parse_catalog,
+    CatalogReviewOptions, ParseCatalogOptions, parse_catalog_for_review, review_catalogs,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let previous_source = parse_catalog(
+    let previous_source = parse_catalog_for_review(
         ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
             .with_locale("en"),
-    )?
-    .into_normalized_view()?;
-    let current_source = parse_catalog(
+    )?;
+    let current_source = parse_catalog_for_review(
         ParseCatalogOptions::new(
             "msgid \"Checkout\"\nmsgstr \"Checkout\"\n\nmsgid \"Cancel\"\nmsgstr \"Cancel\"\n",
             "en",
         )
         .with_locale("en"),
-    )?
-    .into_normalized_view()?;
-    let previous_de = parse_catalog(
+    )?;
+    let previous_de = parse_catalog_for_review(
         ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Zur Kasse\"\n", "en")
             .with_locale("de"),
-    )?
-    .into_normalized_view()?;
-    let current_de = parse_catalog(
+    )?;
+    let current_de = parse_catalog_for_review(
         ParseCatalogOptions::new("msgid \"Checkout\"\nmsgstr \"Checkout\"\n", "en")
             .with_locale("de"),
-    )?
-    .into_normalized_view()?;
+    )?;
 
     let report = review_catalogs(
         &[&previous_source, &previous_de],
@@ -776,12 +788,15 @@ references are replaced by whatever the extractor reports this run.
 Translator-owned metadata is preserved: `#` translator comments and `#,` flags
 stay attached to the `(msgctxt, msgid)` identity, including through the
 transition to obsolete and back, and a new entry never inherits them from an
-unrelated identity. Flags are kept opaquely and are not interpreted — `fuzzy`
-does not produce a status and unknown flags such as `x-custom` survive verbatim.
+unrelated identity. Update and combine keep flags opaquely. The dedicated
+`parse_catalog_for_review` projection recognizes only exact `fuzzy` for
+coverage/audit/review classification; unknown flags such as `x-custom` remain
+uninterpreted and survive verbatim.
 `combine_catalogs` and `combine_catalog_files` attach this metadata to the
 definition that wins the entry rather than merging it across inputs. FCL stores
 the same two fields as the `tc=` and `f=` entry tags. See
-[ADR 0027](/architecture/adr/0027-opaque-po-metadata-roundtrip).
+[ADR 0027](/architecture/adr/0027-opaque-po-metadata-roundtrip) and
+[ADR 0028](/architecture/adr/0028-fuzzy-review-state-projection).
 
 `RenderOptions::order_by` keeps `OrderBy::Msgid` as the default and sorts
 `msgid`, then context, with the CLDR root order used by
@@ -1070,6 +1085,7 @@ part of this source-side metadata format.
 - N-way catalog overlays and set operations: `combine_catalogs`
 - Full app-level catalog maintenance: `update_catalog` or `update_catalog_file`
 - Parsed catalog consumption with keyed accessors: `parse_catalog` + `into_normalized_view`
+- Fuzzy-aware coverage/audit/review input: `parse_catalog_for_review`
 - Locale-specific runtime artifact generation: `compile_catalog_artifact`
 - Selected locale artifact generation by compiled ID: `compile_catalog_artifact_selected`
 - Runtime artifact provenance reporting: `compile_catalog_artifact_report`

--- a/docs/fcl-format.md
+++ b/docs/fcl-format.md
@@ -114,14 +114,15 @@ replacement for gettext context / `msgctxt`; downstream tools should not derive
 it from `msgctxt` by default. See
 [ADR 0024](app/routes/architecture/adr/0024-origin-scope-anchor.mdx).
 
-`c`, `tc`, and `f` all hold free-form values the catalog layer never interprets.
-The split exists purely so the gettext comment kinds and per-entry flags can be
-written back the way they arrived: `c` is extractor-owned and gets refreshed by
-an update, while `tc` and `f` are translator-owned and are preserved verbatim
-against the entry identity. Flags carry no semantics — `fuzzy` does not produce
-a status, and unknown flags such as `x-custom` round-trip unchanged (see
+`c`, `tc`, and `f` all hold free-form values for round-tripping. The split
+exists so the gettext comment kinds and per-entry flags can be written back the
+way they arrived: `c` is extractor-owned and gets refreshed by an update, while
+`tc` and `f` are translator-owned and are preserved verbatim against the entry
+identity. The opt-in review projection recognizes exact `fuzzy` as a
+review-needed status; unknown flags such as `x-custom` remain semantically
+opaque and round-trip unchanged (see
 [ADR 0023](app/routes/architecture/adr/0023-drop-gettext-flags-merge-comments.mdx)
-and [ADR 0027](app/routes/architecture/adr/0027-opaque-po-metadata-roundtrip.mdx)).
+and [ADR 0028](app/routes/architecture/adr/0028-fuzzy-review-state-projection.mdx)).
 
 `lock` is the fingerprint of the value when a machine (AI engine, TMS, script)
 set it; if `hash(current value) != lock`, a human edited it and high-level


### PR DESCRIPTION
## Summary

- add `parse_catalog_for_review`, which keeps exact fuzzy identities without exposing arbitrary PO/FCL metadata
- restore the shared fuzzy status, coverage counter, audit diagnostic, and review behavior
- keep the default `parse_catalog` path metadata-free, including its FCL fast path
- move the CLI and benchmark coverage workflow to the shared classifier
- document the migration and the narrow ADR 0027 exception in ADR 0028

## Migration

`measure_catalog_coverage`, fuzzy-enabled `audit_catalogs`, and current review targets now require catalogs from `parse_catalog_for_review`. Programmatically built catalogs can opt in with `into_normalized_view_assuming_no_fuzzy`.

This is intentional: a catalog parsed through the default metadata-discarding path can't tell "no fuzzy flag" from "fuzzy state was dropped," so report APIs reject it instead of overstating completion.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `cargo +1.93.0 check --workspace --all-targets --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- published-crate packaging with `--locked --allow-dirty`
- docs install and production build
- public API snapshot check
- workspace llvm-cov run and coverage gate (`ferrocat-po` 97.55%, `ferrocat-icu` 96.85%)

Closes #278

BEGIN_COMMIT_OVERRIDE
fix(coverage): classify fuzzy entries as incomplete
END_COMMIT_OVERRIDE
