### PR TITLE
fix(fcl): validate identities at the shared export boundary

### DIFF
--- a/crates/ferrocat-po/CHANGELOG.md
+++ b/crates/ferrocat-po/CHANGELOG.md
@@ -25,6 +25,9 @@
 
 ### Bug Fixes
 
+- FCL update, conversion, and combine now reject duplicate serialized
+  `(id, ctxt)` identities at their shared export boundary. File updates leave
+  an existing destination unchanged when validation fails.
 - Active PO `#, fuzzy` and FCL `f=fuzzy` entries no longer count as translated;
   coverage, audit, and review share the same empty/plural/obsolete/fuzzy
   precedence.

--- a/crates/ferrocat-po/src/api/conversion.rs
+++ b/crates/ferrocat-po/src/api/conversion.rs
@@ -94,7 +94,6 @@ fn finish_catalog_conversion(
             sort_messages(&mut catalog.messages, options.order_by);
         }
         CatalogStorageFormat::Fcl => {
-            super::fcl::validate_catalog_fcl(&catalog)?;
             // FCL intentionally has only source/locale/order header state. PO
             // document-level metadata is outside the cross-format contract.
             catalog.headers.clear();

--- a/crates/ferrocat-po/src/api/export.rs
+++ b/crates/ferrocat-po/src/api/export.rs
@@ -31,12 +31,15 @@ pub(super) fn export_catalog_content(
         super::CatalogStorageFormat::Po => {
             stringify_catalog_po(catalog, options, locale, diagnostics)
         }
-        super::CatalogStorageFormat::Fcl => Ok(super::fcl::stringify_catalog_fcl(
-            catalog,
-            locale,
-            options.source_locale,
-            &options.render,
-        )),
+        super::CatalogStorageFormat::Fcl => {
+            super::fcl::validate_catalog_fcl(catalog)?;
+            Ok(super::fcl::stringify_catalog_fcl(
+                catalog,
+                locale,
+                options.source_locale,
+                &options.render,
+            ))
+        }
     }
 }
 
@@ -593,6 +596,64 @@ mod tests {
             diagnostics[0].code.as_str(),
             diagnostic_codes::plural::UNSUPPORTED_GETTEXT_EXPORT
         );
+    }
+
+    #[test]
+    fn fcl_export_rejects_active_and_obsolete_duplicate_identities() {
+        let active = singular_message("Hallo");
+        let mut obsolete = active.clone();
+        obsolete.obsolete = Some(ObsoleteInfo::default());
+        let catalog = Catalog {
+            messages: vec![active, obsolete],
+            ..Catalog::default()
+        };
+        let fcl_options = UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
+            .with_mode(CatalogMode::IcuFcl);
+        let mut diagnostics = Vec::new();
+
+        let error = export_catalog_content(&catalog, &fcl_options, Some("de"), &mut diagnostics)
+            .expect_err("duplicate FCL identity");
+
+        assert!(matches!(
+            error,
+            ApiError::Conflict(message)
+                if message.contains("duplicate FCL identity")
+                    && message.contains("items")
+        ));
+
+        let po_options = UpdateCatalogOptions::new("en", CatalogUpdateInput::default());
+        let output = export_catalog_content(&catalog, &po_options, Some("de"), &mut diagnostics)
+            .expect("PO keeps separate active and obsolete entries");
+        assert_eq!(output.matches("msgid \"items\"").count(), 2);
+    }
+
+    #[test]
+    fn fcl_export_rejects_singular_and_synthesized_plural_id_collision() {
+        let plural_id = "{count, plural, one {item} other {items}}";
+        let mut singular = singular_message("");
+        singular.msgid = plural_id.to_owned();
+        let mut plural = plural_message(BTreeMap::from([
+            ("one".to_owned(), "Artikel".to_owned()),
+            ("other".to_owned(), "Artikel".to_owned()),
+        ]));
+        plural.msgid = "cart.items".to_owned();
+        let catalog = Catalog {
+            messages: vec![singular, plural],
+            ..Catalog::default()
+        };
+        let options = UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
+            .with_mode(CatalogMode::IcuFcl);
+        let mut diagnostics = Vec::new();
+
+        let error = export_catalog_content(&catalog, &options, Some("de"), &mut diagnostics)
+            .expect_err("synthesized plural FCL identity collision");
+
+        assert!(matches!(
+            error,
+            ApiError::Conflict(message)
+                if message.contains("duplicate FCL identity")
+                    && message.contains(plural_id)
+        ));
     }
 
     #[test]

--- a/crates/ferrocat-po/src/api/tests/catalog.rs
+++ b/crates/ferrocat-po/src/api/tests/catalog.rs
@@ -1547,6 +1547,33 @@ fn combine_catalogs_rejects_empty_inputs() {
 }
 
 #[test]
+fn combine_catalogs_renders_valid_fcl_through_shared_export() {
+    let first = "%FCL1\tsource=en\tlocale=de\torder=collated\nHello\t\tHallo\n";
+    let second = "%FCL1\tsource=en\tlocale=de\torder=collated\nNew\t\tNeu\n";
+    let inputs = [
+        CatalogCombineInput::labeled(first, "first.fcl"),
+        CatalogCombineInput::labeled(second, "second.fcl"),
+    ];
+
+    let result = combine_catalogs(CombineCatalogOptions {
+        inputs: &inputs,
+        source_locale: "en",
+        locale: Some("de"),
+        mode: CatalogMode::IcuFcl,
+        ..CombineCatalogOptions::new(&[], "en")
+    })
+    .expect("combine valid FCL catalogs");
+
+    assert!(
+        result
+            .content
+            .starts_with("%FCL1\tsource=en\tlocale=de\torder=collated\n")
+    );
+    assert!(result.content.contains("Hello\t\tHallo\n"));
+    assert!(result.content.contains("New\t\tNeu\n"));
+}
+
+#[test]
 fn combine_catalogs_use_first_preserves_existing_translations_and_adds_missing() {
     let existing = concat!("msgid \"Hello\"\n", "msgstr \"Hallo\"\n",);
     let template = concat!(
@@ -2512,6 +2539,79 @@ fn update_catalog_roundtrips_fcl_via_public_api() {
     .expect("parse");
     assert_eq!(parsed.messages.len(), 1);
     assert_eq!(parsed.messages[0].msgid, "Hello");
+}
+
+#[test]
+fn update_catalog_rejects_duplicate_serialized_fcl_identities() {
+    let plural_id = "{count, plural, one {item} other {items}}";
+    let error = update_catalog(UpdateCatalogOptions {
+        source_locale: "en",
+        locale: Some("de"),
+        mode: CatalogMode::IcuFcl,
+        input: structured_input(vec![
+            ExtractedMessage::Singular(ExtractedSingularMessage {
+                msgid: plural_id.to_owned(),
+                ..ExtractedSingularMessage::default()
+            }),
+            ExtractedMessage::Plural(ExtractedPluralMessage {
+                msgid: "cart.items".to_owned(),
+                source: PluralSource {
+                    one: Some("item".to_owned()),
+                    other: "items".to_owned(),
+                },
+                ..ExtractedPluralMessage::default()
+            }),
+        ]),
+        ..UpdateCatalogOptions::new("en", CatalogUpdateInput::default())
+    })
+    .expect_err("duplicate serialized FCL identity");
+
+    assert!(matches!(
+        error,
+        ApiError::Conflict(message)
+            if message.contains("duplicate FCL identity")
+                && message.contains(plural_id)
+    ));
+}
+
+#[test]
+fn update_catalog_file_keeps_existing_fcl_on_identity_conflict() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let target = directory.path().join("de.fcl");
+    let original = "%FCL1\tsource=en\tlocale=de\torder=collated\n";
+    fs::write(&target, original).expect("write existing FCL");
+    let plural_id = "{count, plural, one {item} other {items}}";
+    let options = UpdateCatalogOptions::new(
+        "en",
+        structured_input(vec![
+            ExtractedMessage::Singular(ExtractedSingularMessage {
+                msgid: plural_id.to_owned(),
+                ..ExtractedSingularMessage::default()
+            }),
+            ExtractedMessage::Plural(ExtractedPluralMessage {
+                msgid: "cart.items".to_owned(),
+                source: PluralSource {
+                    one: Some("item".to_owned()),
+                    other: "items".to_owned(),
+                },
+                ..ExtractedPluralMessage::default()
+            }),
+        ]),
+    )
+    .with_locale("de")
+    .with_mode(CatalogMode::IcuFcl);
+
+    let error = update_catalog_file(
+        UpdateCatalogFileOptions::new(&target, "en", CatalogUpdateInput::default())
+            .with_options(options),
+    )
+    .expect_err("duplicate serialized FCL identity");
+
+    assert!(matches!(
+        error,
+        ApiError::Conflict(message) if message.contains("duplicate FCL identity")
+    ));
+    assert_eq!(fs::read_to_string(&target).expect("read target"), original);
 }
 
 #[test]

--- a/crates/ferrocat/CHANGELOG.md
+++ b/crates/ferrocat/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 ### Bug Fixes
 
+- FCL catalog workflows now reject duplicate serialized `(id, ctxt)`
+  identities before rendering, and file updates preserve an existing
+  destination when validation fails.
 - Active PO and FCL fuzzy entries no longer count as translated, including in
   the coverage rollups embedded in review reports.
 

--- a/docs/app/routes/architecture/adr/0029-explicit-po-fcl-conversion.mdx
+++ b/docs/app/routes/architecture/adr/0029-explicit-po-fcl-conversion.mdx
@@ -49,9 +49,10 @@ operations.
   placeholder hints, origins and scopes, opaque flags, obsolete metadata, and
   valid machine metadata. Placeholder hints are materialized without the
   update API's presentation limit.
-- FCL conversion validates serialized `(id, ctxt)` uniqueness before rendering.
-  This rejects PO states such as active and obsolete entries with the same
-  identity, which PO can carry but FCL cannot represent.
+- The shared FCL export boundary validates serialized `(id, ctxt)` uniqueness
+  before rendering. This protects conversion, update, and combine alike and
+  rejects states such as active and obsolete entries with the same identity,
+  which PO can carry but FCL cannot represent.
 - PO output uses the requested deterministic PO ordering and serializer
   controls. FCL output always uses its canonical collated order and line shape.
 - The file API reads, validates, parses, and renders completely before atomic

--- a/docs/fcl-format.md
+++ b/docs/fcl-format.md
@@ -146,12 +146,21 @@ catalog-layer decision shared with PO output; the low-level `parse_po` /
 - A line beginning with a git conflict marker (`<<<<<<<`, `=======`, `>>>>>>>`)
   is a hard parse error with position — never silently mis-parsed.
 - Duplicate `(id, ctxt)` (adjacent under either supported order) is a hard
-  error.
+  parse error. The shared FCL export boundary also rejects duplicate serialized
+  identities with `ApiError::Conflict`, so `update_catalog`, catalog conversion,
+  and catalog combine cannot emit an FCL file that its reader would reject.
+- Structured plural messages use their synthesized ICU source string as the
+  serialized `id`. A literal singular ID that matches that string is therefore
+  a collision, just like active and obsolete messages that share an identity.
 - Entries that violate the legacy bytewise order or declared collated order are
   a hard error.
 - Duplicate singleton tags and tags outside canonical order are hard errors.
 - Unknown tag keys are a hard error (the versioned `%FCL1` magic gates
   forward-compatible additions).
+
+File-based catalog workflows finish this validation and render the complete FCL
+content before atomically replacing the destination. An identity conflict
+therefore leaves an existing destination unchanged.
 
 Entry tags are additive the same way the `order=collated` header tag was: a
 reader that knows a tag accepts files with and without it, but a file that


### PR DESCRIPTION
## What changed

- Move serialized FCL identity validation into the shared export path used by update, conversion, and combine.
- Keep PO rendering unchanged and preserve existing files when an FCL file update fails validation.
- Cover active/obsolete duplicates, synthesized plural ID collisions, public update behavior, and the valid combine path.
- Document the writer-side uniqueness guarantee in the FCL format docs, ADR 0029, and both user-facing changelogs.

## Why

Distinct canonical messages can collapse to the same serialized FCL `(id, ctxt)` pair. The conversion path already caught this, but update could still emit duplicate entries that the FCL reader would reject. Keeping the check at the shared export boundary makes every FCL writer enforce the same invariant.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo +1.93.0 check --workspace --all-targets --all-features --locked`
- `bash scripts/check-public-api-snapshots.sh`
- `cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked --allow-dirty`
- coverage gate
- `pnpm install --frozen-lockfile && pnpm build` in `docs/`

Closes #283