### PR TITLE
fix(ci): allow intentional syn major duplication

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -18,10 +18,8 @@ multiple-versions = "deny"
 wildcards = "allow"
 highlight = "all"
 deny = []
-# tempfile pulls getrandom, which currently includes both wasi preview 2 and
-# preview 3 dependency paths with different wit-bindgen versions.
 skip = [
-  { crate = "wit-bindgen@0.51.0", reason = "transitive WASI preview dependency split via getrandom" },
+  { crate = "syn@2.0.119", reason = "ICU4X 2.2 proc macros still require syn 2 while serde_derive 1.0.229 uses syn 3" },
 ]
 skip-tree = []
 


### PR DESCRIPTION
## Summary

- replace the stale `wit-bindgen@0.51.0` duplicate exception
- temporarily allow exactly `syn@2.0.119`
- keep the global `multiple-versions = "deny"` policy unchanged

## Root cause

Serde 1.0.229 moved `serde_derive` to `syn` 3. ICU4X 2.2's transitive proc-macro dependencies still require `syn` 2, so the two major versions cannot currently be unified. The Serde update in #290 therefore made the Supply Chain workflow fail on `main`:

- failing run: https://github.com/sebastian-software/ferrocat/actions/runs/31078730183
- `syn 2.0.119`: ICU4X proc-macro dependency paths
- `syn 3.0.3`: `serde_derive 1.0.229`

The exception is intentionally version-specific so cargo-deny reports it as stale once ICU4X no longer needs `syn` 2.

## Validation

- Before the change, `cargo deny --log-level warn --manifest-path ./Cargo.toml --workspace --all-features --locked check` reproduced the duplicate-`syn` failure and stale `wit-bindgen` warning.
- After the change, the same command passes: `advisories ok, bans ok, licenses ok, sources ok`.
- `git diff --check` passes.