### PR TITLE
fix(ci): test packaged crate archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,8 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
 
-      - name: Package published crates
-        run: cargo package -p ferrocat-icu -p ferrocat-po -p ferrocat -p ferrocat-cli --locked
+      - name: Package and test published crates
+        run: scripts/test-packaged-crates.sh
 
   semver:
     name: Semver compatibility (${{ matrix.crate }})

--- a/crates/ferrocat-icu/Cargo.toml
+++ b/crates/ferrocat-icu/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/ferrocat-icu"
 readme = "README.md"
 keywords = ["ferrocat", "icu", "messageformat", "i18n", "parser"]
 categories = ["internationalization", "localization", "parser-implementations"]
+exclude = ["tests/conformance_icu.rs"]
 
 [lib]
 path = "src/lib.rs"

--- a/crates/ferrocat-po/Cargo.toml
+++ b/crates/ferrocat-po/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/ferrocat-po"
 readme = "README.md"
 keywords = ["ferrocat", "gettext", "po", "i18n", "parser"]
 categories = ["internationalization", "localization", "parser-implementations"]
+exclude = ["tests/conformance_merge.rs", "tests/conformance_po.rs"]
 
 [lib]
 path = "src/lib.rs"

--- a/crates/ferrocat-po/Cargo.toml
+++ b/crates/ferrocat-po/Cargo.toml
@@ -11,7 +11,11 @@ documentation = "https://docs.rs/ferrocat-po"
 readme = "README.md"
 keywords = ["ferrocat", "gettext", "po", "i18n", "parser"]
 categories = ["internationalization", "localization", "parser-implementations"]
-exclude = ["tests/conformance_merge.rs", "tests/conformance_po.rs"]
+exclude = [
+    "tests/conformance_merge.rs",
+    "tests/conformance_po.rs",
+    "tests/workspace_sync.rs",
+]
 
 [lib]
 path = "src/lib.rs"

--- a/crates/ferrocat-po/src/diagnostic_codes.rs
+++ b/crates/ferrocat-po/src/diagnostic_codes.rs
@@ -298,48 +298,4 @@ mod tests {
         assert_eq!(code, "catalog.missing_translation");
         assert_eq!("catalog.missing_translation", code);
     }
-
-    #[test]
-    fn fallback_code_type_matches_ferrocat_icu_definition() {
-        let fallback = sync_block(include_str!("diagnostic_codes.rs"));
-        let canonical_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../ferrocat-icu/src/diagnostic_codes.rs");
-
-        // Published crates intentionally omit workspace-only sibling sources.
-        if !canonical_path.exists() {
-            return;
-        }
-
-        let canonical_source = match std::fs::read_to_string(&canonical_path) {
-            Ok(source) => source,
-            Err(error) => panic!(
-                "failed to read canonical DiagnosticCode source at {}: {error}",
-                canonical_path.display()
-            ),
-        };
-        let canonical = sync_block(&canonical_source);
-
-        assert_eq!(
-            fallback, canonical,
-            "the fallback DiagnosticCode in ferrocat-po drifted from ferrocat-icu; \
-             apply the change inside both sync(diagnostic-code-type) blocks"
-        );
-    }
-
-    /// Extracts the marked block, normalizing the module indentation of the
-    /// fallback copy away so both sides compare structurally.
-    fn sync_block(source: &str) -> Vec<&str> {
-        let block: Vec<&str> = source
-            .lines()
-            .skip_while(|line| !line.contains("sync(diagnostic-code-type): begin"))
-            .skip(1)
-            .take_while(|line| !line.contains("sync(diagnostic-code-type): end"))
-            .map(str::trim_start)
-            .collect();
-        assert!(
-            !block.is_empty(),
-            "sync(diagnostic-code-type) markers missing"
-        );
-        block
-    }
 }

--- a/crates/ferrocat-po/src/diagnostic_codes.rs
+++ b/crates/ferrocat-po/src/diagnostic_codes.rs
@@ -302,7 +302,22 @@ mod tests {
     #[test]
     fn fallback_code_type_matches_ferrocat_icu_definition() {
         let fallback = sync_block(include_str!("diagnostic_codes.rs"));
-        let canonical = sync_block(include_str!("../../ferrocat-icu/src/diagnostic_codes.rs"));
+        let canonical_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../ferrocat-icu/src/diagnostic_codes.rs");
+
+        // Published crates intentionally omit workspace-only sibling sources.
+        if !canonical_path.exists() {
+            return;
+        }
+
+        let canonical_source = match std::fs::read_to_string(&canonical_path) {
+            Ok(source) => source,
+            Err(error) => panic!(
+                "failed to read canonical DiagnosticCode source at {}: {error}",
+                canonical_path.display()
+            ),
+        };
+        let canonical = sync_block(&canonical_source);
 
         assert_eq!(
             fallback, canonical,

--- a/crates/ferrocat-po/tests/workspace_sync.rs
+++ b/crates/ferrocat-po/tests/workspace_sync.rs
@@ -1,0 +1,28 @@
+#[test]
+fn fallback_code_type_matches_ferrocat_icu_definition() {
+    let fallback = sync_block(include_str!("../src/diagnostic_codes.rs"));
+    let canonical = sync_block(include_str!("../../ferrocat-icu/src/diagnostic_codes.rs"));
+
+    assert_eq!(
+        fallback, canonical,
+        "the fallback DiagnosticCode in ferrocat-po drifted from ferrocat-icu; \
+         apply the change inside both sync(diagnostic-code-type) blocks"
+    );
+}
+
+/// Extracts the marked block, normalizing the module indentation of the
+/// fallback copy away so both sides compare structurally.
+fn sync_block(source: &str) -> Vec<&str> {
+    let block: Vec<&str> = source
+        .lines()
+        .skip_while(|line| !line.contains("sync(diagnostic-code-type): begin"))
+        .skip(1)
+        .take_while(|line| !line.contains("sync(diagnostic-code-type): end"))
+        .map(str::trim_start)
+        .collect();
+    assert!(
+        !block.is_empty(),
+        "sync(diagnostic-code-type) markers missing"
+    );
+    block
+}

--- a/scripts/test-packaged-crates.sh
+++ b/scripts/test-packaged-crates.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_root="${CARGO_TARGET_DIR:-target}"
+package_root="${target_root}/package"
+package_test_target="${target_root}/packaged-crate-tests"
+
+cargo package \
+  -p ferrocat-icu \
+  -p ferrocat-po \
+  -p ferrocat \
+  -p ferrocat-cli \
+  --locked
+
+package_dir() {
+  local package="$1"
+  local package_id
+  local version
+  local directory
+
+  package_id="$(cargo pkgid -p "$package")"
+  version="${package_id##*#}"
+  version="${version##*@}"
+  directory="${package_root}/${package}-${version}"
+
+  if [[ ! -f "${directory}/Cargo.toml" ]]; then
+    echo "missing packaged manifest: ${directory}/Cargo.toml" >&2
+    return 1
+  fi
+
+  (cd "$directory" && pwd -P)
+}
+
+icu_dir="$(package_dir ferrocat-icu)"
+po_dir="$(package_dir ferrocat-po)"
+ferrocat_dir="$(package_dir ferrocat)"
+cli_dir="$(package_dir ferrocat-cli)"
+
+icu_patch="patch.crates-io.ferrocat-icu.path=\"${icu_dir}\""
+po_patch="patch.crates-io.ferrocat-po.path=\"${po_dir}\""
+
+cargo test \
+  --manifest-path "${icu_dir}/Cargo.toml" \
+  --all-features \
+  --target-dir "$package_test_target"
+
+cargo test \
+  --manifest-path "${po_dir}/Cargo.toml" \
+  --all-features \
+  --target-dir "$package_test_target" \
+  --config "$icu_patch"
+
+cargo test \
+  --manifest-path "${ferrocat_dir}/Cargo.toml" \
+  --all-features \
+  --target-dir "$package_test_target" \
+  --config "$icu_patch" \
+  --config "$po_patch"
+
+cargo test \
+  --manifest-path "${cli_dir}/Cargo.toml" \
+  --all-features \
+  --target-dir "$package_test_target" \
+  --config "$icu_patch" \
+  --config "$po_patch"


### PR DESCRIPTION
## Summary

- keep workspace-only conformance integration tests out of the published `ferrocat-icu` and `ferrocat-po` archives
- keep the cross-crate diagnostic-code synchronization check as a workspace-only integration test
- package and test all four published crate archives in CI, with local patches for same-version workspace dependencies

## Root cause

`cargo package` verified that the published crates built, but it did not execute the test targets from the generated archives. The archives still contained tests with paths escaping the package root, such as `../../../conformance/icu_harness.rs` and `../../ferrocat-icu/src/diagnostic_codes.rs`. Running `cargo test` from the published 3.4.1 archives therefore failed even though the packaging job was green.

The shared conformance harness, its private `ferrocat-conformance` crate, and the cross-crate source synchronization check are intentionally workspace-only. The published packages now omit only those workspace-bound integration test targets; self-contained unit, property, differential, smoke, and doctests remain packaged and are executed by the new CI check.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `cargo test -p ferrocat-po --test workspace_sync --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/test-packaged-crates.sh` from a clean archive of the commit
